### PR TITLE
feat(commands): change /iteration-start to Review & Edit Chain

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,27 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **0.6.19** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **0.6.20** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **0.6.19** |
+| Monorepo root | `morning-star` (`package.json`) | **0.6.20** |
 | CLI | `@mstar-harness/cli` (`packages/cli`) | **0.5.2** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.6.19** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **0.6.19** |
-| Codex plugin | `.codex-plugin/plugin.json` | **0.6.19** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.6.20** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **0.6.20** |
+| Codex plugin | `.codex-plugin/plugin.json` | **0.6.20** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [0.6.20] - 2026-06-26
+
+### Harness (commands)
+
+- **`/iteration-start` Review & Edit Chain**: Changed §5 from "Review Chain" to "Review & Edit Chain". Each role (product-manager, architect, writing-specialist) now reviews AND directly edits the documents rather than only flagging issues. PM only steps in for the final review and lock, no longer burdened with aggregating edits from other reviewers.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, and Cursor / Codex plugin manifests: **0.6.19 → 0.6.20**. **`@mstar-harness/cli` remains 0.5.2**.
 
 ## [0.6.19] - 2026-06-26
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,26 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.6.19**（CLI 包除外，见下表）。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.6.20**（CLI 包除外，见下表）。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **0.6.19** |
+| monorepo 根 | `morning-star`（`package.json`） | **0.6.20** |
 | CLI | `@mstar-harness/cli`（`packages/cli`） | **0.5.2** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.6.19** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.6.19** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **0.6.19** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.6.20** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.6.20** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **0.6.20** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [0.6.20] - 2026-06-26
+
+### Harness（commands）
+
+- **`/iteration-start` Review & Edit 链**：§5 从"Review Chain"改为"Review & Edit Chain"。product-manager、architect、writing-specialist 三个角色现在 review 后直接编辑文档，而非仅标记问题。PM 只做最终 review 和 lock，不再承担汇总其他 reviewer 修订的工作。
+
+### 版本对齐
+
+- monorepo 根、`@mstar-harness/opencode`、Cursor / Codex 插件 manifest：**0.6.19 → 0.6.20**。**`@mstar-harness/cli` 保持 0.5.2**。
 
 ## [0.6.19] - 2026-06-26
 

--- a/commands/iteration-start.md
+++ b/commands/iteration-start.md
@@ -1,6 +1,6 @@
 ---
 name: iteration-start
-description: Start a new harness iteration — research backlog, lock direction with grill-me, produce compass/plans, run review chain (product-manager → architect → writing-specialist → PM lock), submit to integration branch
+description: Start a new harness iteration — research backlog, lock direction with grill-me, produce compass/plans, run edit chain (product-manager → architect → writing-specialist each review-and-edit, then PM final review and lock), submit to integration branch
 agent: project-manager
 ---
 
@@ -59,11 +59,13 @@ Produce harness artifacts:
 - `{PLAN_DIR}/<plan-id>-<name>.md` for each plan in this iteration
 - Register all plans in `{HARNESS_DIR}/status.json`
 
-## 5. Review Chain
+## 5. Review & Edit Chain
 
-1. **@product-manager** — review compass; adjust scope and user-facing details; write or update specs in `{SPECS_DIR}/`
-2. **@architect** — review compass and specs; adjust technical architecture, interface contracts, and module boundaries
-3. **@writing-specialist** — full review of all documents for clarity, consistency, and completeness
+Each role below **reviews and directly edits** the documents. Do not just flag issues — apply the fixes yourself. PM only steps in for the final lock.
+
+1. **@product-manager** — review and edit the compass; adjust scope, priorities, and user-facing details; write or update specs in `{SPECS_DIR}/`
+2. **@architect** — review and edit the compass and specs; adjust technical architecture, interface contracts, module boundaries, and trade-off reasoning
+3. **@writing-specialist** — review and edit all documents for clarity, consistency, completeness, and bilingual parity; tighten prose, unify terminology, and remove ambiguity
 4. **PM** — final review; lock all documents; confirm Prepare phase gates pass
 
 ## 6. Integration Branch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 0.6.20
+
+- Bundled commands: `/iteration-start` §5 changed to "Review & Edit Chain" — each reviewer now directly edits documents rather than only flagging issues. PM only does the final lock.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **0.6.20**.
+
 ## 0.6.19
 
 - Bundled skills: `mstar-coding-behavior` strengthened with distilled Ponytail principles — YAGNI gate, The Ladder (7-level decision hierarchy), "deletion over addition / boring over clever", `simplify:` marker discipline, "bug fix = root cause", and "minimal check for non-trivial logic".

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Change `/iteration-start` §5 from "Review Chain" (review-only, PM does all editing) to **"Review & Edit Chain"** — each role reviews and directly edits the documents. PM only does the final lock.

## Changes

| File | Change |
|------|--------|
| `commands/iteration-start.md` | Rename §5 to "Review & Edit Chain"; each role (product-manager, architect, writing-specialist) now reviews **and edits** directly; PM only final review + lock |
| `CHANGELOG.md`, `CHANGELOG_CN.md` | 0.6.20 entry |
| `packages/opencode/CHANGELOG.md` | 0.6.20 entry |
| `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`, `package.json`, `packages/opencode/package.json` | Bump 0.6.19 → 0.6.20 |


Made with [Cursor](https://cursor.com)