### PR TITLE
fix(cli): Cursor plugin real git checkout (v0.7.2)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/README.md
+++ b/.cursor-plugin/README.md
@@ -20,9 +20,9 @@ Recommended:
 
 Manual install:
 
-1. `git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness`
+1. `git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness` (optional; used by Codex)
 2. `mkdir -p ~/.cursor/plugins/local`
-3. `ln -s ~/.mstar/harness ~/.cursor/plugins/local/morning-star-harness`
+3. `git clone https://github.com/btspoony/mstar-harness.git ~/.cursor/plugins/local/morning-star-harness` (**real directory** — do not symlink)
 4. Restart Cursor or run `Developer: Reload Window`.
 
 After agent file changes, reload Cursor before smoke-testing Task `subagent_type` names.

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor/LOCAL-VALIDATION.md
+++ b/.cursor/LOCAL-VALIDATION.md
@@ -36,3 +36,4 @@ Use before publishing or sharing the Morning Star Cursor plugin from this repo.
 - Do not use absolute paths in `plugin.json`.
 - Do not reference files outside this repository root.
 - Ensure all referenced directories exist in the current branch.
+- Cursor **cannot load symlinked plugin roots** — local/global install must be a real directory (see `docs/cli.md` § Install path layout).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,29 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **0.7.1** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **0.7.2** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **0.7.1** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **0.5.3** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.7.1** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **0.7.1** |
-| Codex plugin | `.codex-plugin/plugin.json` | **0.7.1** |
+| Monorepo root | `morning-star` (`package.json`) | **0.7.2** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **0.5.4** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.7.2** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **0.7.2** |
+| Codex plugin | `.codex-plugin/plugin.json` | **0.7.2** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [0.7.2] - 2026-06-30
+
+### CLI / Cursor install
+
+- **Cursor plugin path layout**: `mstar-harness init --target cursor` now installs a **real git checkout** at the Cursor plugin path (`git clone` / `git pull`), not a symlink to `~/.mstar/harness`. Cursor does not discover symlinked plugin directories.
+- **`doctor --target cursor`**: fails if the plugin path is a symlink; `init` removes an existing symlink and clones.
+- **Docs**: `docs/cli.md` § Install path layout; README/CN manual install and maintainer refresh notes updated.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`: **0.7.1 → 0.7.2**. **`@mstar-harness/cli`**: **0.5.3 → 0.5.4**.
 
 ## [0.7.1] - 2026-06-30
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,28 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.7.1**（CLI 包除外，见下表）。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.7.2**（CLI 包除外，见下表）。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **0.7.1** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **0.5.3** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.7.1** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.7.1** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **0.7.1** |
+| monorepo 根 | `morning-star`（`package.json`） | **0.7.2** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **0.5.4** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.7.2** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.7.2** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **0.7.2** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [0.7.2] - 2026-06-30
+
+### CLI / Cursor 安装
+
+- **Cursor 插件路径布局**：`mstar-harness init --target cursor` 在 Cursor 插件路径安装**真实 git checkout**（`git clone` / `git pull`），不再软链接到 `~/.mstar/harness`。Cursor **无法发现**软链接形式的插件目录。
+- **`doctor --target cursor`**：插件路径为 symlink 时报错；`init` 会删除已有 symlink 并 clone。
+- **文档**：`docs/cli.md` § Install path layout；README/CN 手动安装与维护者刷新说明已更新。
+
+### 版本对齐
+
+- monorepo 根、`@mstar-harness/opencode`、`.cursor-plugin/plugin.json`、`.codex-plugin/plugin.json`：**0.7.1 → 0.7.2**。**`@mstar-harness/cli`**：**0.5.3 → 0.5.4**。
 
 ## [0.7.1] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Core value:
   - Codex:
     - `npx @mstar-harness/cli init --target codex`
     - `codex plugin add morning-star-harness --marketplace personal`
-- Cursor and Codex installs share a maintained local checkout at `~/.mstar/harness`; target-specific plugin and agent paths are symlinked to that checkout.
+- Cursor and Codex installs maintain a shared checkout at `~/.mstar/harness` (Codex marketplace + agent sources). **Cursor** installs a separate **real git checkout** at the plugin path — Cursor does not discover symlinked plugin directories (see [`docs/cli.md`](docs/cli.md#install-path-layout)).
 
 For full CLI usage and advanced options (`--yes`, `--dry-run`, `--output`, `doctor`) including Cursor and Codex target install modes, see [`docs/cli.md`](docs/cli.md).
 
@@ -72,11 +72,14 @@ For detailed OpenCode setup and migration, see `packages/opencode/INSTALL.md`.
 - Recommended:
   - `npx @mstar-harness/cli init --target cursor --scope global`
   - Restart Cursor or run `Developer: Reload Window`
-- Manual install (same paths the CLI uses):
+- Manual install (same layout the CLI uses; **do not symlink** the Cursor plugin path):
   - `git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness`
   - `mkdir -p ~/.cursor/plugins/local`
-  - `ln -s ~/.mstar/harness ~/.cursor/plugins/local/morning-star-harness`
+  - `git clone https://github.com/btspoony/mstar-harness.git ~/.cursor/plugins/local/morning-star-harness`
   - Restart Cursor or run `Developer: Reload Window`
+- **Maintainers**: develop in your workspace; refresh the Cursor plugin checkout after merge:
+  - `cd ~/.cursor/plugins/local/morning-star-harness && git pull --ff-only`
+  - or re-run `npx @mstar-harness/cli init --target cursor --scope global`
 
 #### Codex
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -37,7 +37,7 @@
   - Codex：
     - `npx @mstar-harness/cli init --target codex`
     - `codex plugin add morning-star-harness --marketplace personal`
-- Cursor 与 Codex 安装共享长期维护的本地 checkout：`~/.mstar/harness`；各宿主的 plugin / agent 入口通过软链接指向该目录。
+- Cursor 与 Codex 共享 `~/.mstar/harness` 长期 checkout（Codex marketplace 与 agent 源）。**Cursor** 在插件路径使用**独立的 git 实目录**——Cursor **无法发现**软链接形式的插件目录（见 [`docs/cli.md`](docs/cli.md#install-path-layout)）。
 
 完整 CLI 用法和高级参数（`--yes`、`--dry-run`、`--output`、`doctor`），以及 Cursor / Codex target 的安装模式说明，见 [`docs/cli.md`](docs/cli.md)。
 
@@ -72,11 +72,14 @@ OpenCode 的详细安装与迁移说明见 `packages/opencode/INSTALL.md`。
 - 推荐：
   - `npx @mstar-harness/cli init --target cursor --scope global`
   - 重启 Cursor 或运行 `Developer: Reload Window`
-- 手动安装（与 CLI 使用相同路径）：
+- 手动安装（与 CLI 相同布局；Cursor 插件路径**不要用软链接**）：
   - `git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness`
   - `mkdir -p ~/.cursor/plugins/local`
-  - `ln -s ~/.mstar/harness ~/.cursor/plugins/local/morning-star-harness`
+  - `git clone https://github.com/btspoony/mstar-harness.git ~/.cursor/plugins/local/morning-star-harness`
   - 重启 Cursor 或运行 `Developer: Reload Window`
+- **维护者**：在 workspace 开发后，更新 Cursor 插件 checkout：
+  - `cd ~/.cursor/plugins/local/morning-star-harness && git pull --ff-only`
+  - 或重新运行 `npx @mstar-harness/cli init --target cursor --scope global`
 
 #### Codex
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,7 +22,7 @@ Use this sequence for the quickest user flow.
 
 ### Cursor
 
-1) Install plugin to project (default scope). The CLI maintains `~/.mstar/harness` and symlinks `.cursor/plugins/morning-star-harness` to it:
+1) Install plugin to project (default scope). The CLI maintains `~/.mstar/harness` and clones a **real directory** at `.cursor/plugins/morning-star-harness` (not a symlink — Cursor cannot load symlinked plugin roots):
 
 - `npx @mstar-harness/cli init --target cursor`
 
@@ -74,9 +74,9 @@ Dry-run preview (no file write):
 
 Cursor install:
 
-- Global install (symlink at `~/.cursor/plugins/local/morning-star-harness`; shared checkout at `~/.mstar/harness`):
+- Global install (git checkout at `~/.cursor/plugins/local/morning-star-harness`; shared Codex/OpenCode checkout at `~/.mstar/harness`):
   - `npx @mstar-harness/cli init --target cursor --scope global`
-- Project install (symlink at `.cursor/plugins/morning-star-harness`; the CLI adds it to `.gitignore`):
+- Project install (git checkout at `.cursor/plugins/morning-star-harness`; the CLI adds it to `.gitignore`):
   - `npx @mstar-harness/cli init --target cursor --scope project`
 
 Codex install:
@@ -112,12 +112,12 @@ OpenCode `init` enforces these baseline requirements in `opencode.json`:
 - `plugin` contains `@mstar-harness/opencode@latest` (legacy `morning-star@git+…` lines for `btspoony/mstar-harness` are stripped on init, including URLs without `.git`, `ssh://`, or `#tag`)
 - all Morning Star roles have `agent.<role>.model`
 
-Cursor and Codex `init` ensure a maintained local checkout exists at `~/.mstar/harness`, then create target-specific symlinks.
+Cursor and Codex `init` ensure a maintained local checkout exists at `~/.mstar/harness`. Codex then creates agent symlinks from that checkout. Cursor clones a **separate real git checkout** at the plugin path (see [Install path layout](#install-path-layout)).
 
 Cursor `init`:
 
-- global: `~/.cursor/plugins/local/morning-star-harness -> ~/.mstar/harness`
-- project: `.cursor/plugins/morning-star-harness -> ~/.mstar/harness` and `.gitignore` entry for the plugin link
+- global: `git clone` / `git pull` at `~/.cursor/plugins/local/morning-star-harness`
+- project: `git clone` / `git pull` at `.cursor/plugins/morning-star-harness` and `.gitignore` entry for the plugin directory
 
 Codex `init` writes or updates marketplace metadata with a local-source entry:
 
@@ -133,8 +133,28 @@ Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` 
 
 - Same schema, role models, and presence of **either** `@mstar-harness/opencode…` **or** a recognized legacy `morning-star@git+…` line (so existing git-based configs still pass).
 - If only legacy git is present, or legacy and npm are both listed, `doctor` prints **yellow recommendations** and still exits 0; run `init` to normalize to `@mstar-harness/opencode@latest`.
-- For Cursor, `doctor` checks the maintained `~/.mstar/harness` checkout, the plugin symlink, and that plugin `agents/*.md` files use Cursor-first frontmatter.
+- For Cursor, `doctor` checks the maintained `~/.mstar/harness` checkout, that the Cursor plugin path is a **real git directory** (not a symlink), and that `agents/*.md` files use Cursor-first frontmatter.
 - For Codex, `doctor` checks the local marketplace entry, the maintained `~/.mstar/harness` checkout, and custom-agent symlinks.
+
+## Install path layout
+
+Cursor **does not discover symlinked plugin directories**. Use real directories at the plugin paths below.
+
+| Path | Host | Layout | Notes |
+| --- | --- | --- | --- |
+| `~/.mstar/harness` | Codex (marketplace `local` source), OpenCode dev bundle | git checkout | Codex agent `.toml` files are **symlinked** from here into `~/.codex/agents/` |
+| `~/.cursor/plugins/local/morning-star-harness` | Cursor global plugin | **git checkout (real dir)** | **Not** a symlink to `~/.mstar/harness`; `init` clones or `git pull`s here |
+| `.cursor/plugins/morning-star-harness` | Cursor project plugin | **git checkout (real dir)** | gitignored; same clone/pull behavior as global |
+
+`init --target cursor` maintains **two** checkouts: `~/.mstar/harness` (shared with Codex) and the Cursor plugin path (independent clone, kept in sync via `git pull` on each init).
+
+**Maintainers** editing this repository in a separate workspace should refresh the Cursor plugin checkout after merging:
+
+```bash
+cd ~/.cursor/plugins/local/morning-star-harness && git pull --ff-only
+```
+
+Or re-run `npx @mstar-harness/cli init --target cursor --scope global`.
 
 ## Options Reference
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -25,3 +25,4 @@ This `packages/cli` directory hosts the standalone `@mstar-harness/cli` package 
 - Do not modify user secrets or credential files.
 - For config writes, only touch the target-specific install/config file chosen by user input
   (`opencode.json`, Cursor plugin paths, or Codex personal marketplace metadata).
+- **Cursor plugin paths must be real git checkouts** — not symlinks. Cursor does not load symlinked plugin roots; see `docs/cli.md` § Install path layout.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
-## Unreleased
-
-### Cursor install
+## 0.5.4
 
 - **Layout fix**: Cursor global/project plugin paths are **real git checkouts** (`git clone` / `git pull`), not symlinks to `~/.mstar/harness`. Cursor does not discover symlinked plugin directories.
 - `doctor --target cursor` fails if the plugin path is a symlink; `init` removes an existing symlink and clones.
 - `~/.mstar/harness` remains the shared checkout for Codex marketplace local source and agent symlinks.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **0.7.2**.
 
 ## 0.5.1
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## Unreleased
+
+### Cursor install
+
+- **Layout fix**: Cursor global/project plugin paths are **real git checkouts** (`git clone` / `git pull`), not symlinks to `~/.mstar/harness`. Cursor does not discover symlinked plugin directories.
+- `doctor --target cursor` fails if the plugin path is a symlink; `init` removes an existing symlink and clones.
+- `~/.mstar/harness` remains the shared checkout for Codex marketplace local source and agent symlinks.
+
 ## 0.5.1
 
 - align Cursor global/project plugin symlinks to `morning-star-harness` (matching plugin manifest `name`)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex).",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/adapters/cursor.ts
+++ b/packages/cli/src/adapters/cursor.ts
@@ -4,11 +4,11 @@ import path from "node:path";
 import type { AgentAdapter, Scope } from "../types";
 import { resolveProjectRoot } from "../utils";
 import {
-  HARNESS_REPO_PATH,
+  REPO_URL,
   ensureLocalHarnessRepo,
-  ensureSymlink,
+  ensureGitCheckout,
   validateLocalHarnessRepo,
-  validateSymlink,
+  validateGitCheckout,
   appendGitignore,
 } from "./shared-install";
 
@@ -25,9 +25,9 @@ function projectInstallPath() {
   return path.join(resolveProjectRoot(), CURSOR_PLUGIN_LINK);
 }
 
-function validatePluginAgents() {
+function validatePluginAgents(pluginRoot: string) {
   const errors: string[] = [];
-  const agentsDir = path.join(HARNESS_REPO_PATH, "agents");
+  const agentsDir = path.join(pluginRoot, "agents");
   if (!fs.existsSync(agentsDir)) {
     errors.push(`Missing plugin agents directory: ${agentsDir}`);
     return errors;
@@ -48,10 +48,14 @@ function validatePluginAgents() {
   return errors;
 }
 
+function ensureCursorPluginCheckout(location: string, dryRun: boolean) {
+  return ensureGitCheckout(REPO_URL, location, dryRun);
+}
+
 function globalInit(dryRun: boolean) {
   const location = globalInstallPath();
   const notes = ensureLocalHarnessRepo(dryRun);
-  notes.push(ensureSymlink(HARNESS_REPO_PATH, location, dryRun));
+  notes.push(...ensureCursorPluginCheckout(location, dryRun));
   return { location, notes };
 }
 
@@ -59,7 +63,7 @@ function projectInit(dryRun: boolean) {
   const projectRoot = resolveProjectRoot();
   const location = projectInstallPath();
   const notes = ensureLocalHarnessRepo(dryRun);
-  notes.push(ensureSymlink(HARNESS_REPO_PATH, location, dryRun));
+  notes.push(...ensureCursorPluginCheckout(location, dryRun));
   notes.push(...appendGitignore(projectRoot, [CURSOR_PLUGIN_LINK], dryRun));
   return { location, notes };
 }
@@ -67,12 +71,8 @@ function projectInit(dryRun: boolean) {
 function globalDoctor() {
   const location = globalInstallPath();
   const errors = validateLocalHarnessRepo();
-  errors.push(...validateSymlink(HARNESS_REPO_PATH, location));
-  const marker = path.join(location, CURSOR_PLUGIN_MARKER);
-  if (!fs.existsSync(marker)) {
-    errors.push(`Missing Cursor plugin marker file: ${marker}`);
-  }
-  errors.push(...validatePluginAgents());
+  errors.push(...validateGitCheckout(location, CURSOR_PLUGIN_MARKER));
+  errors.push(...validatePluginAgents(location));
   return { location, errors };
 }
 
@@ -80,17 +80,13 @@ function projectDoctor() {
   const projectRoot = resolveProjectRoot();
   const location = projectInstallPath();
   const errors = validateLocalHarnessRepo();
-  errors.push(...validateSymlink(HARNESS_REPO_PATH, location));
-  const marker = path.join(location, CURSOR_PLUGIN_MARKER);
-  if (!fs.existsSync(marker)) {
-    errors.push(`Missing Cursor plugin marker file: ${marker}`);
-  }
+  errors.push(...validateGitCheckout(location, CURSOR_PLUGIN_MARKER));
   const gitignorePath = path.join(projectRoot, ".gitignore");
   const gitignore = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
   if (!gitignore.split(/\r?\n/).includes(CURSOR_PLUGIN_LINK)) {
     errors.push(`Missing .gitignore entry: ${CURSOR_PLUGIN_LINK}`);
   }
-  errors.push(...validatePluginAgents());
+  errors.push(...validatePluginAgents(location));
   return { location, errors };
 }
 

--- a/packages/cli/src/adapters/shared-install.ts
+++ b/packages/cli/src/adapters/shared-install.ts
@@ -58,6 +58,63 @@ export function validateLocalHarnessRepo() {
   return errors;
 }
 
+/** Cursor cannot load symlinked plugin roots — use a materialized git checkout. */
+export function ensureGitCheckout(repoUrl: string, checkoutPath: string, dryRun: boolean) {
+  const notes: string[] = [];
+  const parentDir = path.dirname(checkoutPath);
+
+  if (pathOrSymlinkExists(checkoutPath)) {
+    const stat = fs.lstatSync(checkoutPath);
+    if (stat.isSymbolicLink()) {
+      notes.push(
+        dryRun
+          ? `Would remove symlink at ${checkoutPath} and clone ${repoUrl}`
+          : `Removed symlink at ${checkoutPath} (Cursor requires a real directory)`,
+      );
+      if (dryRun) return notes;
+      fs.unlinkSync(checkoutPath);
+    } else if (fs.existsSync(path.join(checkoutPath, ".git"))) {
+      if (!dryRun) {
+        runCommand(["git", "-C", checkoutPath, "pull", "--ff-only"], checkoutPath, dryRun);
+      }
+      notes.push(`Updated git checkout at ${checkoutPath}`);
+      return notes;
+    } else {
+      throw new Error(`Path exists but is not a git checkout: ${checkoutPath}`);
+    }
+  }
+
+  ensureDir(parentDir, dryRun);
+  if (!dryRun) {
+    runCommand(["git", "clone", repoUrl, checkoutPath], parentDir, dryRun);
+  }
+  notes.push(`${dryRun ? "Would clone" : "Cloned"} ${repoUrl} to ${checkoutPath}`);
+  return notes;
+}
+
+export function validateGitCheckout(checkoutPath: string, markerRelativePath: string) {
+  const errors: string[] = [];
+  if (!pathOrSymlinkExists(checkoutPath)) {
+    errors.push(`Missing checkout directory: ${checkoutPath}`);
+    return errors;
+  }
+  const stat = fs.lstatSync(checkoutPath);
+  if (stat.isSymbolicLink()) {
+    errors.push(
+      `Path must be a real directory, not a symlink: ${checkoutPath}. Run: mstar-harness init --target cursor`,
+    );
+    return errors;
+  }
+  if (!fs.existsSync(path.join(checkoutPath, ".git"))) {
+    errors.push(`Path is not a git checkout: ${checkoutPath}`);
+  }
+  const marker = path.join(checkoutPath, markerRelativePath);
+  if (!fs.existsSync(marker)) {
+    errors.push(`Missing marker file: ${marker}`);
+  }
+  return errors;
+}
+
 export function ensureSymlink(target: string, linkPath: string, dryRun: boolean) {
   if (pathOrSymlinkExists(linkPath)) {
     const stat = fs.lstatSync(linkPath);

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 0.7.2
+
+- Docs only at package level: root **0.7.2** documents CLI Cursor install layout (real git checkout at plugin path, not symlink). Re-bundle on publish if CLI dist changed.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **0.7.2**.
+
 ## 0.7.1
 
 - Bundled commands/skills: `/iteration-start` §5 Review & Edit chain is a hard gate before integration branch commit — Task dispatch for product-manager, architect, writing-specialist; evidence is edited docs + locked compass (no iteration `reports/` artifacts). Synced in `mstar-iteration` §1.6, `pm`, `mstar-dispatch-gates`, `mstar-harness-core`.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Cursor **cannot discover symlinked plugin directories** — `mstar-harness init --target cursor` now clones/pulls a **real git checkout** at the plugin path instead of symlinking to `~/.mstar/harness`.
- `doctor --target cursor` rejects symlinked plugin paths; `init` removes existing symlinks and clones.
- Document dual-checkout layout in `docs/cli.md` § Install path layout; update README/CN manual install and maintainer refresh notes.
- Release **0.7.2** (harness surfaces) / **0.5.4** (`@mstar-harness/cli`).

## Test plan

- [ ] `mstar-harness init --target cursor --scope global` on a machine with symlinked plugin path → symlink removed, clone succeeds
- [ ] `mstar-harness doctor --target cursor --scope global` → healthy with real directory
- [ ] Cursor Reload Window → plugin loads from `~/.cursor/plugins/local/morning-star-harness`
- [ ] Codex path unchanged: `~/.mstar/harness` + agent symlinks still work


Made with [Cursor](https://cursor.com)