### PR TITLE
QC targeted re-review and short report filenames (0.6.8)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,29 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **0.6.7** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **0.6.8** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **0.6.7** |
+| Monorepo root | `morning-star` (`package.json`) | **0.6.8** |
 | CLI | `@mstar-harness/cli` (`packages/cli`) | **0.5.0** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.6.7** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **0.6.7** |
-| Codex plugin | `.codex-plugin/plugin.json` | **0.6.7** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.6.8** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **0.6.8** |
+| Codex plugin | `.codex-plugin/plugin.json` | **0.6.8** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [0.6.8] - 2026-06-04
+
+### Harness (skills / agents)
+
+- **QC fix-round revalidation (default)**: After dev fixes blocking findings, PM dispatches only the QC seat(s) that raised each item (**targeted re-review**), not a blind full tri-review. Reviewers update the **same** report file in place (`## Revalidation`); PM updates the same `qc-consolidated.md`. Full tri re-review requires explicit Assignment `QC re-review: full tri-review` and new `qcN-rev2.md` basenames.
+- **QC report naming**: Under `{PLAN_DIR}/reports/<plan-id>/`, use short basenames `qc1.md`, `qc2.md`, `qc3.md`, and `qc-consolidated.md` (no `<plan-id>` prefix in filenames; `plan_id` stays in frontmatter and the directory). SSOT: `mstar-plan-artifacts/references/plan-files-and-reports.md`.
+- **Dispatch**: `mstar-dispatch-gates` and `mstar-host` parallel-dispatch allow **N = 1–3** invokes for targeted re-review in one message; initial tri-review remains **N = 3**.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, and Cursor / Codex plugin manifests: **0.6.7 → 0.6.8**. **`@mstar-harness/cli` remains 0.5.0**.
 
 ## [0.6.7] - 2026-06-03
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,28 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.6.7**（CLI 包除外，见下表）。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.6.8**（CLI 包除外，见下表）。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **0.6.7** |
+| monorepo 根 | `morning-star`（`package.json`） | **0.6.8** |
 | CLI | `@mstar-harness/cli`（`packages/cli`） | **0.5.0** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.6.7** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.6.7** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **0.6.7** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.6.8** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.6.8** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **0.6.8** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [0.6.8] - 2026-06-04
+
+### Harness（skills / agents）
+
+- **QC 修复后复验（默认）**：dev 修完 blocking 项后，PM **只派**提出该问题的 QC 席（**targeted re-review**），不再默认无脑重派三审。各 QC **原位更新**同一份报告（`## Revalidation`）；PM 原位更新 `qc-consolidated.md`。仅当 Assignment 写明 **`QC re-review: full tri-review`** 时才复跑三审并使用 `qcN-rev2.md` 新文件名。
+- **QC 报告命名**：`{PLAN_DIR}/reports/<plan-id>/` 下使用 `qc1.md`、`qc2.md`、`qc3.md`、`qc-consolidated.md`（文件名**不再**带 `<plan-id>` 前缀；`plan_id` 在 frontmatter 与目录中体现）。SSOT：`mstar-plan-artifacts/references/plan-files-and-reports.md`。
+- **派发**：`mstar-dispatch-gates` 与 `mstar-host` 并行派发支持 targeted 复验 **N=1–3** 同条消息；首轮三审仍为 **N=3**。
+
+### 版本对齐
+
+- monorepo 根、`@mstar-harness/opencode`、Cursor / Codex 插件 manifest：**0.6.7 → 0.6.8**。**`@mstar-harness/cli` 保持 0.5.0**。
 
 ## [0.6.7] - 2026-06-03
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 0.6.8
+
+- Bundled skills: targeted QC re-review after fixes (owner seat only, in-place reports), short QC report basenames under `reports/<plan-id>/` (`qc1.md` …).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **0.6.8**.
+
 ## 0.6.7
 
 - Bundled skills: Codex Plan / Goal Mode bridge for keeping `/plan`, `update_plan`, `/goal`, and goal progress aligned with `.mstar/` SSOT.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-dispatch-gates/SKILL.md
+++ b/skills/mstar-dispatch-gates/SKILL.md
@@ -40,7 +40,8 @@ description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent
 当 PM 声明「并发分派」时，须同时满足**文案并发**与**工具并发**：
 
 - **工具并发**：同一调度轮次内，多个 subagent 调用须在**同一条 assistant 消息**里一次性发出（宿主允许时）。
-- **QC 三审硬门禁**：`qc-specialist` / `qc-specialist-2` / `qc-specialist-3` 须**同一条消息**全部发起；只发其中一个 = **`dispatch incomplete`**，不得写「三审已并行启动」。
+- **QC 三审硬门禁（initial wave）**：`qc-specialist` / `qc-specialist-2` / `qc-specialist-3` 须**同一条消息**全部发起（**N=3**）；只发其中一个 = **`dispatch incomplete`**，不得写「三审已并行启动」。
+- **QC targeted re-review**：Assignment 含 **`QC re-review: targeted — reviewers: …`** 时，**N** = 所列席位数（1–3），仍须**同一条消息**发满 **N**；不得默认补满三人。
 - **先自检再发送**：发送前核对「Assignment 条数 = 本条消息中的实际 **派发** 调用条数」。
 - **前置步骤与派发回合分离（防串行 rollout）**：为派发准备的 **`bash` / `read` / `glob` / `grep`**（如 `merge-base`、`Review range`、`git rev-parse`）**不计入** `N` 次派发；可在上一条仅含准备的消息完成。准备完成后，**下一条派发消息**须**一次性**含 **`N` 次** Task / subagent invoke。**禁止**先发 `1` 次、等返回再补发其余 `N-1` 次。
 - **未齐不发（emit zero until batch-ready）**：需并发 `N≥2` 而当前只能发 `1` 条时，本条应发 **`0` 条派发 invoke`**（可继续 read/bash 补齐），**禁止**「先发一个顶一下」；`N` 份 payload 就绪后**单次消息发满 `N`**。见 **`mstar-host`** → `references/parallel-dispatch.md`（具备 invoke / Task / subagent 工具的宿主共用）。
@@ -53,7 +54,7 @@ description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent
 
 - 独立模块可并行；避免写操作归属重叠；跨领域变更先锁接口契约再并行编码。
 - **QC 三审**在 feature 开发完成后执行；三名 reviewer 共用同一组 `Review cwd` / `Working branch` / `plan_id` / `Review range` / `Diff basis`（**`mstar-branch-worktree`**）。
-- **同一 plan 多 batch**：默认整 plan 交付完成跑一轮完整三审；复验波次用新文件名（**`mstar-plan-artifacts`**、**`mstar-review-qc`**）。
+- **同一 plan 多 batch**：默认整 plan 交付完成跑一轮完整三审；**fix 后默认 targeted re-review**（N = 被指派的 QC 席位数，同条消息发满 N）；**仅** Assignment 写明 **`QC re-review: full tri-review`** 时复跑三审且用新文件名（**`mstar-plan-artifacts/references/plan-files-and-reports.md`**、**`mstar-review-qc`**）。
 
 ## 反模式（派发）
 

--- a/skills/mstar-harness-core/SKILL.md
+++ b/skills/mstar-harness-core/SKILL.md
@@ -123,6 +123,7 @@ Read **`mstar-host`** after this skill; detect host per its table, then Read the
 | 反模式 | 详见 |
 |--------|------|
 | QC 串行 rollout / dispatch incomplete | `mstar-dispatch-gates` |
+| fix 后无脑重派三审 / 用 `-rev2` 代替原位复验 | `mstar-plan-artifacts` · `mstar-review-qc` |
 | 递归误派 / 误读 Handoff | `mstar-dispatch-gates` |
 | `quick` 跳过 Prepare | 上表 + `mstar-phase-gates` |
 | 多 worktree 未归并就 QC | `mstar-branch-worktree` |

--- a/skills/mstar-host/references/parallel-dispatch.md
+++ b/skills/mstar-host/references/parallel-dispatch.md
@@ -27,16 +27,22 @@ Printing `## Assignment` in the main thread **without** matching host invocation
 - Dual-track implement: **`N = 2` ⇒ two invocations in one message** when parallel is required.
 - Status Update on dispatch turns: **`Subagent invokes issued: N`** (must match Assignment count). If Assignments were written but `N = 0` → **`dispatch failed — paste-only`**; fix next message.
 
-## QC tri-review
+## QC tri-review (initial wave)
 
-- Launch `qc-specialist`, `qc-specialist-2`, `qc-specialist-3` in **one** dispatch turn (**3** invocations, one message).
+- Launch `qc-specialist`, `qc-specialist-2`, `qc-specialist-3` in **one** dispatch turn (**N=3** invocations, one message).
 - Do not claim parallel QC unless all three were issued in that turn.
 - Post-dispatch: verify three distinct agent IDs and intended model mapping; on mismatch → invalid dispatch, re-dispatch before consolidation.
+
+## QC targeted re-review (after fixes)
+
+- Assignment: **`QC re-review: targeted — reviewers: <role-ids>`** → **N** = listed seats only (1–3), **one** dispatch turn with **N** invocations.
+- Do **not** default to three invocations after a routine fix round.
+- Post-dispatch: verify only **dispatched** seats returned; PM updates same `qc-consolidated.md` (see `mstar-plan-artifacts/references/plan-files-and-reports.md`).
 
 ## Self-check before send
 
 1. Required assignments this turn? (`N`)
 2. Prerequisite-only message? → **zero** batch dispatches unless `N = 1`.
 3. Dispatch message contains **exactly `N`** invocation calls?
-4. QC tri-review → **exactly 3** in one dispatch message?
+4. QC initial tri-review → **exactly 3** in one dispatch message? Targeted re-review → **N** = Assignment reviewer count?
 5. Previous message was prerequisite-only → this message must include **all `N`** (not “QC1 first”).

--- a/skills/mstar-phase-gates/SKILL.md
+++ b/skills/mstar-phase-gates/SKILL.md
@@ -102,7 +102,7 @@ description: Morning Star (启明星) Spec-Driven 双阶段门禁 —— Prepare
 
 ## Plan 目录与审查报告（启用 `{PLAN_DIR}` 时）
 
-- 进入 `InReview` 后，QC 书面产出按 `mstar-plan-conventions` 落入 `{PLAN_DIR}/reports/<plan-id>/`（如 `*-qc1.md` … `*-qc-consolidated.md`）；勿与主 plan 文件混写为「唯一草稿」后又删，保留可追溯历史。**多 batch 的同一 plan**：完整 QC 三审**默认在整 plan dev 完成后一次**（非每 batch），见 `mstar-plan-conventions`「QC 三审触发时机」。
+- 进入 `InReview` 后，QC 书面产出落入 `{PLAN_DIR}/reports/<plan-id>/`（如 `qc1.md` … `qc-consolidated.md`）；**fix 后默认 targeted re-review**（原位更新同文件，不默认 `-rev2`），见 **`mstar-plan-artifacts/references/plan-files-and-reports.md`**。**多 batch**：完整三审**默认在整 plan dev 完成后一次**（非每 batch）。
 - 非阻断项与后续技术债：PM 汇总后写入 `{HARNESS_DIR}/status.json` 根级 `residual_findings[<plan-id>]`（**open**，与 `plans` 平级；canonical 见 **`mstar-plan-artifacts` SKILL.md**）；关闭后迁入 `{HARNESS_DIR}/archived/residuals/<plan-id>.json`，与 `mstar-review-qc` 一致。每条 **`severity`** 遵守 **`mstar-plan-artifacts/references/status-and-residuals.md`**「Residual findings：severity（SSOT，机器字段）」。
 
 ## 快速判定（PM）

--- a/skills/mstar-plan-artifacts/references/knowledge-and-designs.md
+++ b/skills/mstar-plan-artifacts/references/knowledge-and-designs.md
@@ -71,7 +71,7 @@
 
 | 与相邻目录的分工                                  | 典型内容                                                                  |
 | ----------------------------------------- | --------------------------------------------------------------------- |
-| `**{PLAN_DIR}/reports/<plan-id>/**`       | QC / review **流程留档**（`-qc*.md`、consolidated 等），只读历史链                  |
+| `**{PLAN_DIR}/reports/<plan-id>/**`       | QC / review **流程留档**（`qc1.md` … `qc-consolidated.md` 等），只读历史链                  |
 | **本目录 `{PLAN_DIR}/residuals/<plan-id>/`** | 针对**仍 open** 的某一 R#：defer 背景、遗留原因、代码锚点、后续接手提示等**长文**                  |
 | `**{KNOWLEDGE_DIR}/**`            | 可跨 plan 复用的**实现向**设计上下文、规格修订、gap 分析（若文中顺带提到 residual，仍以 JSON + residuals 为跟踪权威） |
 | `**{ITERATION_DIR}/**`            | 迭代/版本级 compass；**不**替代 `{KNOWLEDGE_DIR}` 中的跨版本 SSOT |

--- a/skills/mstar-plan-artifacts/references/plan-files-and-reports.md
+++ b/skills/mstar-plan-artifacts/references/plan-files-and-reports.md
@@ -10,16 +10,18 @@
 
 **审查报告文件**（置于 `{PLAN_DIR}/reports/<plan-id>/`）：
 
-| 类型 | 文件名 |
+**QC basename rule**：目录名已是 `<plan-id>` — **do not** repeat it in report filenames. Put `plan_id` in YAML frontmatter only.
+
+| 类型 | 文件名（相对 `reports/<plan-id>/`） |
 |------|--------|
-| 架构/设计评审 | `<plan-id>-review.md` |
-| QC 并行报告 | `<plan-id>-qc1.md`、`-qc2.md`、`-qc3.md` |
-| QC 汇总结论 | `<plan-id>-qc-consolidated.md` |
+| 架构/设计评审 | `<plan-id>-review.md`（或团队约定的 `review.md`） |
+| QC 并行报告 | `qc1.md`、`qc2.md`、`qc3.md`（与 `mstar-roles` `{report_suffix}` 一致） |
+| QC 汇总结论 | `qc-consolidated.md` |
 
 ## QC 分报告与 consolidated：可否只留一份？
 
-- **不要删除** `<plan-id>-qc1.md`、`-qc2.md`、`-qc3.md`**只因为**已写入 `<plan-id>-qc-consolidated.md`。`reports/` 在此约定下是**只读历史 / 审计链**：分 reviewer 原文保留**证据出处、分歧与独立视角**；**consolidated** 是 PM 的**门控摘要**，二者**叠加**，**不互为替代**。
-- **极窄例外**（须团队显式采纳并承担审计缺口）：例如仓库体积极敏感时，仅保留 consolidated + 指向外部归档的链接——**不在**本默认 harness 中推荐；默认仍保留三份 `-qc*.md`。
+- **不要删除** `qc1.md`、`qc2.md`、`qc3.md` **只因为**已写入 `qc-consolidated.md`。`reports/<plan-id>/` 是**审计链**：分 reviewer 原文保留**证据出处、分歧与独立视角**；**consolidated** 是 PM 的**门控摘要**，二者**叠加**，**不互为替代**。
+- **极窄例外**（须团队显式采纳并承担审计缺口）：例如仓库体积极敏感时，仅保留 consolidated + 指向外部归档的链接——**不在**本默认 harness 中推荐；默认仍保留三份 `qc*.md`。
 
 ## Residual findings（R#）：权威在哪、和主 plan 谁先谁后？
 
@@ -34,8 +36,9 @@
 
 - **默认（推荐）**：同一 **`plan_id`** 下，**完整 QC 三审**（`qc1` + `qc2` + `qc3` 并行）**仅在 dev team 按该 plan 约定范围全部交付之后**执行**一次**，再进入 `@project-manager` 汇总与 `@qa-engineer` 验证。**不要**在每个中间 **batch** / 子里程碑都跑全套三审：否则 `reports/<plan-id>/` 会堆积多套并列报告，**`Review range` / `Diff basis` 与结论**易混淆，handoff 成本高。
 - **batch 之间**：依赖实现方 **`verification-before-completion`**、主 plan 任务勾选与 PM 协调；需要书面中间意见时，用对话、主 plan 批注或**非三审**的定向检查（如单审、架构 review），**不**默认等同「又一轮完整三审」。
-- **Request Changes 后复验**：若须再跑一轮完整三审，使用**新文件名**落盘，避免覆盖首轮报告，例如 `<plan-id>-qc1-rev2.md` … `<plan-id>-qc3-rev2.md`（或团队约定的 `wave2-` 前缀）；`@project-manager` 在 `QC Consolidated Decision` 中写明**当前以哪一波次为准**。
-- **显式例外**：仅当用户与 PM 书面同意**中间门禁**时，在 Assignment 写清 **`QC gate: incremental — <scope>`**（或等价），并仍须保证该次三审的 **`plan_id` + `Review range` / `Diff basis`** 三份一致；**优先**用子范围专用标签或子目录，避免与「整 plan 终局」那套 `-qc*.md` 混名。
+- **After `Request Changes` (default — targeted re-review)**：PM maps each **blocking** finding to the QC seat that raised it (`source` on R#, consolidated table, or the originating `qcN.md` / `F-###`). Dispatch **only** those reviewers (`QC re-review: targeted — reviewers: qc-specialist, qc-specialist-2, …`). Each re-reviewing QC **updates the same** `qc1.md` / `qc2.md` / `qc3.md` in place (add `## Revalidation`, refresh verdict / `generated_at`); **do not** add `qc1-rev2.md` siblings on this path. PM **updates the same** `qc-consolidated.md` in place. Git history is the audit trail.
+- **Full tri re-review (exception)**：Only when Assignment states **`QC re-review: full tri-review`**. Run **three** parallel reviews again; use **new basenames** (`qc1-rev2.md` … `qc3-rev2.md`, `qc-consolidated-rev2.md`) so wave-1 files stay immutable; PM states **active wave** in consolidated decision. See `mstar-review-qc` · `mstar-dispatch-gates`.
+- **显式例外**：仅当用户与 PM 书面同意**中间门禁**时，在 Assignment 写清 **`QC gate: incremental — <scope>`**（或等价），并仍须保证该次三审的 **`plan_id` + `Review range` / `Diff basis`** 三份一致；**优先**用子范围子目录，避免与终局 `qc1..3.md` 混名。
 - **同仓多 worktree 并行 dev**：**推荐**在排各 batch / 各轨 worktree 前确立 **plan 集成分支** 与各轨 topic 线及 **merge 靶**（见 `mstar-branch-worktree` **「推荐默认编排：先建 plan 集成分支，再挂各 worktree」**）。**多 `plan_id` 同属一条 `primary_spec`（Spec 文档）时**：该「集成分支」在计划语义上即 **Spec 集成分支**；各 Plan 的 topic 分支 **merge 回 Spec 集成分支**，**全部 Plans 完成后** 合入 `main`/`master` **须走 PR**，见 `mstar-plan-conventions` SKILL.md **「Spec 文档驱动的分支模型」**。终局（或增量）三审派单前，PM 仍须满足 **单一待审 `Working branch` / `HEAD`** 或已按上条 **拆 scope**；**不得**假设「整 plan 一次三审」可只靠某一个开发 worktree 路径覆盖未合并的其他并行轨。
 
 ### 多 `plan_id` 同时 `InReview`（PM 编排）

--- a/skills/mstar-review-qc/SKILL.md
+++ b/skills/mstar-review-qc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-review-qc
-description: Morning Star (启明星) QC 审查基线与 QA 验证契约 —— 三名 QC reviewer 的共享审查工作流、代码质量/安全正确性/性能可靠/可维护性清单、标准审查报告 Markdown 模板（YAML frontmatter + Findings 三档 + Source Trace + Summary + Verdict）、QC 三审分派时机（与 plan-batch 对齐）、高危变更（运维/数据/生产）最小检查、门禁规则（Approve / Request Changes / Needs Discussion）、CI 门禁补充、Residual Findings 留档门禁与关闭验证。`@qc-specialist` / `@qc-specialist-2` / `@qc-specialist-3` 开工审查前必读；`@qa-engineer` 对同 feature 做验证前必读；`@project-manager` 派发 QC 三审或 high-risk 变更审查前必读；所有涉及 QC 报告、Residual 登记或门禁判定的角色都应该优先 Read 本 skill。
+description: Morning Star QC/QA review baseline — tri-review workflow, checklists, report template (YAML frontmatter + Findings + Verdict), reports at `reports/<plan-id>/qc1.md` (no plan-id prefix in basename), targeted re-review after fixes, full-tri `qcN-rev2.md` exception, residual gate. Use when `@qc-specialist*` review, `@qa-engineer` verifies, or `@project-manager` dispatches/consolidates QC.
 ---
 
 ## Load order（必读顺序）
@@ -17,16 +17,16 @@ description: Morning Star (启明星) QC 审查基线与 QA 验证契约 —— 
 
 - **默认**：`@project-manager` 在 **该 plan 的实现范围已由 dev team 全部交付**、准备进入预合并门禁时，分派完整 QC 三审。**同一 `plan_id` 下多 batch 滚动实现时，不默认每 batch 跑一轮全套三审**（避免 `reports/<plan-id>/` 多套报告与范围串线）；中间阶段靠自检与 PM 协调，**显式增量三审**须在 Assignment 写明（见 `mstar-plan-conventions` `references/plan-files-and-reports.md`「QC 三审触发时机」）。
 - **同仓多 worktree 并行开发**：一轮 QC 三审仍只对应 **一套** `Review cwd` + `Working branch` + `Review range` / `Diff basis`（三票逐字相同）。若成果曾分布在 **未合并** 的多条分支或多个 `HEAD`，PM **须先**完成 Git 归并到 **单一**待审分支再派 QC；**不得**指望 reviewer 自行在多个开发 worktree 之间拼凑审查范围。**推荐** PM 在并行开发开始前已建立 **plan 集成分支** 作为各轨 merge 靶（见 `mstar-branch-worktree` 同节 **「推荐默认编排：先建 plan 集成分支，再挂各 worktree」**）。细则见 `mstar-branch-worktree` **「多 worktree 并行开发与 QC / QA 的门禁衔接」**。
-- **Request Changes 后**：再审为**新波次**，落盘用新文件名（如 `-rev2` / `wave2-`），PM 汇总时标明有效波次。
+- **After `Request Changes` (default)**：**Targeted re-review** — PM dispatches only QC seats that **raised** blocking findings for this fix round; each updates **the same** `{PLAN_DIR}/reports/<plan-id>/qcN.md` (e.g. `qc1.md` — no `<plan-id>` prefix in basename) (add `## Revalidation`, update verdict). **Do not** spawn `qcN-rev2.md` files on this path. Artifact naming and PM consolidated updates → **`mstar-plan-artifacts/references/plan-files-and-reports.md`** § QC 三审触发时机.
+- **Full tri re-review (exception)**：Assignment must say **`QC re-review: full tri-review`**; then new basenames (`qc1-rev2.md` … `qc-consolidated-rev2.md`); PM marks **active wave** in consolidated decision.
 
 ## 三审身份与模型独立性门禁（PM 强制）
 
-在 PM 发出 QC 三审后、进入汇总前，必须先完成以下校验：
+在 PM 发出 **initial** QC 三审后、进入汇总前，必须先完成以下校验（**targeted re-review** 仅校验 Assignment 列出的席位）：
 
-- 三个实际运行会话的角色 ID 必须分别为 `qc-specialist`、`qc-specialist-2`、`qc-specialist-3`。
-- 三个会话的运行模型应与 `opencode.json` 的对应角色配置一致。
-- 若出现“Assignment 写的是 #2/#3，但实际拉起仍为 `qc-specialist`”或模型映射不符，判定为 `dispatch invalid`，不得进入 consolidated 结论，必须重派。
-- 若宿主故障导致三审退化为同模型且无法即时修复，需在 Status Update 明确标记 `degraded tri-review` 并请求用户确认是否继续（默认不放行）。
+- **Initial wave**：三个会话角色 ID 须分别为 `qc-specialist`、`qc-specialist-2`、`qc-specialist-3`；运行模型与 `opencode.json` 对应配置一致。
+- **Targeted re-review**：仅校验 Assignment 列出的席位；缺席或角色/模型映射错误 → `dispatch invalid`，重派。
+- 若宿主故障导致并行 QC 退化为同模型且无法即时修复，Status Update 标记 `degraded tri-review` 并请用户确认（默认不放行）。
 
 ## 共享基线（所有审查员）
 
@@ -82,7 +82,7 @@ description: Morning Star (启明星) QC 审查基线与 QA 验证契约 —— 
 
 ## 标准输出模板
 
-落盘到 **`{PLAN_DIR}/reports/<plan-id>/<plan-id>-qc#.md`** 时：文件**最上方**须为 YAML frontmatter（`report_kind`、`reviewer`、`reviewer_index`、`plan_id`、`verdict`、`generated_at` 等，见 `agents/qc-specialist*.md`），**紧接着**再写下列 Markdown 正文（可将 **Reviewer Metadata** 与 frontmatter 对齐，避免矛盾）。**Findings 下三节标题**（Critical / Warning / Suggestion）为**人类可读分类**；PM 将条目写入根级 **`residual_findings`**（见 `mstar-plan-artifacts` **SKILL.md** 开篇）时的 **`severity` 机器字段**以 `mstar-plan-artifacts/references/status-and-residuals.md` **「Residual findings：severity（SSOT，机器字段）」** 为准。
+落盘到 **`{PLAN_DIR}/reports/<plan-id>/qc#.md`**（`qc1.md` … `qc3.md`；目录已含 `plan_id`，文件名勿再加前缀）时：文件**最上方**须为 YAML frontmatter（`report_kind`、`reviewer`、`reviewer_index`、`plan_id`、`verdict`、`generated_at` 等，见 `agents/qc-specialist*.md`），**紧接着**再写下列 Markdown 正文（可将 **Reviewer Metadata** 与 frontmatter 对齐，避免矛盾）。**Findings 下三节标题**（Critical / Warning / Suggestion）为**人类可读分类**；PM 将条目写入根级 **`residual_findings`**（见 `mstar-plan-artifacts` **SKILL.md** 开篇）时的 **`severity` 机器字段**以 `mstar-plan-artifacts/references/status-and-residuals.md` **「Residual findings：severity（SSOT，机器字段）」** 为准。
 
 ```markdown
 # Code Review Report
@@ -156,7 +156,7 @@ description: Morning Star (启明星) QC 审查基线与 QA 验证契约 —— 
 ## Residual Findings 留档门禁
 
 - 当阻断项（`Critical`）修复后仍有未关闭 **Warning / Suggestion** 类问题或技术债，不得仅在对话中口头说明，必须留档；登记 **`severity`** 时遵守 `mstar-plan-artifacts` `references/status-and-residuals.md` **「Residual findings：severity（SSOT，机器字段）」**。
-- **启用 plan 管理且存在 `plan-id` 时**：**待跟踪（open）** residual 的 **SSOT** 为 **`{HARNESS_DIR}/status.json`** 根级 **`residual_findings[<plan-id>]`**（与 `plans` 平级；canonical 见 `mstar-plan-artifacts` **SKILL.md** 开篇）；PM 在 consolidated 决策中分配 **稳定 `id`（R1…）** 后须**写入该数组**（`source` 指回 `-qc*.md` 等）。**已关闭**条目归档至 **`{HARNESS_DIR}/archived/residuals/<plan-id>.json`**（字段与严重等级见 `mstar-plan-conventions`），与 **`{PLAN_DIR}/reports/<plan-id>/`** 交叉引用。
+- **启用 plan 管理且存在 `plan-id` 时**：**待跟踪（open）** residual 的 **SSOT** 为 **`{HARNESS_DIR}/status.json`** 根级 **`residual_findings[<plan-id>]`**（与 `plans` 平级；canonical 见 `mstar-plan-artifacts` **SKILL.md** 开篇）；PM 在 consolidated 决策中分配 **稳定 `id`（R1…）** 后须**写入该数组**（`source` 指回 `qc1.md` 等）。**已关闭**条目归档至 **`{HARNESS_DIR}/archived/residuals/<plan-id>.json`**（字段与严重等级见 `mstar-plan-conventions`），与 **`{PLAN_DIR}/reports/<plan-id>/`** 交叉引用。
 - **主 plan**：仅作**人类可读索引**（可选）——复述 `id` 与摘要并指向 **`{HARNESS_DIR}/status.json`**；**不得**作为与 SSOT 脱钩的唯一登记处（见 `mstar-plan-conventions` `references/plan-files-and-reports.md`「Residual findings：权威在哪」）。
 - 可选：`@project-manager` 维护 **`metadata.tech_debt_summary`** 作为跨 plan 聚合视图（与 `residual_findings` 互补，见 `mstar-plan-conventions`）。
 - 若无 `{PLAN_DIR}`：写入项目认可的进度载体或根级 `notes`（结构化条目），仍须含 `id` 与跟踪字段。

--- a/skills/mstar-roles/SKILL.md
+++ b/skills/mstar-roles/SKILL.md
@@ -79,9 +79,11 @@ Role `references/*.md` files include explicit **`NEVER`** sections (anti-recursi
 
 | role_id | reviewer_index | focus | report_suffix |
 | --- | --- | --- | --- |
-| `qc-specialist` | `1` | Architecture coherence and maintainability risk | `qc1` |
-| `qc-specialist-2` | `2` | Security and correctness risk | `qc2` |
-| `qc-specialist-3` | `3` | Performance and reliability risk | `qc3` |
+| `qc-specialist` | `1` | Architecture coherence and maintainability risk | `qc1` → `{PLAN_DIR}/reports/<plan-id>/qc1.md` |
+| `qc-specialist-2` | `2` | Security and correctness risk | `qc2` → `…/qc2.md` |
+| `qc-specialist-3` | `3` | Performance and reliability risk | `qc3` → `…/qc3.md` |
+
+PM consolidated: `…/qc-consolidated.md` (same folder; no `<plan-id>` basename prefix). Naming SSOT: `mstar-plan-artifacts/references/plan-files-and-reports.md`.
 
 ## Maintenance Rules
 

--- a/skills/mstar-roles/references/project-manager.md
+++ b/skills/mstar-roles/references/project-manager.md
@@ -238,7 +238,7 @@ PM must:
 
 - Dispatch QC with aligned scope fields
 - Consolidate to one gate verdict
-- Assign fixes and run revalidation loop
+- Assign fixes; default **targeted QC re-review** (same `qcN.md` under `reports/<plan-id>/`); full tri only when Assignment says `QC re-review: full tri-review`
 - Record non-blocking leftovers as residual findings
 - Keep open vs archived residual state coherent at closure
 - Sync plan/status in the same coordination round

--- a/skills/mstar-roles/references/project-manager/qc-and-residuals.md
+++ b/skills/mstar-roles/references/project-manager/qc-and-residuals.md
@@ -14,7 +14,11 @@ Use this reference when PM is dispatching QC, consolidating review verdicts, or 
 3. Verify runtime identity/model mapping for three distinct QC roles.
 4. De-duplicate findings and resolve conflicts by evidence strength.
 5. Emit one consolidated gate decision.
-6. Assign fix owners when needed; send back to dev -> QC/QA revalidation.
+6. After dev fixes blocking items:
+   - **Default**: **Targeted QC re-review** — dispatch only QC seats that **raised** blocking findings (consolidated table, R# `source` e.g. `QC-#2` → `qc-specialist-2`, or originating `qcN.md` / `F-###`). Assignment: `QC re-review: targeted — reviewers: <role-ids>`. Same `plan_id` + `Review range` / `Diff basis` unless PM narrows to fix commits (must still be copy-pasteable for QA).
+   - Each targeted QC **edits the same** `qc1.md` / `qc2.md` / `qc3.md` (per seat); PM **edits the same** `qc-consolidated.md`. **Do not** re-dispatch all three by default.
+   - **Exception**: `QC re-review: full tri-review` → three parallel QC again + new `qc1-rev2.md` … files (see `mstar-plan-artifacts/references/plan-files-and-reports.md`).
+   - Then **QA** when the gate requires sign-off (same checkout fields as initial review).
 
 ## QC / Residual NEVER (PM)
 
@@ -22,7 +26,9 @@ Use this reference when PM is dispatching QC, consolidating review verdicts, or 
 - **NEVER** register or rewrite residual `severity` values outside the machine enum in `mstar-plan-artifacts`.
 - **NEVER** drop residual tracking to chat-only when `Approve with residuals` applies—canonical open list lives under `{HARNESS_DIR}/status.json` `residual_findings[<plan-id>]`.
 - **NEVER** archive or delete open residual rows from `status.json` without the documented close + `{HARNESS_DIR}/archived/residuals/` workflow.
-- **NEVER** treat “two of three QC reports arrived” as sufficient for a parallel tri-review wave—missing reviewer => `Blocked` or explicit PM decision, not silent `Approve`.
+- **NEVER** treat “two of three QC reports arrived” as sufficient for a **full parallel tri-review wave**—missing reviewer => `Blocked` or explicit PM decision, not silent `Approve`.
+- **NEVER** re-dispatch all three QC reviewers after a routine fix round when only one or two seats had blocking findings—use **targeted re-review** unless Assignment declares **`QC re-review: full tri-review`**.
+- **NEVER** create `qc1-rev2.md` (etc.) for **targeted** re-review; update the original `qcN.md` in place.
 
 ## Consolidated Decision Template
 

--- a/skills/mstar-roles/references/qc-specialist-shared.md
+++ b/skills/mstar-roles/references/qc-specialist-shared.md
@@ -37,7 +37,7 @@ Your output is a structured QC report plus completion report.
 
 If any item below matches, **stop** and return `Blocked` to `project-manager` instead of improvising:
 
-- **NEVER** invoke another QC seat (`qc-specialist` / `qc-specialist-2` / `qc-specialist-3`) or `{role_id}` again, nor `qa-engineer` / dev / `architect` / `project-manager`, to “split” **this** review unless `Delegation: allowed (...)` lists them. PM launches tri-review with **three** separate assignments/invokes.
+- **NEVER** invoke another QC seat (`qc-specialist` / `qc-specialist-2` / `qc-specialist-3`) or `{role_id}` again, nor `qa-engineer` / dev / `architect` / `project-manager`, to “split” **this** review unless `Delegation: allowed (...)` lists them. PM launches **initial** tri-review with **three** separate assignments/invokes; **targeted re-review** lists only the seats PM assigned.
 - **NEVER** ask the user for permission to submit a report, present “notify PM?” choosers, or stall after a completed review—when requirements are met, emit **Completion Report v2** in the **same** assistant turn (with a real **Git** line when commits are required).
 - **NEVER** modify business implementation/tests, `{HARNESS_DIR}/status.json` residual lifecycle fields, `{HARNESS_DIR}/archived/`, or any path outside the host write whitelist for QC (typically `{PLAN_DIR}/reports/**/*.md` only).
 - **NEVER** `git add .` or stage unrelated paths when committing QC reports—stage **only** the report files you changed.
@@ -81,6 +81,21 @@ Use severity and formatting standards from `mstar-review-qc`; machine `severity`
 - **NEVER** emit `Approve` while any unresolved `Critical` finding remains (per `mstar-review-qc`).
 - **NEVER** emit `Approve` while unresolved `Warning` findings remain when the review template marks them mandatory to resolve before approval.
 - **NEVER** skip required static checks, security scans, or diff review steps called out in the assignment and then claim `Approve`.
+
+## Report path (required)
+
+Write under **`{PLAN_DIR}/reports/<plan-id>/`** using basename **`{report_suffix}.md`** (e.g. `qc1.md`, `qc2.md`, `qc3.md`). **Do not** prefix the filename with `<plan-id>` — the folder already scopes the plan. PM consolidated report: **`qc-consolidated.md`** in the same directory.
+
+## Targeted re-review (same report file)
+
+When Assignment includes **`QC re-review: targeted`** (or lists you among targeted reviewers after a fix round):
+
+- **Edit the same** `{PLAN_DIR}/reports/<plan-id>/{report_suffix}.md` — do **not** create `qc1-rev2.md` siblings on this path.
+- Add **`## Revalidation`**: what was re-checked, evidence (diff/tests), per-finding disposition (resolved / still open).
+- Update frontmatter **`verdict`** and **`generated_at`**; keep **`reviewer_index`** unchanged.
+- Commit **only** that report path; Completion Report cites the same artifact path as wave 1.
+
+Full tri re-review (`QC re-review: full tri-review`) uses **new** filenames per `mstar-plan-artifacts/references/plan-files-and-reports.md`.
 
 ## QC Report Frontmatter (Required)
 

--- a/skills/mstar-superpowers-align/references/per-role-matrix.md
+++ b/skills/mstar-superpowers-align/references/per-role-matrix.md
@@ -22,7 +22,7 @@
 - 当任务进入 **gate / sign-off / merge decision**，若未出现 `verification-before-completion` 或等价证据要求，视为门禁不完整。
 - 当任务声明 **并行分派**，`Superpowers` 中应显式包含 `dispatching-parallel-agents`（或同义触发短语），并为每个可写承接方写清 `Working branch`。
 - 当 **并行分派** 且 **≥2 个可写承接方** 针对 **同一 Git 仓库** 可能并发落盘时，`Superpowers` 中还 **必须** 显式包含 **`using-git-worktrees`**（或同义触发短语），并在 Assignment 中写清各流 **检出路径约定**（或要求 Completion Report 回报实际 worktree 路径）；**禁止**依赖「多 subagent 共享同一工作目录」完成并发写入。
-- **QC 三审**：三份 Assignment 除 `Review cwd`、`Working branch` 外，**必须**含 **相同**的 **`plan_id`** 与 **`Review range` / `Diff basis`**（可复制粘贴）；**@qa-engineer** 同 feature 验证时 **照抄**同一组字符串。缺任一项视为 PM 分派不完整（`mstar-branch-worktree`）。**同仓、同一 plan、多 worktree 并行**：PM **推荐**先建 **plan 集成分支** 再挂各轨 worktree，QC 前再归并到单一 `HEAD`（见同 reference **「推荐默认编排：先建 plan 集成分支，再挂各 worktree」**）。**同一 plan 多 batch**：**默认仅在整 plan dev 完成后**派一轮完整三审；复验波次用新文件名；增量例外须 Assignment 写明（`mstar-plan-conventions`）。
+- **QC 三审**：三份 Assignment 除 `Review cwd`、`Working branch` 外，**必须**含 **相同**的 **`plan_id`** 与 **`Review range` / `Diff basis`**（可复制粘贴）；**@qa-engineer** 同 feature 验证时 **照抄**同一组字符串。缺任一项视为 PM 分派不完整（`mstar-branch-worktree`）。**同仓、同一 plan、多 worktree 并行**：PM **推荐**先建 **plan 集成分支** 再挂各轨 worktree，QC 前再归并到单一 `HEAD`。**同一 plan 多 batch**：**默认仅在整 plan dev 完成后**派一轮完整三审。**Fix 后**：默认 **targeted re-review**（只派提出 blocking 的 QC 席，原位改 `qcN.md`）；**仅** `QC re-review: full tri-review` 时复跑三审且 `qcN-rev2.md` — 见 `mstar-plan-artifacts/references/plan-files-and-reports.md`。
 
 ## @product-manager
 


### PR DESCRIPTION
## Summary

- **Fix-round QC (default)**: After dev resolves blocking findings, PM dispatches only the QC seat(s) that raised each item (`QC re-review: targeted`). Reviewers update the same `qc1.md` / `qc2.md` / `qc3.md` in place (`## Revalidation`); PM updates the same `qc-consolidated.md`. Full tri re-review requires explicit `QC re-review: full tri-review` and new `qcN-rev2.md` files.
- **Report naming**: QC reports live under `{PLAN_DIR}/reports/<plan-id>/` as `qc1.md`, `qc2.md`, `qc3.md`, and `qc-consolidated.md` (no `<plan-id>` prefix in basenames; `plan_id` in frontmatter and directory).
- **Dispatch**: Initial tri-review remains N=3 in one message; targeted re-review allows N=1–3 per Assignment.
- **Release**: Bump harness surfaces to **0.6.8** (`CHANGELOG.md`, `CHANGELOG_CN.md`, OpenCode/Cursor/Codex manifests). CLI stays **0.5.0**.

SSOT: `skills/mstar-plan-artifacts/references/plan-files-and-reports.md`.

## Commits

1. `docs(skills): targeted QC re-review and short report filenames` — 12 skill/host files
2. `chore(release): bump harness surfaces to 0.6.8` — version + changelogs

## Test plan

- [ ] Read `plan-files-and-reports.md` QC sections; confirm no conflicting `-rev2` default for targeted path
- [ ] PM Assignment examples use `QC re-review: targeted — reviewers: …` and report paths `reports/<plan-id>/qcN.md`
- [ ] `mstar-dispatch-gates` / `parallel-dispatch.md` aligned on N=1–3 vs N=3
- [ ] Version table in `CHANGELOG.md` / `CHANGELOG_CN.md` shows **0.6.8** on root, OpenCode, Cursor, Codex
- [ ] `packages/opencode` bundle includes updated skills after publish/install smoke check (optional)


Made with [Cursor](https://cursor.com)