### PR TITLE
Fix Cursor Plan Build resume contract

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -24,6 +24,9 @@
     "workflow",
     "quality-gates"
   ],
+  "agents": [
+    "agents/"
+  ],
   "skills": [
     "skills/"
   ],

--- a/.cursor/LOCAL-VALIDATION.md
+++ b/.cursor/LOCAL-VALIDATION.md
@@ -22,6 +22,7 @@ Use before publishing or sharing the Morning Star Cursor plugin from this repo.
 - Trigger a role-routed task (for example, PM-style routing).
 - Confirm one `mstar-*` skill and `mstar-host` from `skills/` can load.
 - Confirm one `./rules/*.mdc` rule is applied during execution.
+- In Plan mode, create a Morning Star plan, click Build, and confirm the first Agent-mode step resumes PM/harness context before any product-code edit.
 
 ## 4) Packaging guardrails
 

--- a/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
+++ b/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
@@ -1,7 +1,7 @@
 {
   "harness_name": "pm-routing-evals",
-  "version": 6,
-  "updated_at": "2026-06-01",
+  "version": 7,
+  "updated_at": "2026-06-02",
   "cases": [
     {
       "id": "small-ui-tweak",
@@ -107,6 +107,13 @@
       "expected_route": ["@explore", "@architect", "@fullstack-dev", "@fullstack-dev-2", "QC-3-reviewers", "@qa-engineer"],
       "must_have_artifacts": ["Context Loaded declaration", "assignment language contract (EN keys + CN task body)", "PM Task Board with >=2 independent backend units", "Execute as alternates between fullstack-dev and fullstack-dev-2 across batches (round-robin) OR Pre-Implement Gate Check single_stream_justified: yes with documented reason", "Dev routing documents rotation or parallel intent per batch", "QA evidence in English"],
       "hard_fail_if": ["missing Context Loaded declaration", "all independent backend batches assigned only to @fullstack-dev without single_stream_justified and Dev owner tie-break reason", "claims rotation but every batch uses same Execute as without continuity override", "assignment uses non-English field keys", "report is non-English without user override"]
+    },
+    {
+      "id": "cursor-plan-build-resume",
+      "prompt": "In Cursor Plan mode, create a Morning Star plan, then click Build to start execution.",
+      "expected_route": ["@project-manager", "@fullstack-dev", "QC-3-reviewers", "@qa-engineer"],
+      "must_have_artifacts": ["Context Loaded declaration", "Cursor Build resume contract acknowledged", "SSOT plan path in Context Loaded", "status.json plan_id registration", "PM Assignment before implementation", "matching host Task invoke for implementation"],
+      "hard_fail_if": ["Build treated as replay of /pm", "parent session edits product code before PM Assignment and Task dispatch", "implementation starts before SSOT plan and status.json registration", "implement todo lacks Execute as or Delegation or Working branch or Branch policy or SSOT Plan Path", "assignment uses non-English field keys", "report is non-English without user override"]
     },
     {
       "id": "hotfix-exception-with-post-rca",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,29 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **0.6.3** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **0.6.4** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **0.6.3** |
+| Monorepo root | `morning-star` (`package.json`) | **0.6.4** |
 | CLI | `@mstar-harness/cli` (`packages/cli`) | **0.4.0** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.6.3** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **0.6.3** |
-| Codex plugin | `.codex-plugin/plugin.json` | **0.6.3** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.6.4** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **0.6.4** |
+| Codex plugin | `.codex-plugin/plugin.json` | **0.6.4** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [0.6.4] - 2026-06-03
+
+### Cursor Plan mode × Harness
+
+- **Build resume contract**: Cursor Build is treated as plan resume, not `/pm` replay. Morning Star plans must reload harness context, resume PM orchestration, and dispatch implementation instead of letting the parent Build session edit product code.
+- **Cursor routing-eval**: Add `cursor-plan-build-resume` to guard against parent-session implementation before SSOT plan registration, PM Assignment, and host Task dispatch.
+- **Cursor plugin manifest**: Register `agents/` in `.cursor-plugin/plugin.json`, matching plugin docs and validation checks.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, and Cursor / Codex plugin manifests: **0.6.3 → 0.6.4**. **`@mstar-harness/cli` remains 0.4.0**.
 
 ## [0.6.3] - 2026-06-03
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,28 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.6.3**（CLI 包除外，见下表）。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.6.4**（CLI 包除外，见下表）。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **0.6.3** |
+| monorepo 根 | `morning-star`（`package.json`） | **0.6.4** |
 | CLI | `@mstar-harness/cli`（`packages/cli`） | **0.4.0** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.6.3** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.6.3** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **0.6.3** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.6.4** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.6.4** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **0.6.4** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [0.6.4] - 2026-06-03
+
+### Cursor Plan 模式 × Harness
+
+- **Build resume contract**：Cursor Build 视为 plan resume，而不是 `/pm` replay。Morning Star plan 必须重新加载 harness 上下文，恢复 PM 编排，并通过 dispatch 执行实现，禁止父 Build 会话直接改产品代码。
+- **Cursor routing-eval**：新增 `cursor-plan-build-resume`，防止在 SSOT plan 注册、PM Assignment 与 host Task dispatch 之前由父会话直接实现。
+- **Cursor 插件 manifest**：`.cursor-plugin/plugin.json` 注册 `agents/`，与插件文档和本地校验清单对齐。
+
+### 版本对齐
+
+- monorepo 根、`@mstar-harness/opencode`、Cursor / Codex 插件 manifest：**0.6.3 → 0.6.4**。**`@mstar-harness/cli` 保持 0.4.0**。
 
 ## [0.6.3] - 2026-06-03
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 0.6.4
+
+- Bundled skills: Cursor Plan Build resume contract and routing-eval v7.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **0.6.4**.
+
 ## 0.6.3
 
 - Bundled skills: slim `/pm` with dispatch-first + `/pm`-only rules; PM shell pointer.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/rules/mstar-cursor-plan-mode.mdc
+++ b/rules/mstar-cursor-plan-mode.mdc
@@ -34,6 +34,16 @@ Do **not** mark an implement todo complete until:
 - Keep CreatePlan body and SSOT plan file aligned when scope changes.
 - Use SSOT paths in **Plan Path** / **Context Loaded**, not only the Cursor plan URI.
 
+## Build resume contract
+
+When the user clicks **Build** or Cursor switches from Plan mode to Agent mode:
+
+- Treat Build as **resume**, not as a replay of `/pm`.
+- Before editing product files, reload the Morning Star entry: `mstar-harness-core` → `mstar-host` Cursor reference → `cursor-plan-mode-bridge`.
+- If the plan belongs to Morning Star, default to `project-manager` orchestration: plan/status upkeep is allowed; implementation, tests, review, and ops execution must be dispatched.
+- Do not start an implement/code todo until the SSOT plan exists, `status.json` contains the `plan_id`, and the task has a PM Assignment with `Execute as`, `Delegation`, `Working branch` or `Branch policy`, and SSOT `Plan Path`.
+- If any field is missing, report **Blocked** and restore the harness state before implementation.
+
 ## Detail
 
 Read `skills/mstar-host/references/cursor-plan-mode-bridge.md` (via `mstar-host` skill) for templates and checklists. Conflict with harness invariants → **`mstar-harness-core`** wins.

--- a/skills/mstar-host/references/cursor-plan-mode-bridge.md
+++ b/skills/mstar-host/references/cursor-plan-mode-bridge.md
@@ -148,6 +148,22 @@ Before switching from Plan to Agent for implementation (or declaring Plan phase 
 
 If any item fails → **Blocked**; finish harness sync before implement.
 
+## Build resume contract
+
+Cursor **Build** resumes the current plan in Agent mode. Do not assume it replays `/pm` or re-enters a role skill automatically.
+
+First action after Build, before product-code edits:
+
+1. Reload the harness entry: `mstar-harness-core` → `mstar-host` Cursor reference → this bridge.
+2. If the plan is a Morning Star plan, resume as `project-manager` for coordination and dispatch only.
+3. Read the SSOT plan and `status.json`; use them as the source of truth over the Cursor plan URI.
+4. For each implement/code todo, require a PM Assignment with `Execute as`, `Delegation`, `Working branch` or `Branch policy`, and SSOT `Plan Path`.
+5. If the Assignment or SSOT state is missing, report **Blocked** and repair the harness state before implementation.
+
+Allowed in the parent Build session: plan/status maintenance, routing decisions, Assignment writing, and host Task dispatch.
+
+Not allowed in the parent Build session by default: product implementation, test implementation, QC execution, QA execution, deployment, or ops changes. Those follow the normal PM dispatch rules unless the user explicitly overrides the harness.
+
 ## PM in Plan mode (`/pm`)
 
 When `/pm` runs under Plan mode:
@@ -166,6 +182,7 @@ When `/pm` runs under Plan mode:
 | Drift between CreatePlan and SSOT plan | Update both in same round |
 | Cursor plan URI as Plan Path | Use `{PLAN_DIR}/...` path |
 | Skip `spec-register` | Add `plans[]` row before implement |
+| Build starts coding in the parent session | Resume PM context; dispatch implement work or block on missing Assignment |
 
 ## Related skills
 

--- a/skills/mstar-host/references/cursor.md
+++ b/skills/mstar-host/references/cursor.md
@@ -27,6 +27,8 @@ Each **implement todo**: per–task-ID **git commit** on Working branch → SSOT
 
 Before **SwitchMode → Agent**: mirror plan exists; `status.json` lists `plan_id`; bootstrap todos done. **Never** use only the Cursor plan URI as **Plan Path**.
 
+After **Build**: treat the run as plan resume, not `/pm` replay. Reload `mstar-harness-core` + this Cursor reference, resume Morning Star plans as `project-manager` orchestration, and dispatch implementation through Task unless the user explicitly overrides the harness.
+
 Enforcement: `rules/mstar-cursor-plan-mode.mdc` when plugin active.
 
 ## `/pm` precedence


### PR DESCRIPTION
## Summary
- Treat Cursor Plan Build as a Morning Star plan resume instead of `/pm` replay, requiring harness context reload and PM dispatch before product-code implementation.
- Add a Cursor routing-eval case and local validation check for Plan mode Build resume behavior.
- Register Cursor plugin agents and bump shared harness surfaces to `0.6.4` with English/Chinese changelog updates.

## Test plan
- `python3 -m json.tool package.json >/dev/null && python3 -m json.tool packages/opencode/package.json >/dev/null && python3 -m json.tool .cursor-plugin/plugin.json >/dev/null && python3 -m json.tool .codex-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .cursor/skills/mstar-routing-eval/assets/routing-evals.json >/dev/null`
- `git diff --check`
- Cursor smoke test noted in `.cursor/LOCAL-VALIDATION.md`: create a Morning Star plan in Plan mode, click Build, and confirm the first Agent-mode step resumes PM/harness context before product-code edits.

Made with [Cursor](https://cursor.com)