### PR TITLE
feat(commands): add /iteration-start command for Cursor and OpenCode

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,27 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **0.6.14** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **0.6.15** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **0.6.14** |
+| Monorepo root | `morning-star` (`package.json`) | **0.6.15** |
 | CLI | `@mstar-harness/cli` (`packages/cli`) | **0.5.1** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.6.14** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **0.6.14** |
-| Codex plugin | `.codex-plugin/plugin.json` | **0.6.14** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.6.15** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **0.6.15** |
+| Codex plugin | `.codex-plugin/plugin.json` | **0.6.15** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [0.6.15] - 2026-06-24
+
+### Harness (commands)
+
+- **New `iteration-start` command**: Add a reusable command (`/iteration-start`) to bootstrap a new harness iteration. The command guides PM through six checkpointed steps: research (structured harness dirs + unstructured glob for `roadmap*.md`, `deferred*.md`, `features*.md` etc.), explore candidate directions for product completeness, lock direction with `grill-me`, write iteration compass and plans, run the review chain (`@product-manager` → `@architect` → `@writing-specialist` → PM lock), and create the iteration integration branch from `main`. Registered for both Cursor (`commands/` auto-discovery) and OpenCode (`harness-commands/` bundled via plugin code).
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, and Cursor / Codex plugin manifests: **0.6.14 → 0.6.15**. **`@mstar-harness/cli` remains 0.5.1**.
 
 ## [0.6.14] - 2026-06-24
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,26 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.6.14**（CLI 包除外，见下表）。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.6.15**（CLI 包除外，见下表）。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **0.6.14** |
+| monorepo 根 | `morning-star`（`package.json`） | **0.6.15** |
 | CLI | `@mstar-harness/cli`（`packages/cli`） | **0.5.1** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.6.14** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.6.14** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **0.6.14** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.6.15** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.6.15** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **0.6.15** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [0.6.15] - 2026-06-24
+
+### Harness（commands）
+
+- **新增 `iteration-start` 命令**：添加可复用的命令（`/iteration-start`）用于启动新一轮 harness 迭代。命令引导 PM 完成六个检查站步骤：调研（结构化 harness 目录 + 非结构化 glob 搜索 `roadmap*.md`、`deferred*.md`、`features*.md` 等）、探索产品完备性候选方向、使用 `grill-me` 锁定方向、编写迭代 compass 与 plans、运行审查链（`@product-manager` → `@architect` → `@writing-specialist` → PM 锁定）、从 `main` 创建迭代集成分支。同时注册到 Cursor（`commands/` 自动发现）和 OpenCode（通过插件代码捆绑 `harness-commands/`）。
+
+### 版本对齐
+
+- monorepo 根、`@mstar-harness/opencode`、Cursor / Codex 插件 manifest：**0.6.14 → 0.6.15**。**`@mstar-harness/cli` 保持 0.5.1**。
 
 ## [0.6.14] - 2026-06-24
 

--- a/commands/iteration-start.md
+++ b/commands/iteration-start.md
@@ -1,0 +1,65 @@
+---
+name: iteration-start
+description: Start a new harness iteration — research backlog, lock direction with grill-me, produce compass/plans, run review chain (product-manager → architect → writing-specialist → PM lock), submit to integration branch
+agent: project-manager
+---
+
+# Start Iteration
+
+Start a new Morning Star harness iteration. Follow Prepare gates from `mstar-phase-gates` (specify → clarify → plan).
+
+## 1. Research
+
+Load harness entry, then survey structured and unstructured sources:
+
+**Structured harness dirs:**
+- `{HARNESS_DIR}/status.json` → active plans, deferred features, residuals
+- `{ITERATION_DIR}/` → previous iteration compasses, roadmap batches
+- `{KNOWLEDGE_DIR}/` → design knowledge, architecture notes
+- `{SPECS_DIR}/` → existing specs, gaps
+
+**Unstructured discovery — search the repo for planning artifacts by name:**
+- Glob for `**/roadmap*.md`, `**/ROADMAP*.md`, `**/*-roadmap.md`
+- Glob for `**/deferred*.md`, `**/DEFERRED*.md`
+- Glob for `**/features*.md`, `**/FEATURES*.md`
+- Also search for `**/backlog*.md`, `**/TODO*.md`, `**/todo*.md`, `**/*.plan.md`
+- Open and read any matches that carry iteration-level or deferred-scope information
+
+Identify deferred or incomplete items from prior iterations as priority candidates for this iteration.
+
+## 2. Explore Directions
+
+Explore candidate directions targeting **product completeness**:
+
+- Default to completing deferred items from previous iterations
+- Allow substantive refactoring where it accelerates product maturity
+- Scope 2–4 candidates, each with clear product-completeness goals and trade-offs
+
+## 3. Lock Direction — grill-me
+
+Run the **grill-me skill** to stress-test candidate directions with the user:
+
+- Walk through trade-offs for each candidate
+- Converge on a **single iteration direction** with shared understanding
+- Document: locked direction, success criteria, non-goals
+
+## 4. Write Compass & Plans
+
+Produce harness artifacts:
+
+- `{ITERATION_DIR}/<iteration-id>-compass.md` — iteration vision, scope, roadmap batches, deferred items
+- `{PLAN_DIR}/<plan-id>-<name>.md` for each plan in this iteration
+- Register all plans in `{HARNESS_DIR}/status.json`
+
+## 5. Review Chain
+
+1. **@product-manager** — review compass; adjust scope and user-facing details; write or update specs in `{SPECS_DIR}/`
+2. **@architect** — review compass and specs; adjust technical architecture, interface contracts, and module boundaries
+3. **@writing-specialist** — full review of all documents for clarity, consistency, and completeness
+4. **PM** — final review; lock all documents; confirm Prepare phase gates pass
+
+## 6. Integration Branch
+
+- Create `iteration/<iteration-id>` from `main`
+- Register `spec_integration_branch` in `{HARNESS_DIR}/status.json`
+- Commit all documents to the integration branch and push to remote

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 0.6.15
+
+- Bundled commands: New `harness-commands/` directory bundle and `loadBundledCommands()` registration in the config hook. Adds `/iteration-start` command that guides PM through iteration bootstrap (research, explore, lock, compass/plans, review chain, integration branch).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **0.6.15**.
+
 ## 0.6.11
 
 - Bundled agents: Cursor-first frontmatter on all role shells so hosts that share `agents/*.md` parse `name`/`description`/`model` before OpenCode fields.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {
@@ -14,6 +14,7 @@
     "dist",
     "harness-skills",
     "harness-agents",
+    "harness-commands",
     "AGENTS.md",
     "INSTALL.md"
   ],

--- a/packages/opencode/scripts/bundle-harness-assets.ts
+++ b/packages/opencode/scripts/bundle-harness-assets.ts
@@ -1,5 +1,5 @@
 /**
- * Copies repo-root `skills/` and `agents/` into this package for npm publish.
+ * Copies repo-root `skills/`, `agents/`, and `commands/` into this package for npm publish.
  * Run from `packages/opencode` via the `build` script (monorepo checkout required).
  */
 import fs from "node:fs";
@@ -11,8 +11,10 @@ const packageRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(packageRoot, "..", "..");
 const sourceSkills = path.join(repoRoot, "skills");
 const sourceAgents = path.join(repoRoot, "agents");
+const sourceCommands = path.join(repoRoot, "commands");
 const destSkills = path.join(packageRoot, "harness-skills");
 const destAgents = path.join(packageRoot, "harness-agents");
+const destCommands = path.join(packageRoot, "harness-commands");
 
 function copyTree(label: string, from: string, to: string) {
   if (!fs.existsSync(from)) {
@@ -25,4 +27,5 @@ function copyTree(label: string, from: string, to: string) {
 
 copyTree("skills", sourceSkills, destSkills);
 copyTree("agents", sourceAgents, destAgents);
-console.log(`bundle-harness-assets: synced skills -> ${destSkills}, agents -> ${destAgents}`);
+copyTree("commands", sourceCommands, destCommands);
+console.log(`bundle-harness-assets: synced skills -> ${destSkills}, agents -> ${destAgents}, commands -> ${destCommands}`);

--- a/packages/opencode/src/mstar.ts
+++ b/packages/opencode/src/mstar.ts
@@ -4,6 +4,7 @@
  * - Injects one-time harness bootstrap into first user message.
  * - Registers skill paths only inside this package: `harness-skills/` (synced at build / repo postinstall; includes `mstar-host`).
  * - Loads agents from `harness-agents/` only (same sync). Does not use `process.cwd()` so OpenCode project cwd does not matter.
+ * - Loads custom commands from `harness-commands/` only (same sync).
  */
 import type { Plugin } from "@opencode-ai/plugin";
 import fs from "node:fs";
@@ -26,6 +27,7 @@ const packageRoot = path.resolve(__dirname, "..");
 
 const bundledSkillsDir = path.join(packageRoot, "harness-skills");
 const bundledAgentsDir = path.join(packageRoot, "harness-agents");
+const bundledCommandsDir = path.join(packageRoot, "harness-commands");
 const bootstrapAgentsPath = path.join(packageRoot, "AGENTS.md");
 const BOOTSTRAP_MARKER = "IMPORTANT_FOR_HARNESS";
 
@@ -148,6 +150,41 @@ const loadAgentsFromDir = (agentsDirPath: string): Record<string, JsonObject> =>
 
 const loadBundledAgents = (): Record<string, JsonObject> => loadAgentsFromDir(bundledAgentsDir);
 
+const loadBundledCommands = (): Record<string, JsonObject> => {
+  if (!fs.existsSync(bundledCommandsDir)) return {};
+
+  const files = fs
+    .readdirSync(bundledCommandsDir)
+    .filter((name: string) => /\.(?:md|mdc|markdown|txt)$/.test(name))
+    .sort((a, b) => a.localeCompare(b));
+
+  const result: Record<string, JsonObject> = {};
+  for (const file of files) {
+    const filePath = path.join(bundledCommandsDir, file);
+    const content = fs.readFileSync(filePath, "utf8");
+    const { frontmatter, body } = extractFrontmatterAndBody(content);
+    const parsed = parseSimpleFrontmatter(frontmatter);
+    const parsedName = typeof parsed.name === "string" ? parsed.name : file.replace(/\.(?:md|mdc|markdown|txt)$/, "");
+
+    const commandDef: JsonObject = {
+      template: body.trim(),
+    };
+    if (typeof parsed.description === "string") {
+      commandDef.description = parsed.description;
+    }
+    if (typeof parsed.agent === "string") {
+      commandDef.agent = parsed.agent;
+    }
+    if (typeof parsed.model === "string") {
+      commandDef.model = parsed.model;
+    }
+
+    result[parsedName] = commandDef;
+  }
+
+  return result;
+};
+
 export const MorningStarHarnessPlugin: Plugin = async () => {
   const homeDir = os.homedir();
   const envConfigDir = normalizePath(process.env.OPENCODE_CONFIG_DIR, homeDir);
@@ -161,6 +198,7 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
       const runtimeConfig = config as JsonObject & {
         skills?: { paths?: string[] };
         agent?: Record<string, JsonObject>;
+        command?: Record<string, JsonObject>;
       };
       runtimeConfig.skills = runtimeConfig.skills || {};
       runtimeConfig.skills.paths = runtimeConfig.skills.paths || [];
@@ -175,6 +213,15 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
       for (const [agentId, definition] of Object.entries(markdownAgents)) {
         runtimeConfig.agent[agentId] = {
           ...(runtimeConfig.agent[agentId] || {}),
+          ...definition,
+        };
+      }
+
+      const markdownCommands = loadBundledCommands();
+      runtimeConfig.command = runtimeConfig.command || {};
+      for (const [commandId, definition] of Object.entries(markdownCommands)) {
+        runtimeConfig.command[commandId] = {
+          ...(runtimeConfig.command[commandId] || {}),
           ...definition,
         };
       }


### PR DESCRIPTION
## Summary

- Add reusable `/iteration-start` command for bootstrapping a new harness iteration
- 6-step guided flow: Research → Explore directions → Lock direction (grill-me) → Write compass/plans → Review chain → Integration branch
- Dual-host registration: Cursor auto-discovers `commands/`, OpenCode bundles `harness-commands/` via plugin config hook

## Changes

| File | Change |
|------|--------|
| `commands/iteration-start.md` | New command with frontmatter (`agent: project-manager`) |
| `packages/opencode/src/mstar.ts` | `loadBundledCommands()` + config registration |
| `packages/opencode/scripts/bundle-harness-assets.ts` | Bundle `commands/` → `harness-commands/` |
| `packages/opencode/package.json` | Add `harness-commands` to `files` |
| `CHANGELOG.md`, `CHANGELOG_CN.md` | 0.6.15 entry |
| `packages/opencode/CHANGELOG.md` | 0.6.15 entry |
| `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`, `package.json`, `packages/opencode/package.json` | Bump 0.6.14 → 0.6.15 |


Made with [Cursor](https://cursor.com)