### PR TITLE
feat(cli): add cursor target installation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,27 @@ Core value:
 
 ## Quick Start
 
-### OpenCode (Recommended): CLI Install
+### CLI Install
 
 - Use the `mstar-harness` CLI:
   - `npx mstar-harness init`
   - or `bunx mstar-harness init`
-- The CLI will:
-  - ensure `"$schema": "https://opencode.ai/config.json"` in `opencode.json`
-  - ensure and deduplicate the Morning Star plugin entry
-  - configure role model mapping with interactive or non-interactive flows
-  - run target-aware self-check after writing
+- `init` provides a target-aware guided setup so installation and baseline config happen in one flow.
+- CLI target support currently includes:
+  - `opencode`
+  - `cursor`
 
-For full CLI usage and advanced options (`--yes`, `--dry-run`, `--output`, `doctor`), see [`docs/cli.md`](docs/cli.md).
+For full CLI usage and advanced options (`--yes`, `--dry-run`, `--output`, `doctor`) including Cursor target install modes, see [`docs/cli.md`](docs/cli.md).
 
-### OpenCode: Manual Install (Alternative)
+### Manual Install
+
+Manual install targets currently include:
+
+- `opencode`
+- `cursor`
+- `codex`
+
+#### OpenCode
 
 - Plugin install:
   - Add plugin config in `opencode.json`:
@@ -51,14 +58,14 @@ For full CLI usage and advanced options (`--yes`, `--dry-run`, `--output`, `doct
 
 For detailed OpenCode setup and migration, see `.opencode/INSTALL.md`.
 
-### Cursor Installation
+#### Cursor
 
 - Local plugin install (direct clone):
   - `mkdir -p ~/.cursor/plugins/local`
   - `git clone https://github.com/btspoony/mstar-harness.git ~/.cursor/plugins/local/mstar-harness`
   - Restart Cursor or run `Developer: Reload Window`
 
-### Codex Installation
+#### Codex
 
 - Marketplace install:
   - `codex plugin marketplace add https://github.com/btspoony/mstar-harness.git --sparse .codex/`

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,20 +21,27 @@
 
 ## 快速开始（推荐方式）
 
-### OpenCode（推荐）：使用 CLI 安装
+### CLI Install
 
 - 使用 `mstar-harness` CLI：
   - `npx mstar-harness init`
   - 或 `bunx mstar-harness init`
-- CLI 会自动：
-  - 确保 `opencode.json` 包含 `"$schema": "https://opencode.ai/config.json"`
-  - 确保并去重 Morning Star 插件配置
-  - 配置角色模型映射（交互或非交互）
-  - 写入后执行按目标 agent 的自检
+- `init` 提供按 target 的引导式安装流程，将安装与基础配置一步完成。
+- CLI 当前支持的 target：
+  - `opencode`
+  - `cursor`
 
-完整 CLI 用法和高级参数（`--yes`、`--dry-run`、`--output`、`doctor`）见 [`docs/cli.md`](docs/cli.md)。
+完整 CLI 用法和高级参数（`--yes`、`--dry-run`、`--output`、`doctor`），以及 Cursor target 的安装模式说明，见 [`docs/cli.md`](docs/cli.md)。
 
-### OpenCode：手动安装（备选）
+### Manual Install
+
+当前支持手动安装的 target：
+
+- `opencode`
+- `cursor`
+- `codex`
+
+#### OpenCode
 
 - 推荐使用 plugin 安装：
   - 在 `opencode.json` 增加插件配置：
@@ -51,14 +58,14 @@
 
 OpenCode 的详细安装与迁移说明见 `.opencode/INSTALL.md`。
 
-### Cursor 安装方式
+#### Cursor
 
 - 本地插件安装（直接 clone）：
   - `mkdir -p ~/.cursor/plugins/local`
   - `git clone https://github.com/btspoony/mstar-harness.git ~/.cursor/plugins/local/mstar-harness`
   - 重启 Cursor or 运行 `Developer: Reload Window`
 
-### Codex 安装方式
+#### Codex
 
 - Marketplace 安装：
   - `codex plugin marketplace add https://github.com/btspoony/mstar-harness.git --sparse .codex/`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,22 +1,34 @@
 # mstar-harness CLI Guide
 
-This guide documents the standalone `mstar-harness` CLI for OpenCode bootstrap.
+This guide documents the standalone `mstar-harness` CLI for OpenCode and Cursor bootstrap.
 
 ## Fast Path
 
-Use this sequence for the quickest user flow:
+Use this sequence for the quickest user flow.
+
+### OpenCode
 
 1) Preview what will change:
 
-- `npx mstar-harness init --dry-run --scope project --yes --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
+- `npx mstar-harness init --target opencode --dry-run --yes --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
 
 2) Apply the setup:
 
-- `npx mstar-harness init --scope project --yes --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
+- `npx mstar-harness init --target opencode --yes --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
 
 3) Verify the final config:
 
-- `npx mstar-harness doctor --scope project`
+- `npx mstar-harness doctor --target opencode`
+
+### Cursor
+
+1) Install plugin to project (default scope):
+
+- `npx mstar-harness init --target cursor`
+
+2) Verify project install:
+
+- `npx mstar-harness doctor --target cursor`
 
 ## Install
 
@@ -36,7 +48,9 @@ Interactive bootstrap:
 - `npx mstar-harness init`
 - `bunx mstar-harness init`
 
-Non-interactive bootstrap:
+`--scope` defaults to `project` when omitted.
+
+OpenCode non-interactive bootstrap:
 
 - `npx mstar-harness init --yes --target opencode --scope project --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5,openai/gpt-5.4 --dev-models openai/gpt-5.3-codex,openai/gpt-5.5-fast --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5,openai/gpt-5.4`
 
@@ -44,18 +58,27 @@ Dry-run preview (no file write):
 
 - `npx mstar-harness init --dry-run --scope project --output .tmp/opencode.json --yes --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
 
+Cursor install:
+
+- Global install (clone to `~/.cursor/plugins/local/mstar-harness`):
+  - `npx mstar-harness init --target cursor --scope global`
+- Project install (git submodule at `.cursor/plugins/mstar-harness`):
+  - `npx mstar-harness init --target cursor --scope project`
+
 ### `mstar-harness doctor`
 
 Check an existing config:
 
 - `npx mstar-harness doctor --target opencode --scope project`
 - `npx mstar-harness doctor --output ./opencode.json`
+- `npx mstar-harness doctor --target cursor --scope global`
+- `npx mstar-harness doctor --target cursor --scope project`
 
 If validation fails, `doctor` exits with a non-zero status code.
 
 ## What `init` Ensures
 
-`init` enforces these baseline requirements in `opencode.json`:
+OpenCode `init` enforces these baseline requirements in `opencode.json`:
 
 - `"$schema": "https://opencode.ai/config.json"`
 - `plugin` contains `morning-star@git+https://github.com/btspoony/mstar-harness.git` (deduplicated)
@@ -70,8 +93,8 @@ If validation fails, `doctor` exits with a non-zero status code.
 ### `init` options
 
 - `--yes`: non-interactive mode
-- `--target <opencode>`
-- `--scope <global|project>`
+- `--target <opencode|cursor>`
+- `--scope <global|project>` (default: `project`)
 - `--dry-run`
 - `--pm-model <model>`
 - `--strategic-models <a,b,c>`
@@ -91,8 +114,6 @@ These are for contributors developing this repository:
 
 - `bun run cli:dev -- --help`
 - `bun run cli:build`
-- `bun run cli:publish:dry-run`
-- `bun run cli:publish`
 
 ### Target Adapter Architecture
 
@@ -100,6 +121,7 @@ The CLI uses a target adapter layer so new code agents can be added without rewr
 
 - Adapter registry: `packages/cli/src/adapters/index.ts`
 - OpenCode adapter: `packages/cli/src/adapters/opencode.ts`
+- Cursor adapter: `packages/cli/src/adapters/cursor.ts`
 - Shared contracts: `packages/cli/src/types.ts`
 
 To add a new agent target, implement a new adapter with:

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to `mstar-harness` CLI are documented in this file.
+
+## 0.2.0
+
+- add target adapter architecture for CLI flows
+- add `cursor` target support in `init` and `doctor`
+  - `global`: install plugin via clone into `~/.cursor/plugins/local/mstar-harness`
+  - `project`: install plugin as git submodule at `.cursor/plugins/mstar-harness`
+- keep `opencode` model-driven init flow with schema/plugin/model validation
+- default `--scope` behavior to `project` when not provided
+- add standalone CLI docs at `docs/cli.md` and document target-based usage

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mstar-harness",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "files": [
     "dist"

--- a/packages/cli/src/adapters/cursor.ts
+++ b/packages/cli/src/adapters/cursor.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import type { AgentAdapter, Scope } from "../types";
+import { resolveProjectRoot } from "../utils";
+
+const REPO_URL = "https://github.com/btspoony/mstar-harness.git";
+const CURSOR_PLUGIN_NAME = "mstar-harness";
+const CURSOR_PLUGIN_MARKER = ".cursor-plugin/plugin.json";
+
+function globalInstallPath() {
+  return path.join(os.homedir(), ".cursor", "plugins", "local", CURSOR_PLUGIN_NAME);
+}
+
+function projectInstallPath() {
+  return path.join(resolveProjectRoot(), ".cursor", "plugins", CURSOR_PLUGIN_NAME);
+}
+
+function ensureDir(dirPath: string, dryRun: boolean) {
+  if (dryRun) return;
+  if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function runCommand(command: string[], cwd: string, dryRun: boolean) {
+  if (dryRun) return;
+  execFileSync(command[0], command.slice(1), { cwd, stdio: "pipe", encoding: "utf8" });
+}
+
+function globalInit(dryRun: boolean) {
+  const location = globalInstallPath();
+  const notes: string[] = [];
+  if (fs.existsSync(location)) {
+    notes.push(`Plugin already exists at ${location}`);
+    return { location, notes };
+  }
+
+  ensureDir(path.dirname(location), dryRun);
+  runCommand(["git", "clone", REPO_URL, location], path.dirname(location), dryRun);
+  notes.push(`Cloned ${REPO_URL} to ${location}`);
+  return { location, notes };
+}
+
+function projectInit(dryRun: boolean) {
+  const projectRoot = resolveProjectRoot();
+  const location = projectInstallPath();
+  const notes: string[] = [];
+  if (fs.existsSync(location)) {
+    notes.push(`Submodule path already exists at ${location}`);
+    return { location, notes };
+  }
+
+  runCommand(["git", "rev-parse", "--is-inside-work-tree"], projectRoot, dryRun);
+  ensureDir(path.join(projectRoot, ".cursor", "plugins"), dryRun);
+  runCommand(
+    ["git", "submodule", "add", REPO_URL, ".cursor/plugins/mstar-harness"],
+    projectRoot,
+    dryRun,
+  );
+  notes.push("Added mstar-harness as git submodule at .cursor/plugins/mstar-harness");
+  return { location, notes };
+}
+
+function globalDoctor() {
+  const location = globalInstallPath();
+  const errors: string[] = [];
+  if (!fs.existsSync(location)) {
+    errors.push(`Missing plugin directory: ${location}`);
+    return { location, errors };
+  }
+  const marker = path.join(location, CURSOR_PLUGIN_MARKER);
+  if (!fs.existsSync(marker)) {
+    errors.push(`Missing Cursor plugin marker file: ${marker}`);
+  }
+  return { location, errors };
+}
+
+function projectDoctor() {
+  const projectRoot = resolveProjectRoot();
+  const location = projectInstallPath();
+  const errors: string[] = [];
+  if (!fs.existsSync(location)) {
+    errors.push(`Missing submodule directory: ${location}`);
+  }
+
+  const gitmodulesPath = path.join(projectRoot, ".gitmodules");
+  if (!fs.existsSync(gitmodulesPath)) {
+    errors.push("Missing .gitmodules (expected cursor plugin submodule entry).");
+    return { location, errors };
+  }
+
+  const gitmodules = fs.readFileSync(gitmodulesPath, "utf8");
+  if (!gitmodules.includes("path = .cursor/plugins/mstar-harness")) {
+    errors.push("Missing .cursor/plugins/mstar-harness entry in .gitmodules.");
+  }
+
+  return { location, errors };
+}
+
+export const cursorAdapter: AgentAdapter = {
+  target: "cursor",
+  mode: "install",
+  runInstallInit: (scope, dryRun) => {
+    if (scope === "global") return globalInit(dryRun);
+    return projectInit(dryRun);
+  },
+  runInstallDoctor: (scope) => {
+    if (scope === "global") return globalDoctor();
+    return projectDoctor();
+  },
+};

--- a/packages/cli/src/adapters/index.ts
+++ b/packages/cli/src/adapters/index.ts
@@ -1,8 +1,10 @@
 import type { AgentAdapter, Target } from "../types";
+import { cursorAdapter } from "./cursor";
 import { opencodeAdapter } from "./opencode";
 
 const adapters: Record<Target, AgentAdapter> = {
   opencode: opencodeAdapter,
+  cursor: cursorAdapter,
 };
 
 export function getAdapter(target: Target) {

--- a/packages/cli/src/adapters/opencode.ts
+++ b/packages/cli/src/adapters/opencode.ts
@@ -90,6 +90,7 @@ function validateSetup(config: Record<string, unknown>) {
 
 export const opencodeAdapter: AgentAdapter = {
   target: "opencode",
+  mode: "config",
   getAvailableModels: () => getOpencodeModels(),
   resolveConfigPath: (scope, outputPath) => resolveOpencodeConfigPath(scope, outputPath),
   mutateConfigForInit: (config, assignments) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,16 +35,6 @@ async function pickTargetInteractive() {
   });
 }
 
-async function pickScopeInteractive() {
-  return select<Scope>({
-    message: "Select install scope",
-    choices: [
-      { name: "global", value: "global" },
-      { name: "project", value: "project" },
-    ],
-  });
-}
-
 async function pickModelsInteractive(params: {
   title: string;
   hint: string;
@@ -117,30 +107,52 @@ async function resolveSelections(options: InitOptions, models: string[]) {
 
 async function runInit(options: InitOptions) {
   const target = options.target || (options.yes ? "opencode" : await pickTargetInteractive());
-  const scope = options.scope || (options.yes ? "project" : await pickScopeInteractive());
+  const scope = options.scope || "project";
   const adapter = getAdapter(target);
 
+  if (!options.scope && !options.yes) {
+    console.log(pc.dim("Scope not provided; defaulting to project."));
+  }
+
+  if (adapter.mode === "install") {
+    logStep("Step 2/2 - Run target install flow");
+    const installResult = adapter.runInstallInit?.(scope, !!options.dryRun);
+    if (!installResult) {
+      throw new Error(`Adapter ${target} does not implement install init flow.`);
+    }
+    console.log(pc.green(`Status: ${options.dryRun ? "ready (dry-run)" : "configured"} (${scope})`));
+    console.log(`Target: ${target}`);
+    console.log(`Install location: ${installResult.location}`);
+    for (const note of installResult.notes) {
+      console.log(`  - ${note}`);
+    }
+    return;
+  }
+
   logStep(`Step 3/7 - Fetch available models from ${adapter.target}`);
-  const models = adapter.getAvailableModels();
+  const models = adapter.getAvailableModels?.();
+  if (!models) throw new Error(`Adapter ${target} does not implement model discovery.`);
   const selections = await resolveSelections(options, models);
 
   logStep("Step 5/7 - Build role model assignments");
   const assignments = buildModelAssignments(selections);
 
   logStep("Step 6/7 - Update config");
-  const configPath = adapter.resolveConfigPath(scope, options.output);
+  const configPath = adapter.resolveConfigPath?.(scope, options.output);
+  if (!configPath) throw new Error(`Adapter ${target} does not implement config path resolution.`);
   const current = readJson(configPath);
-  const updated = adapter.mutateConfigForInit(current, assignments);
+  const updated = adapter.mutateConfigForInit?.(current, assignments);
+  if (!updated) throw new Error(`Adapter ${target} does not implement init mutation.`);
 
   logStep("Step 7/7 - Self-check");
-  const checkErrors = adapter.validateConfig(updated);
+  const checkErrors = adapter.validateConfig?.(updated) || [];
   if (checkErrors.length) {
     throw new Error(`Configuration verification failed:\n- ${checkErrors.join("\n- ")}`);
   }
 
   if (!options.dryRun) {
     writeJson(configPath, updated);
-    const persistedErrors = adapter.validateConfig(readJson(configPath));
+    const persistedErrors = adapter.validateConfig?.(readJson(configPath)) || [];
     if (persistedErrors.length) {
       throw new Error(`Post-write verification failed:\n- ${persistedErrors.join("\n- ")}`);
     }
@@ -160,17 +172,35 @@ function runDoctor(options: DoctorOptions) {
   const target = options.target || "opencode";
   const adapter = getAdapter(target);
   const scope = options.scope || "project";
-  const configPath = adapter.resolveConfigPath(scope, options.output);
-  const config = readJson(configPath);
-  const errors = adapter.validateConfig(config);
-
   console.log(`Target: ${target}`);
+
+  if (adapter.mode === "install") {
+    const result = adapter.runInstallDoctor?.(scope);
+    if (!result) {
+      throw new Error(`Adapter ${target} does not implement install doctor flow.`);
+    }
+    console.log(`Install location: ${result.location}`);
+    if (!result.errors.length) {
+      console.log(pc.green("Doctor result: healthy"));
+      return;
+    }
+    console.log(pc.red(`Doctor result: ${result.errors.length} issue(s)`));
+    for (const issue of result.errors) console.log(`  - ${issue}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const configPath = adapter.resolveConfigPath?.(scope, options.output);
+  if (!configPath) {
+    throw new Error(`Adapter ${target} does not implement config doctor flow.`);
+  }
+  const config = readJson(configPath);
+  const errors = adapter.validateConfig?.(config) || [];
   console.log(`Config file: ${configPath}`);
   if (!errors.length) {
     console.log(pc.green("Doctor result: healthy"));
     return;
   }
-
   console.log(pc.red(`Doctor result: ${errors.length} issue(s)`));
   for (const issue of errors) console.log(`  - ${issue}`);
   process.exitCode = 1;
@@ -183,10 +213,10 @@ program
 
 program
   .command("init")
-  .description("Interactive/non-interactive setup for target agent model mapping")
+  .description("Interactive/non-interactive setup for target agent bootstrap")
   .option("-y, --yes", "Non-interactive mode")
   .option("--target <target>", "Install target", "opencode")
-  .option("--scope <scope>", "Config scope: global|project")
+  .option("--scope <scope>", "Config scope: global|project (default: project)")
   .option("--output <path>", "Config file path override, relative to project root")
   .option("--dry-run", "Preview result without writing config")
   .option("--pm-model <model>", "Model for project-manager")

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_TARGETS = ["opencode"] as const;
+export const SUPPORTED_TARGETS = ["opencode", "cursor"] as const;
 export type Target = (typeof SUPPORTED_TARGETS)[number];
 export type Scope = "global" | "project";
 
@@ -31,12 +31,15 @@ export type ModelSelections = {
 
 export type AgentAdapter = {
   target: Target;
-  getAvailableModels: () => string[];
-  resolveConfigPath: (scope: Scope, outputPath?: string) => string;
-  mutateConfigForInit: (
+  mode: "config" | "install";
+  getAvailableModels?: () => string[];
+  resolveConfigPath?: (scope: Scope, outputPath?: string) => string;
+  mutateConfigForInit?: (
     config: Record<string, unknown>,
     assignments: Record<string, string>,
   ) => Record<string, unknown>;
-  validateConfig: (config: Record<string, unknown>) => string[];
+  validateConfig?: (config: Record<string, unknown>) => string[];
+  runInstallInit?: (scope: Scope, dryRun: boolean) => { location: string; notes: string[] };
+  runInstallDoctor?: (scope: Scope) => { location: string; errors: string[] };
   printPostSetupSummary?: (config: Record<string, unknown>) => void;
 };


### PR DESCRIPTION
## Summary
- add `cursor` as a first-class CLI target with install-mode adapter behavior for `init` and `doctor`
- keep `opencode` model-config flow intact while making scope default to `project`
- refresh docs and release metadata (`docs/cli.md`, README/README_CN, `packages/cli` version `0.2.0`, changelog)

## Test plan
- [x] `bun run cli:dev -- --help`
- [x] `bun run cli:dev -- init --help`
- [x] `bun run cli:dev -- doctor --help`
- [x] `bun run cli:build`
- [x] `MSTAR_CLI_PROJECT_ROOT=/tmp bun run --cwd packages/cli dev -- init --target cursor --scope global --dry-run`
- [x] `MSTAR_CLI_PROJECT_ROOT=/tmp bun run --cwd packages/cli dev -- init --target cursor --dry-run`
- [x] `MSTAR_CLI_PROJECT_ROOT=/tmp bun run --cwd packages/cli dev -- init --yes --target opencode --output .tmp-opencode.json --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
- [x] `MSTAR_CLI_PROJECT_ROOT=/tmp bun run --cwd packages/cli dev -- doctor --target opencode --output .tmp-opencode.json`

Made with [Cursor](https://cursor.com)