### PR TITLE
docs: OpenCode PM must invoke subagents (not only paste assignments)

### DIFF
--- a/agents/project-manager.md
+++ b/agents/project-manager.md
@@ -115,6 +115,8 @@ description: 项目经理 - 协调开发团队，管理项目进度。Use proact
 
 在 **OpenCode** 等支持 **`@explore` / `@general`** 的宿主上，下表适用；Cursor 等无独立子代理时，用 `host-cursor.md` 的「单会话多帽」等模式等价执行，不得凭空假设已派出独立会话。
 
+**OpenCode 上 PM 派单与 §1.3 的边界**：下文 **§1.3** 要求写入承接方 Assignment 的 **`Execute as: <role-id>` 不带 `@`**，是为防止**承接方**把正文里的 `@` 当成再派单信号；**不**表示 PM 只能「贴字」。在 OpenCode 上，PM **必须**用宿主支持的 **`@<agent-id>`（与 `opencode.json` 的 `agent.<id>` 一致）或 Task / subagent 工具** 实际发起一轮子代理，**每条 implement Assignment = 一次 invoke**（并行则多次）。详见 **§2** 段首。
+
 | Agent | 能力 | 用途 |
 |-------|------|------|
 | @explore | 快速只读代码搜索与导航 | **主要由你（PM）在分派前**用于摸底；写入 Assignment 后，承接方不得用 @explore 代做实现/测试/审查/文档等交付（见 `harness-loop.md`「内置 `@explore` 能力边界」） |
@@ -469,6 +471,7 @@ description: 项目经理 - 协调开发团队，管理项目进度。Use proact
 - **Q10：`Delegation` ↔ `Superpowers`**：`forbidden` 同条勿写 `subagent-driven-development`（见 `superpowers-skills.md`「Delegation 与 Superpowers 清单一致」）。
 - **Q11：Task Board**：非平凡 plan 已公示板且本条含 **`PM Task Board coverage`**？否 → 先补 Status Update，再 implement。
 - **Q12：单层 dispatch**：implement 是否只派一层？**禁止**在含 **Execute as** 的 Assignment **外**再写「请再 Task 同名」；外层应写明「已是该角色，按 Assignment 亲自完成」。§1.3、`host-cursor.md`。
+- **Q13：宿主级 invoke（OpenCode 等）**：本轮每条 implement Assignment 是否已对 **`Execute as`** 对应角色执行 **一次**子代理 / Task **invoke**（而非仅把 Markdown 贴进主会话）？并行 N 条 → **N 次** invoke。仅打印正文 → **分派未完成**，不得写「已派 `@fullstack-dev`」类表述。见 **§2**、`host-opencode.md`。
 
 ### 1.1.2 Pre-implement Gate Check（强制输出）
 
@@ -521,7 +524,7 @@ Decision:
 - **执行身份写死**：每条 Assignment **必须**含 **`Execute as: <role-id>`**（与 `agent.<id>` 一致，**纯 id、不要 `@`**）。语义：承接方**亲自**完成；已在同名 subagent 内再 Task 同类型 = **递归误派**（禁止）。`Execute as: @role` / **`Owner Agent`** 与上同义；新文默认纯 id。
 - **唯一调度者**：只有 `@project-manager` 可创建/并行 subagent；承接方默认**禁止**二次分派。
 - **默认禁转派**：除非 **`Delegation: allowed (to @<role> | <role-id>, …)`**，否则 **forbidden**。
-- **`@` 分列**：**Execute as** 行**禁止** `@`。**Delegation: allowed** 的 callee **可** `@role`（推荐，表向下分发）或纯 id。其余字段（`Task`、`Scope`、`QA note` 等）指角色用 `` `role-id` `` 或中文，**勿** `@`。路由表可保留 `@`；贴承接方正文遵循上表。
+- **`@` 分列**：**Execute as** 行**禁止** `@`（**仅约束贴给承接方的 Assignment 正文**，避免承接方误读为可再派单）。**PM 在 OpenCode 上发起子代理时**仍须按宿主约定使用 **`@<agent-id>`** 或 Task 入口，见 **§2** 段首与 `host-opencode.md`。**Delegation: allowed** 的 callee **可** `@role`（推荐，表向下分发）或纯 id。其余字段（`Task`、`Scope`、`QA note` 等）指角色用 `` `role-id` `` 或中文，**勿** `@`。路由表可保留 `@`；贴承接方正文遵循上表。
 - **路由全链 ≠ 本条多派单**：路由表中的「开发团队 → QC 三审 → QA」等是 **plan 级流程全貌**。**本条 implement** 的承接方**仅**履行 **`Execute as`** 所写角色；除非本条 Assignment **明文**要求在同一轮完成 QC/QA（极少见），否则正文中提及的 `qc-specialist*`、`qa-engineer`、`project-manager`（无论是否加 `@`）都**禁止**作为「立刻 Task 该角色」的依据；**无 `@` 时也同样不得擅自拉起**。
 - **QA note / Handoff 释义**：**QA note** 写「Assignment ③ 再交 `` `qa-engineer` ``」= **Scheduling**（PM 另发单），**不是**让本条执行方 Task 该角色。**Handoff** 写「交给 `` `project-manager` ``」= **叙事 handoff**，**不是**再 Task PM。
 - **`Parallelism` 与多 plan**：若 **`Parallelism`** 描述的是 **其他 plan、兄弟 worktree 或组织级并行**（例如 Plan 13 与 Plan 14 同时在不同目录推进），其含义是 **全局上下文**；**不得**误解为「本条 Assignment 要并行 Task 多名 dev / QC / QA」。本条仍只认 **`Execute as`** + **`Dev routing`** 对本工作单元的定义。
@@ -529,6 +532,9 @@ Decision:
 - **并行主控权**：并行拓扑（谁和谁并行、分支如何隔离）仅由 PM 在 Assignment 中声明；承接方不得扩展并行面。
 - **`explore` 非替身**：承接方不得用内置 explore 子代理完成本 Assignment 的交付主体；仅允许只读摸底，细则见 `~/.config/opencode/docs/agents/harness-loop.md`「内置 `@explore` 能力边界」。
 ### 2. 分配任务给 subagent
+
+**OpenCode（及任何「具名 subagent / Task」宿主）：贴出 Assignment ≠ 已完成分派**  
+若你**只**在用户可见的主回复里打印 `## Assignment` 全文、或仅在 Status Update 里复述 Assignment，而**没有**通过宿主机制 **invoke** 对应 `Execute as` 角色（例如 OpenCode 里对 `@fullstack-dev` / `@qc-specialist` 等**各起一轮**子代理或等价 Task，消息体为该条 Assignment），则 **implement 视为未发出**：没有子代理被拉起，不是「子代理坏了」。**正确顺序**：先 **invoke**（每条 Assignment 一次），再（可选）对用户摘要 Status；**禁止**用「已粘贴 Assignment」代替 invoke。若 UI 要求先选角色再输入任务，则 **先选与子代理 id 一致的入口，再粘贴 Assignment 正文**。
 
 调用 subagent 时，**必须提供以下上下文**：
 

--- a/docs/agents/host-opencode.md
+++ b/docs/agents/host-opencode.md
@@ -11,9 +11,10 @@
 ## OpenCode 专属能力（其他宿主可能没有）
 
 - **结构化澄清**：优先使用内置 `**question`** 工具（标题、题干、选项；可自定义文本回答）。须在配置中允许 `permission.question`（由用户维护；agent 不得擅自改全局配置）。
-- **内置子代理**：如 `**@explore`**（只读导航）、`**@general**` 等，由 OpenCode 调度；语义上仍须遵守 `harness-loop.md` 中对 `@explore` 边界等的约定。
+- **内置子代理**：如 `**@explore`**（只读导航）、`**@general`** 等，由 OpenCode 调度；语义上仍须遵守 `harness-loop.md` 中对 `@explore` 边界等的约定。
+- **具名角色（`@<agent-id>`）**：配置在 `opencode.json` 的 `agent.<id>`（与 `agents/<id>.md` 同名）的角色，须由 **PM 通过宿主提供的入口实际拉起**（例如对 `@fullstack-dev` 发起一轮子代理 / Task，以 Assignment 为消息体）。**仅**在主会话里打印 `## Assignment` Markdown **不会**自动创建子代理会话；若未见子代理启动，属于**未分派**，见 `agents/project-manager.md` **§2** 与 **Q13**。
 - **按角色模型**：可在 `opencode.json` 为不同 subagent 配置不同 `model`。
 
 ## 与 Cursor 的差异摘要
 
-需要对比 Cursor 下的用法时，见同目录 `**host-cursor.md`**；库文档与上下文降噪的共用协议见 `**library-docs-and-hosts.md**`。
+需要对比 Cursor 下的用法时，见同目录 `**host-cursor.md`**；库文档与上下文降噪的共用协议见 `**library-docs-and-hosts.md`**。


### PR DESCRIPTION
Clarifies in `agents/project-manager.md` and `docs/agents/host-opencode.md` that posting Assignment markdown in the main session does not dispatch work; PM must use host subagent/Task invoke per Assignment. Adds Q13 checklist item.

Made with [Cursor](https://cursor.com)