### PR TITLE
Use plain role ids in Assignment prose for OpenCode

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,30 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **0.7.8** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **0.7.9** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **0.7.8** |
+| Monorepo root | `morning-star` (`package.json`) | **0.7.9** |
 | CLI | `@mstar-harness/cli` (`packages/cli`) | **0.5.4** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.7.8** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **0.7.8** |
-| Codex plugin | `.codex-plugin/plugin.json` | **0.7.8** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **0.7.9** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **0.7.9** |
+| Codex plugin | `.codex-plugin/plugin.json` | **0.7.9** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [0.7.9] - 2026-07-06
+
+### Harness (Assignment plain role ids / OpenCode `@` hygiene)
+
+- **Assignment SSOT**: `dispatch-and-assignment.md` template, PM routing table, and `project-manager.md` Language rule — all role references in Assignment **body** use **plain role ids** (no `@`); host invoke uses task tool **`subagent`** matching `Execute as`.
+- **`mstar-dispatch-gates`** and **leaf-executor checklist**: anti-recursion NEVER rules reworded to `role-id` mentions (not `@<role>` literals).
+- **`mstar-host/references/opencode.md`**: Role-mention hygiene — Assignment prose vs task-tool dispatch; warnings avoid `@` literals that trigger OpenCode auto-dispatch.
+- **Iteration commands**, **`mstar-branch-worktree`**, **`mstar-plan-artifacts`** (plan checkbox duties), **`pm` skill**, and **role NEVER** references aligned on plain ids.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `.cursor-plugin/plugin.json`, `.codex-plugin/plugin.json`: **0.7.8 → 0.7.9**. **`@mstar-harness/cli` remains 0.5.4**.
 
 ## [0.7.8] - 2026-07-06
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,29 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.7.8**（CLI 包除外，见下表）。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**0.7.9**（CLI 包除外，见下表）。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **0.7.8** |
+| monorepo 根 | `morning-star`（`package.json`） | **0.7.9** |
 | CLI | `@mstar-harness/cli`（`packages/cli`） | **0.5.4** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.7.8** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.7.8** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **0.7.8** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **0.7.9** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **0.7.9** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **0.7.9** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [0.7.9] - 2026-07-06
+
+### Harness（Assignment plain role id / OpenCode `@` 卫生）
+
+- **Assignment SSOT**：`dispatch-and-assignment.md` 模板、PM 路由表、`project-manager.md` Language 规则 — Assignment **正文**角色引用一律 **plain role id**（无 `@`）；宿主派发用 task tool **`subagent`** 对齐 `Execute as`。
+- **`mstar-dispatch-gates`** 与 **leaf-executor checklist**：反递归 NEVER 改为 `role-id` 提及表述（避免 `@<role>` 字面量）。
+- **`mstar-host/references/opencode.md`**：Role-mention hygiene — Assignment 正文 vs task-tool 派发；警告文案不含会触发 OpenCode 自动派发的 `@` 字面量。
+- **iteration commands**、**`mstar-branch-worktree`**、**`mstar-plan-artifacts`**（plan 勾选职责）、**`pm` skill**、各 **role NEVER** 引用已对齐 plain id。
+
+### 版本对齐
+
+- monorepo 根、`@mstar-harness/opencode`、`.cursor-plugin/plugin.json`、`.codex-plugin/plugin.json`：**0.7.8 → 0.7.9**。**`@mstar-harness/cli` 保持 0.5.4**。
 
 ## [0.7.8] - 2026-07-06
 

--- a/commands/iteration-drive.md
+++ b/commands/iteration-drive.md
@@ -33,7 +33,7 @@ Phase 2: Autonomous Execute  →  Phase 3: iteration-close  →  Phase 4: Create
 | 只写 Assignment 就进入下一 gate | 同轮 dispatch：`Subagent invokes issued: N`（N = Assignment 条数） |
 | 最后一个 plan `Done` 后直接开 PR / 汇报结束 | **Phase 3 → 4 → 5** 顺序执行 |
 | Phase 4 开 PR 后停止 | Phase 5 loop 至 merge-ready；**禁止**未过 §5.5 就结束会话 |
-| Phase 5 自己改产品代码 | 需改产品代码时 **dispatch** `@fullstack-dev` / `@ops-engineer` |
+| Phase 5 自己改产品代码 | 需改产品代码时 **dispatch** `fullstack-dev` / `ops-engineer` |
 
 派发细则 → **`mstar-dispatch-gates`** + **`mstar-host`**。Phase 3 细则 → **`mstar-iteration` §3** + **`mstar-compound`**。
 

--- a/commands/iteration-start.md
+++ b/commands/iteration-start.md
@@ -14,7 +14,7 @@ Start a new Morning Star harness iteration. **Not Done until the Review & Edit c
 
 | 禁止（PM 线程） | 必须（宿主有 Task 时） |
 |-----------------|------------------------|
-| 自己 Edit compass/plans/specs 冒充 @product-manager / @architect / @writing-specialist 的审查编辑 | §5.1 → §5.2 → §5.3 **顺序**各 **1 次 invoke**；上一角色返回后再派发下一角色 |
+| 自己 Edit compass/plans/specs 冒充 product-manager / architect / writing-specialist 的审查编辑 | §5.1 → §5.2 → §5.3 **顺序**各 **1 次 invoke**；上一角色返回后再派发下一角色 |
 | 只写 `## Assignment` 或 checklist 就声称 review chain 完成 | **几条角色 ⇒ 几条 invoke**；零 invoke = `dispatch incomplete`（`mstar-dispatch-gates`） |
 | §5 完成前 commit / 创建 integration 分支 | 5.4 PM lock 在 subagent 返回且磁盘产物已修订之后（`mstar-iteration` §1.6） |
 
@@ -93,16 +93,16 @@ Produce harness artifacts per **`mstar-iteration` § 1.3**（template: `mstar-it
 
 **STOP**: Do not run §6 Integration Branch until **all** rows below are true.
 
-**顺序（HARD）**：`product-manager` → `architect` → `writing-specialist` → PM lock。后一角色基于前一角色已落盘的修订继续编辑；**禁止**三角色并行 invoke。
+**顺序（HARD）**：`product-manager` → `architect` → `writing-specialist` → PM lock。后一角色基于前一角色已落盘的修订继续编辑；**禁止**三角色并行 invoke。OpenCode：正文用 plain role id — **`mstar-host/references/opencode.md`** § Role-mention hygiene。
 
 Each role below **reviews and directly edits** the documents. Do not just flag issues — apply the fixes yourself. PM only steps in for the final lock.
 
 | # | Role | Required action | Gate |
 |---|------|-----------------|------|
-| 5.1 | **@product-manager** | invoke: **edit** compass, plans, `{SPECS_DIR}/`; scope, UX, priorities | 完成后方可 5.2 |
-| 5.2 | **@architect** | invoke: **edit** compass, plans, specs（含 5.1 修订后版本）; contracts, SQL, module boundaries | 5.1 返回后；完成后方可 5.3 |
-| 5.3 | **@writing-specialist** | invoke: **edit** all iteration docs（含 5.1–5.2 修订后版本）; terminology, structure, clarity | 5.2 返回后 |
-| 5.4 | **@project-manager** | Merge subagent edits; resolve conflicts; **lock** compass (`status: locked`); confirm Prepare gates | 5.3 返回后 |
+| 5.1 | **product-manager** | invoke: **edit** compass, plans, `{SPECS_DIR}/`; scope, UX, priorities | 完成后方可 5.2 |
+| 5.2 | **architect** | invoke: **edit** compass, plans, specs（含 5.1 修订后版本）; contracts, SQL, module boundaries | 5.1 返回后；完成后方可 5.3 |
+| 5.3 | **writing-specialist** | invoke: **edit** all iteration docs（含 5.1–5.2 修订后版本）; terminology, structure, clarity | 5.2 返回后 |
+| 5.4 | **project-manager** | Merge subagent edits; resolve conflicts; **lock** compass (`status: locked`); confirm Prepare gates | 5.3 返回后 |
 
 **Evidence of done** = edited compass / plans / specs on disk + compass `status: locked`. **No** separate iteration review reports under `reports/` — unlike per-plan QC, there is no downstream audit chain to preserve.
 
@@ -129,9 +129,9 @@ PM must print this block before §6; all `[ ]` must be `[x]`:
 
 - [ ] grill-me decisions recorded in compass
 - [ ] Draft compass + plans + `status.json` registered
-- [ ] @product-manager Task completed — compass / plans / specs edited
-- [ ] @architect Task completed — compass / specs edited
-- [ ] @writing-specialist Task completed — iteration docs edited
+- [ ] product-manager invoke completed — compass / plans / specs edited
+- [ ] architect invoke completed — compass / specs edited
+- [ ] writing-specialist invoke completed — iteration docs edited
 - [ ] PM final lock: compass `status: locked`; Prepare gates pass (blocked plans documented)
 - [ ] Branch policy locked: `iteration_base_branch`, `spec_integration_branch`, and `target_branch` recorded in compass / `status.json`
 - [ ] **THEN**: git commit + push `iteration/<iteration-id>`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 0.7.9
+
+- Bundled commands/skills: Assignment plain role ids across PM templates, dispatch gates, branch-worktree, iteration commands, opencode host hygiene, and role NEVER rules — avoids OpenCode `@` auto-dispatch in harness prose.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **0.7.9**.
+
 ## 0.7.8
 
 - Bundled commands/skills: `mstar-iteration` Phase 4–5 (PR delivery + merge-ready loop); `iteration-drive` sequences through Phase 5 with optional greploop/babysit helpers; core index and anti-patterns updated.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-branch-worktree/SKILL.md
+++ b/skills/mstar-branch-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-branch-worktree
-description: Morning Star business-repo Git feature branches, same-repo concurrent `git worktree` isolation, plan/Spec integration branches, and QC/QA checkout alignment (`Review cwd`, `Working branch`, `plan_id`, `Review range` / `Diff basis` must match verbatim across three QC reviewers and QA). Read when PM writes `Working branch` / `Branch policy`, two or more writable streams touch one repo, dispatching QC tri-review or QA after merging to a single `HEAD`, dev/QA/ops before first `git commit`, or explaining worktree paths. Required for `@project-manager` parallel implement or pre-QC orchestration; `@fullstack-dev*` / `@frontend-dev` / `@qa-engineer` / `@ops-engineer` on repo writes; `@qc-specialist*` before review. Does not replace the state machine (`mstar-harness-core`).
+description: Morning Star business-repo Git feature branches, same-repo concurrent `git worktree` isolation, plan/Spec integration branches, and QC/QA checkout alignment (`Review cwd`, `Working branch`, `plan_id`, `Review range` / `Diff basis` must match verbatim across three QC reviewers and QA). Read when PM writes `Working branch` / `Branch policy`, two or more writable streams touch one repo, dispatching QC tri-review or QA after merging to a single `HEAD`, dev/QA/ops before first `git commit`, or explaining worktree paths. Required for `project-manager` parallel implement or pre-QC orchestration; `fullstack-dev*` / `frontend-dev` / `qa-engineer` / `ops-engineer` on repo writes; `qc-specialist*` before review. Does not replace the state machine (`mstar-harness-core`).
 ---
 
 ## Load order（必读顺序）
@@ -33,23 +33,23 @@ description: Morning Star business-repo Git feature branches, same-repo concurre
 - 当需要**从已有功能分支继续拆新分支**时，Assignment 应写清**祖先分支** `<base>`，例如：`create feature/foo-part2 from feature/foo`。
 - **`<base>` 可取**：`main` / `master`（或项目默认分支名）、任意已存在的 `feature/*` / `fix/*`、远程跟踪分支名、或 **`current`**（表示以执行者检出时的 `HEAD` 为祖先，用于「就在当前分支上再拉一枝」）。
 - 若只写 **`Working branch`: `feature/foo`且无「create … from …」**：表示**沿用 / 切到**该已存在分支上开发，不要求新建。
-- 若写新建但未写 `<base>`：实现侧应**停下问** `@project-manager`（或按项目 `AGENTS.md` 的默认 base）；**禁止**擅自假设「一定是 `main`」。
+- 若写新建但未写 `<base>`：实现侧应**停下问** `project-manager`（或按项目 `AGENTS.md` 的默认 base）；**禁止**擅自假设「一定是 `main`」。
 
 ### 角色职责
 
-- **`@project-manager`（唯一分支决策入口）**：向 `@product-manager`（向项目仓库提交产品文档时）、`@architect`（向项目仓库提交技术/架构/契约类文档时）、`@fullstack-dev` / `@frontend-dev` / `@fullstack-dev-2`、以及会向仓库提交工件的 `@qa-engineer`、会改仓库内文件的 `@ops-engineer`、对**项目仓库**落盘的 `@prompt-engineer` 分派前，核对分支策略；在 Assignment 中写明 **`Working branch`**（沿用已有分支名，或 `create <new-branch> from <base>`，其中 `<base>` 遵守上一节）。若用户已指定分支/祖先，照抄进 Assignment。**只有 `@project-manager` 可以决定是否新开分支、从哪个 `<base>` 开分支。**
-- **实现 / QA / 运维 / prompt / product-manager / architect（项目侧）**：在**首次**编辑仓库内文件或执行 `git commit` 前，核对当前分支与 Assignment，并在回报中明确"正在哪个分支上工作"。**禁止自行决定新开分支、禁止自行切回 `main`/`master` 重开分支。**若未授权 `Branch policy` 且当前在默认分支，则仅可按 PM 已写明的 `Working branch` 执行切换/开枝；若 Assignment 未写清或与现场分支不一致，先回报 `@project-manager`，不得擅自处理。
+- **`project-manager`（唯一分支决策入口）**：向 `product-manager`（向项目仓库提交产品文档时）、`architect`（向项目仓库提交技术/架构/契约类文档时）、`fullstack-dev` / `frontend-dev` / `fullstack-dev-2`、以及会向仓库提交工件的 `qa-engineer`、会改仓库内文件的 `ops-engineer`、对**项目仓库**落盘的 `prompt-engineer` 分派前，核对分支策略；在 Assignment 中写明 **`Working branch`**（沿用已有分支名，或 `create <new-branch> from <base>`，其中 `<base>` 遵守上一节）。若用户已指定分支/祖先，照抄进 Assignment。**只有 `project-manager` 可以决定是否新开分支、从哪个 `<base>` 开分支。**
+- **实现 / QA / 运维 / prompt / product-manager / architect（项目侧）**：在**首次**编辑仓库内文件或执行 `git commit` 前，核对当前分支与 Assignment，并在回报中明确"正在哪个分支上工作"。**禁止自行决定新开分支、禁止自行切回 `main`/`master` 重开分支。**若未授权 `Branch policy` 且当前在默认分支，则仅可按 PM 已写明的 `Working branch` 执行切换/开枝；若 Assignment 未写清或与现场分支不一致，先回报 `project-manager`，不得擅自处理。
 
 ## 分支协作契约（Branch Collaboration Contract）
 
 ### 适用范围
 
 - 当任务会在项目 Git 仓库产生可合并 diff 时适用。
-- 适用于 `@project-manager`、`@product-manager`、`@architect`、`@fullstack-dev`、`@frontend-dev`、`@fullstack-dev-2`、`@qa-engineer`、`@ops-engineer`、`@prompt-engineer`（项目侧写入）。
+- 适用于 `project-manager`、`product-manager`、`architect`、`fullstack-dev`、`frontend-dev`、`fullstack-dev-2`、`qa-engineer`、`ops-engineer`、`prompt-engineer`（项目侧写入）。
 
 ### 唯一分支决策者
 
-- 只有 `@project-manager` 可以决定分支策略：
+- 只有 `project-manager` 可以决定分支策略：
   - 继续在现有分支开发，或
   - 使用 `create <new-branch> from <base>` 新开分支，或
   - 使用 `Branch policy: direct on <branch> — <reason>`。
@@ -103,7 +103,7 @@ description: Morning Star business-repo Git feature branches, same-repo concurre
 
 **首要场景是开发阶段**：多条可写流 **并发** 改 **同一仓库** 时，用 worktree 做 **写入侧目录隔离**。下列规则针对该类开发并发；**QC / QA 阶段的检出约定**见下一小节。
 
-当 **`@project-manager` 在同一调度轮次内并发启动多个** subagent（含宿主侧「并行 Task / 并行 subagent」），且 **≥2 个承接方**可能对 **同一 Git 仓库的同一工作区（同一 cwd 检出目录）**产生写文件或 `git commit` 级改动时：
+当 **`project-manager` 在同一调度轮次内并发启动多个** subagent（含宿主侧「并行 Task / 并行 subagent」），且 **≥2 个承接方**可能对 **同一 Git 仓库的同一工作区（同一 cwd 检出目录）**产生写文件或 `git commit` 级改动时：
 
 - **必须**为每条并发写流使用 **独立检出目录**：优先使用宿主原生 worktree/checkout 隔离能力；没有原生能力时使用 `git worktree`，并按本 skill 的目录、分支和 QC/QA 对齐规则执行。
 - **必须**与既有分支门禁一致：每个可写承接方的 Assignment 仍须含 PM 已批准的 **`Working branch`** / **`Branch policy`**；在某一 worktree 内 **不得**擅自 `checkout` 到未授权分支或私自新建分支。
@@ -137,11 +137,11 @@ description: Morning Star business-repo Git feature branches, same-repo concurre
 
 开发在 **feature 分支**上完成（往往在 **独立 worktree** 中实现）后，**QC 审查与 QA 验证针对的都是这份 feature**，而不是 `main` 或任意未对齐的默认 cwd。
 
-- **`@project-manager`** 分派 **QC** 时须在 Assignment 写明与待审实现一致的 **`Working branch`**，并写明 **`Review cwd` / `Worktree path`**：**优先**沿用开发 **Completion Report** 中回报的业务仓 **实现检出路径**（即「该 feature 的 worktree」）**当且仅当**该路径上的检出分支 **`HEAD` 已包含本轮待审的全部提交**（含曾发生在其他并行 worktree、现已归并到该分支的变更）。否则 **必须**改用 **集成完成后的** `Working branch` 与对应检出路径（或在该分支上 **另开** 审查专用 worktree）。若开发未用 worktree，则写明单一明确的业务仓根路径。若审查需与开发目录 **物理分离** 但仍审 **同一分支**，可指示在 **`Working branch`** 上 **另加** 一个 worktree 专供审查（只读使用业务仓）。**多流并行开发**时的前置归并、**推荐默认编排（plan 集成分支先行）** 与误派禁令见上一小节。
+- **`project-manager`** 分派 **QC** 时须在 Assignment 写明与待审实现一致的 **`Working branch`**，并写明 **`Review cwd` / `Worktree path`**：**优先**沿用开发 **Completion Report** 中回报的业务仓 **实现检出路径**（即「该 feature 的 worktree」）**当且仅当**该路径上的检出分支 **`HEAD` 已包含本轮待审的全部提交**（含曾发生在其他并行 worktree、现已归并到该分支的变更）。否则 **必须**改用 **集成完成后的** `Working branch` 与对应检出路径（或在该分支上 **另开** 审查专用 worktree）。若开发未用 worktree，则写明单一明确的业务仓根路径。若审查需与开发目录 **物理分离** 但仍审 **同一分支**，可指示在 **`Working branch`** 上 **另加** 一个 worktree 专供审查（只读使用业务仓）。**多流并行开发**时的前置归并、**推荐默认编排（plan 集成分支先行）** 与误派禁令见上一小节。
 - **三票审同一功能（强制对齐）**：分派 **QC 三审**时，除上述字段外，**必须**在 **三份 Assignment 中逐字写入相同**的 **`plan_id`** 与 **`Review range` / `Diff basis`**：
   - **`plan_id`**：与 `{PLAN_DIR}/reports/<plan-id>/` 及主 **Plan Path** 一致；无 `{PLAN_DIR}` 流程时写 **`plan_id: N/A`**，并另给一行 **`Feature / scope label`**（不可歧义，足以与并行其它 feature 区分）。
-  - **`Review range` / `Diff basis`**：明确本次审查所针对的 **diff/提交范围**（例如 `merge-base: <target_branch-or-base-ref>` + `tip: HEAD`；或 `rev-range: <full-40>..<full-40>`；或一句 `equivalent to: git diff <merge-base>...HEAD`，以团队可复现为准）。**三名 reviewer 的 Assignment 间该字段必须完全一致**；**@qa-engineer** 验证同一 feature 时 **复用同一 `plan_id` 与同一 `Review range` / `Diff basis`**。**热修 / QC 单审**路径也须含 **同一组字段**，仅承接方份数为 1。
+  - **`Review range` / `Diff basis`**：明确本次审查所针对的 **diff/提交范围**（例如 `merge-base: <target_branch-or-base-ref>` + `tip: HEAD`；或 `rev-range: <full-40>..<full-40>`；或一句 `equivalent to: git diff <merge-base>...HEAD`，以团队可复现为准）。**三名 reviewer 的 Assignment 间该字段必须完全一致**；**`qa-engineer`** 验证同一 feature 时 **复用同一 `plan_id` 与同一 `Review range` / `Diff basis`**。**热修 / QC 单审**路径也须含 **同一组字段**，仅承接方份数为 1。
 - **三审并行**时，三名 reviewer **共用同一组 `Review cwd` / `Worktree path` + `Working branch` + `plan_id` + `Review range` / `Diff basis`**（对业务仓只读分析）；**一般不必**为每位 reviewer 各开一个 worktree，除非宿主或执行环境要求进程级隔离。
 - QC 的 **报告落盘**仍仅限 `{PLAN_DIR}/reports/`；上述约定保证 `git diff`、`git log`、lint 与所读文件与 **待合并 feature** 一致。
-- **`@project-manager`** 分派 **`@qa-engineer`** 做 **本 feature 的验证**（跑测试、复现、可观察取证、或向业务仓提交测试/配置）时，须在 Assignment 中写明 **同一套** **`Review cwd` / `Worktree path`**、**`Working branch`**、**`plan_id`** 与 **`Review range` / `Diff basis`**（与 QC 三审 **逐字相同**；若 QC 已写清，QA **照抄**）。**@qa-engineer** 在执行业务仓命令前须核对当前目录与分支与 Assignment 一致；**Report-only**、且本轮 **不涉及** 业务仓内命令/路径依赖时，若 Assignment 未写 `Review cwd`，须在回报中说明验证所基于的检出或环境，缺失则 `Blocked` 并请 PM 补全。
+- **`project-manager`** 分派 **`qa-engineer`** 做 **本 feature 的验证**（跑测试、复现、可观察取证、或向业务仓提交测试/配置）时，须在 Assignment 中写明 **同一套** **`Review cwd` / `Worktree path`**、**`Working branch`**、**`plan_id`** 与 **`Review range` / `Diff basis`**（与 QC 三审 **逐字相同**；若 QC 已写清，QA **照抄**）。**`qa-engineer`** 在执行业务仓命令前须核对当前目录与分支与 Assignment 一致；**Report-only**、且本轮 **不涉及** 业务仓内命令/路径依赖时，若 Assignment 未写 `Review cwd`，须在回报中说明验证所基于的检出或环境，缺失则 `Blocked` 并请 PM 补全。
 - 若 **QA 与同仓其他可写角色并发**提交测试代码，仍须遵守上文「同仓并发写入」的 **worktree** 规则（可为 QA 单开一条写入 worktree，**同一 `Working branch`**，由 PM 在 Assignment 写明）。

--- a/skills/mstar-dispatch-gates/SKILL.md
+++ b/skills/mstar-dispatch-gates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-dispatch-gates
-description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent、`Execute as` 与 `Delegation`、承接方反递归 NEVER 红线、同条消息 N 次 invoke、QC 三审禁止串行 rollout、Assignment 文案≠派发（invoke 条数须对齐）、未齐不发（emit zero until batch-ready）。**必须**在 `@project-manager` 每轮派发、QC 三审并发、双轨 implement、或 leaf 角色疑惑能否 Task 时 Read；所有非 PM 承接方动手前必读反递归与自检。同仓 worktree 与 QC 检出对齐见 `mstar-branch-worktree`。宿主细则见 `mstar-host`（`references/parallel-dispatch.md` 与各宿主 reference）。
+description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent、`Execute as` 与 `Delegation`、承接方反递归 NEVER 红线、同条消息 N 次 invoke、QC 三审禁止串行 rollout、Assignment 文案≠派发（invoke 条数须对齐）、未齐不发（emit zero until batch-ready）。**必须**在 `project-manager` 每轮派发、QC 三审并发、双轨 implement、或 leaf 角色疑惑能否 Task 时 Read；所有非 PM 承接方动手前必读反递归与自检。同仓 worktree 与 QC 检出对齐见 `mstar-branch-worktree`。宿主细则见 `mstar-host`（`references/parallel-dispatch.md` 与各宿主 reference）。
 ---
 
 ## Load order（必读顺序）
@@ -21,10 +21,10 @@ description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent
 
 ## 承接方反递归红线（NEVER / DO NOT；leaf executor 必读）
 
-下列行为易触发递归误派；`@project-manager` 之外的角色一旦命中，须立即停止并改为本会话内可交付物，或 **`Blocked`** 回报 PM。**禁止**以「更高效」「Assignment 像 PM 编排」等理由绕开：
+下列行为易触发递归误派；`project-manager` 之外的角色一旦命中，须立即停止并改为本会话内可交付物，或 **`Blocked`** 回报 PM。**禁止**以「更高效」「Assignment 像 PM 编排」等理由绕开：
 
 - **NEVER** 在本会话内调用 Task / subagent，且其 `subagent_type` **等于**你当前的 **`Execute as`** 角色 id。
-- **NEVER** 把 Assignment 里出现的 **任何** `@<role>`、反引号 `` `<role-id>` ``、**Handoff**、**QA note**、**Completion Report** 模板里的角色名、路由表下游角色当成「立刻 invoke」的指令；这些是**叙事 / 路由文档 / 后续 PM 编排意图**，不是命令。
+- **NEVER** 把 Assignment 里出现的 **任何** plain `role-id` 提及、反引号 `` `<role-id>` ``、**Handoff**、**QA note**、**Completion Report** 模板里的角色名、路由表下游角色当成「立刻 invoke」的指令；这些是**叙事 / 路由文档 / 后续 PM 编排意图**，不是命令。
 - **NEVER** 把「分解为多个计划 / 多 phase / 多 track」等**设计产物层面**的并行或拆分读成「应 invoke 与子会话数量对应的多个 subagent」。**纸面产物**由本会话写盘完成；并行**调度**由 PM 在后续轮次决定。
 - **NEVER** 因宿主**暴露**了 `Task` 或若干 `subagent_type` 名称就推断可以调用。**工具可用 ≠ 授权使用**；授权只来自 **`Delegation: allowed (...)`**。
 - **NEVER**（非 PM）主动执行 parallel-agent dispatch 来分派子代理；需要并行时回报 PM。
@@ -42,12 +42,12 @@ description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent
 
 ## 调度防串扰（强制；leaf executor 已在上方读过反递归红线，此处为完整规则供 PM/对照用）
 
-- 只有 **`@project-manager`** 可以决定增加/并行 subagent；承接方**默认不得二次分派**。
+- 只有 **`project-manager`** 可以决定增加/并行 subagent；承接方**默认不得二次分派**。
 - **`Execute as: <role-id>`** = 承接方**亲自**完成本单，**不是**再起同名 subagent 或嵌套同 `subagent_type` 的 Task（禁止**递归误派**）。
 - 额外代理仅以 **`Delegation: allowed (...)`** 为准；未显式写时视为 **`Delegation: forbidden`**。
-- Assignment 正文中的 `@xxx` 默认按「文本引用」解释，**不**视为自动调用命令。
+- Assignment 正文中的 role 引用：默认 **plain id**（`product-manager`）；OpenCode 见 **`mstar-host/references/opencode.md`** § Role-mention hygiene。
 - 承接方若判断必须增加 subagent，应先回报 **`Blocked`** 请 PM 重分派。
-- Per-task informal review, when PM explicitly allows it, must not use `@qc-specialist*`; use `@general` / `generalPurpose` or PM-marked informal `@qa-engineer`. Formal QC remains `mstar-review-qc`.
+- Per-task informal review, when PM explicitly allows it, must not use `qc-specialist*`; use `generalPurpose` or PM-marked informal `qa-engineer`. Formal QC remains `mstar-review-qc`.
 
 ## 并发分派完整性门禁（PM 强制）
 

--- a/skills/mstar-dispatch-gates/references/leaf-executor-checklist.md
+++ b/skills/mstar-dispatch-gates/references/leaf-executor-checklist.md
@@ -14,7 +14,7 @@ Before any Task/subagent call (if I somehow forget the preamble):
 2. Does the Assignment include **`Delegation: allowed (...)`**? If no → **no** Task/subagent.
 3. Is my next step a Task/subagent invoke? If yes without (2) → **stop**; use Read/Write/Shell/Edit in-session or **`Blocked`**.
 4. Is `subagent_type` equal to my `Execute as`? If yes → **forbidden** (recursive dispatch).
-5. Am I treating `@roles`, Handoff, QA note, Completion Report roles, or multi-plan/multi-track **design text** as invoke commands? If yes → **stop**; deliver in-session.
+5. Am I treating plain `role-id` mentions, Handoff, QA note, Completion Report roles, or multi-plan/multi-track **design text** as invoke commands? If yes → **stop**; deliver in-session.
 6. Am I invoking because the tool exists? **Available ≠ authorized.**
 7. Need parallel work or PM-only dispatch? → **`Blocked`**; PM dispatches on the next round.
 

--- a/skills/mstar-harness-core/SKILL.md
+++ b/skills/mstar-harness-core/SKILL.md
@@ -108,7 +108,7 @@ Read **`mstar-host`** after this skill; detect host per its table, then Read the
 
 | 宿主 | 要点 |
 |------|------|
-| OpenCode | `question`、`@explore`、named-role invoke → `references/opencode.md` |
+| OpenCode | `question`、**task tool**（**subagent** 参数）→ `references/opencode.md` |
 | Cursor | Task 并行 QC；Plan 双写 → `references/cursor.md` · `cursor-plan-mode-bridge.md` |
 | Codex | plugin skills、sandbox/apply_patch/tool discovery；无 invoke 工具时不声称 subagent dispatch → `references/codex.md` |
 | 其它 | 同 `mstar-host` skill；按工具信号选 reference |
@@ -146,6 +146,7 @@ Read **`mstar-host`** after this skill; detect host per its table, then Read the
 | CreatePlan 不落盘 / 无 `{HARNESS_DIR}` mirror | `mstar-host` · `cursor-plan-mode-bridge` |
 | 临时方案 / 后续计划只写在对话里 | `mstar-phase-gates` · Durable Roadmap Gate |
 | Phase 1 review chain 未完成即 commit | `mstar-iteration` §1.6；PM 代做专业角色编辑；或三角色并行派发 |
+| OpenCode prompt 含多个 prefix-style role mention | `mstar-host/references/opencode.md` § Role-mention hygiene |
 | Phase 2 paste-only / PM 自实现 | `mstar-dispatch-gates` |
 | Phase 3 折叠进 final plan closure / 跳过 §3.1 gate | `mstar-iteration` §3.0–§3.5 |
 | Phase 4 开 PR 后跳过 merge-ready loop | `mstar-iteration` §5 |

--- a/skills/mstar-host/SKILL.md
+++ b/skills/mstar-host/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-host
-description: Morning Star host adapter (OpenCode, Cursor, Codex). Use after mstar-harness-core whenever host entry, clarify, dispatch, or plan UX differs by platform - OpenCode question/@agent-id invoke, Cursor /pm and CreatePlan/SwitchMode dual-write and Task parallel QC, Codex plugin skills plus Plan/Goal Mode, sandboxed tools, and tool discovery. Auto-detect host from session tools; then Read references/<host>.md. Always load after mstar-harness-core.
+description: Morning Star host adapter (OpenCode, Cursor, Codex). Use after mstar-harness-core whenever host entry, clarify, dispatch, or plan UX differs by platform - OpenCode question/task-tool subagent invoke, Cursor /pm and CreatePlan/SwitchMode dual-write and Task parallel QC, Codex plugin skills plus Plan/Goal Mode, sandboxed tools, and tool discovery. Auto-detect host from session tools; then Read references/<host>.md. Always load after mstar-harness-core.
 ---
 
 # Morning Star Host Adapter
@@ -28,7 +28,7 @@ Use **capability signals** (not filesystem paths):
 | Signal | Host | Next read |
 |--------|------|-----------|
 | **CreatePlan** / **SwitchMode** available | `cursor` | `references/cursor.md`; Plan mode also `references/cursor-plan-mode-bridge.md` |
-| **`question`** tool or PM **`@<agent-id>`** subagent invoke | `opencode` | `references/opencode.md` |
+| **`question`** tool or **`task`** tool (**subagent** invoke) | `opencode` | `references/opencode.md` |
 | **Task** + `subagent_type`, no CreatePlan | `cursor` | `references/cursor.md` |
 | **Codex app/CLI/plugin context**, `/plan`, `/goal`, Goal tools, `functions.*`, `codex_app.*`, `tool_search`, Browser plugin tools | `codex` | `references/codex.md`; Plan/Goal mode also `references/codex-plan-goal-mode-bridge.md` |
 | Still ambiguous | - | Read sections in **`cursor.md`**, **`opencode.md`**, and **`codex.md`** that match tools you have; **`mstar-harness-core` wins** on conflict |

--- a/skills/mstar-host/references/opencode.md
+++ b/skills/mstar-host/references/opencode.md
@@ -1,6 +1,6 @@
 # OpenCode host reference
 
-Load when **`mstar-host`** detection resolves **opencode** (`question` tool, `@<agent-id>` invoke, or OpenCode session).
+Load when **`mstar-host`** detection resolves **opencode** (`question` tool, **task tool** with **subagent** parameter, or OpenCode session).
 
 Parallel PM dispatch: **`parallel-dispatch.md`** (read in dispatch rounds).
 
@@ -12,23 +12,50 @@ Parallel PM dispatch: **`parallel-dispatch.md`** (read in dispatch rounds).
 
 ## OpenCode-specific capabilities
 
-- **Structured clarify**: prefer `question` tool (title, prompt, options, optional custom text). Requires `permission.question` in config (user-maintained; do not edit global config without consent).
-- **Built-in subagents**: `@explore` (read-only), `@general`; subject to `mstar-harness-core` explore boundaries.
-- **Named roles (`@<agent-id>`)**: configured in `opencode.json` `agent.<id>` must be **actually invoked** by PM. Assignment Markdown alone does not open sessions.
+- **Structured clarify**: prefer **`question`** tool (title, prompt, options, optional custom text). Requires `permission.question` in config (user-maintained; do not edit global config without consent).
+- **Built-in subagents** (via **task tool**): **explore** (read-only), **general**; subject to `mstar-harness-core` explore boundaries.
+- **Named role subagents**: Morning Star roles configured under `opencode.json` `agent.<id>` — PM must **call the task tool** with **`subagent`** set to that agent id. Assignment Markdown alone does not open subagent sessions.
 - **Per-role models**: configurable per subagent in `opencode.json`.
 
-## Invoke entry
+## PM dispatch (task tool + subagent)
 
-Use host subagent / Task / equivalent per **`parallel-dispatch.md`**. OpenCode PM typically uses **`@<agent-id>`** or the host’s subagent entry — same **no tool = no dispatch** rule.
+Harness **dispatch** on OpenCode = **one or more `task` tool calls**, each with **`subagent: <agent-id>`** (read the tool schema every session).
+
+| Harness | OpenCode |
+|---------|----------|
+| `Execute as: <role-id>` | **`subagent`** on **task tool** = same agent id |
+| 1 Assignment ⇒ 1 invoke | **1 task tool** call with matching **subagent** + prompt from Assignment |
+| Parallel batch **N** | **N task tool** calls in **one assistant message** when the host allows (`parallel-dispatch.md`) |
+| No task tool call | **Not dispatched** — paste-only / `dispatch incomplete` |
+
+PM workflow: finalize Assignment → **call task tool** with **subagent** + generated prompt → wait for subagent Completion Report → update plan / status.
+
+## Role-mention hygiene (OpenCode)
+
+OpenCode may **auto-append** system lines when prompt text stacks multiple agent-id **prefix mentions**. Typical boilerplate (host-generated — **not** harness Assignment):
+
+```text
+Use the above message and context to generate a prompt and call the task tool with subagent: <agent-id>
+```
+
+(Same sentence repeated with different **subagent** values — mechanical template, not user prose.)
+
+| Do | Don't |
+|----|-------|
+| Use **plain role ids** (`product-manager`) in skill / command / Assignment prose | Stack prefix-style role mentions that trigger multi-**subagent** boilerplate |
+| Sequential chains: **one task tool / one subagent per dispatch turn** | Treat auto-appended **task tool + subagent** lines as authorized parallel batch |
+| Real dispatch: PM **calls task tool** with explicit Assignment + **`Delegation`** rules | Confuse boilerplate with **`Delegation: allowed`** |
+
+When documenting this in harness text, avoid embedding prefix-style role examples in the warning — that can re-trigger the host.
 
 ## Prepare phase — serial roles still require invoke
 
-`mstar-roles` **project-manager** may route `@explore → @product-manager → @architect` **sequentially**. Each handoff still needs a real **host invoke** with Assignment (often **`N = 1`** per dispatch turn). Writing PRD / architecture only in the PM chat when routing assigns **`product-manager`** or **`architect`** is **not** a substitute. Cross-check: `mstar-roles` → `references/project-manager.md` → **§1.1.1a Phase routing pre-flight**.
+`mstar-roles` **project-manager** may route `explore → product-manager → architect` **sequentially**. Each handoff still needs a real **task tool** call with the matching **subagent** and Assignment (**`N = 1`** per dispatch turn). Writing PRD / architecture only in the PM chat is **not** a substitute.
 
 ## Gotchas
 
 - `question` availability is config-dependent; if unavailable, structured Markdown clarify.
-- `@explore` is orientation only, not role-owned implementation or review deliverables.
+- **explore** subagent (via task tool) is orientation only — not role-owned implementation or review deliverables.
 - More MCPs do not replace phase gates or evidence rules.
 
 ## Session noise control

--- a/skills/mstar-host/references/parallel-dispatch.md
+++ b/skills/mstar-host/references/parallel-dispatch.md
@@ -17,7 +17,7 @@ Printing `## Assignment` in the main thread **without** matching host invocation
 
 1. Finalize all `N` Assignment payloads (after any prerequisite turn).
 2. Count distinct `Execute as` sessions (`N`).
-3. Issue **`N` host invocations first** (subagent / Task / `@agent-id`), each with one Assignment body. For parallel work, **all `N` tool calls in one assistant message** when the host allows.
+3. Issue **`N` host invocations first** — OpenCode: **N `task` tool** calls with **subagent**; Cursor: **N `Task`** with `subagent_type`; each with one Assignment body. For parallel work, **all `N` tool calls in one assistant message** when the host allows.
 4. Optionally post a short **Status Update** after invocations (audit trail only — does not replace step 3).
 
 ## Hard rules

--- a/skills/mstar-iteration/SKILL.md
+++ b/skills/mstar-iteration/SKILL.md
@@ -159,10 +159,10 @@ compass frontmatter 的 `iteration_base_branch` / `target_branch` **必须与** 
 
 派发机制 → **`mstar-dispatch-gates`**（specialist review-and-edit dispatch，**顺序链**）。PM **不得**将迭代 harness 文档 commit 到 `spec_integration_branch`，直到：
 
-1. **@product-manager** → **@architect** → **@writing-specialist** 已按序通过宿主 invoke **直接编辑**（非仅评论）compass、plans 及受影响 specs；每一环基于上一环落盘修订
+1. **product-manager** → **architect** → **writing-specialist** 已按序通过宿主 invoke **直接编辑**（非仅评论）compass、plans 及受影响 specs；每一环基于上一环落盘修订
 2. PM 将 compass `status` 设为 `locked`，并确认各 plan 的 Prepare gate（specify / clarify / plan）
 
-**顺序理由**：产品范围与优先级 → 架构与契约 → 术语与行文；并行会导致后手重复劳动或覆盖前手未定稿内容。
+**顺序理由**：产品范围与优先级 → 架构与契约 → 术语与行文；并行会导致后手重复劳动或覆盖前手未定稿内容。OpenCode：plain role id — **`mstar-host/references/opencode.md`** § Role-mention hygiene。
 
 **完成证据** = 磁盘上的 compass / plans / specs 修订 + compass `status: locked`。**不**要求 `reports/<iteration-id>/` 审查报告——迭代审查的 SSOT 是被编辑的文档本身，无 per-plan QC 式审计链。
 

--- a/skills/mstar-plan-artifacts/references/plan-files-and-reports.md
+++ b/skills/mstar-plan-artifacts/references/plan-files-and-reports.md
@@ -27,14 +27,14 @@
 
 - **Open 条目的单一事实来源（SSOT）**是 **`{HARNESS_DIR}/status.json`** 根级 **`residual_findings[<plan-id>]`**（与 `plans` 平级；canonical 见 `mstar-plan-artifacts` **SKILL.md** 开篇；字段见 `mstar-plan-artifacts/references/status-and-residuals.md`）。跨会话 handoff、关闭与归档流程**以该数组为准**。
 - **推荐操作顺序**（避免 plan 与 JSON 两套 ID 漂移）：
-  1. `@project-manager` 读完三份 QC 报告并完成「QC 三审轻量汇总」：对 finding **去重合并**，为每条待跟踪项分配**稳定 `id`**（如 `R1`、`R2`，全 plan 内唯一）。
+  1. `project-manager` 读完三份 QC 报告并完成「QC 三审轻量汇总」：对 finding **去重合并**，为每条待跟踪项分配**稳定 `id`**（如 `R1`、`R2`，全 plan 内唯一）。
   2. **立即**将上述条目写入根级 **`residual_findings[<plan-id>]`**（含 `source` 指向哪位 QC / 哪份报告文件名，便于回溯）；**勿**与 legacy 侧双写（见 `mstar-plan-conventions` **SKILL.md** 开篇）。
   3. **可选**：在主 plan 中增加 **「Residual findings（索引）」** 小节，**仅复述** `id` + 短标题 + 决策摘要，并写明「**权威列表见** `status.json` 根级 `residual_findings[<plan-id>]`（见 `mstar-plan-conventions` **SKILL.md** 开篇）」。**不要**只在主 plan 里「发明」R# 而不写回 SSOT。
 - **不要**反过来把主 plan 当作唯一登记处：若仅更新 plan、`status.json` 未同步，下一任 agent **无法**依赖 SSOT 继承债务状态。
 
 ## QC 三审触发时机（单 plan · 多 batch）
 
-- **默认（推荐）**：同一 **`plan_id`** 下，**完整 QC 三审**（`qc1` + `qc2` + `qc3` 并行）**仅在 dev team 按该 plan 约定范围全部交付之后**执行**一次**，再进入 `@project-manager` 汇总与 `@qa-engineer` 验证。**不要**在每个中间 **batch** / 子里程碑都跑全套三审：否则 `reports/<plan-id>/` 会堆积多套并列报告，**`Review range` / `Diff basis` 与结论**易混淆，handoff 成本高。
+- **默认（推荐）**：同一 **`plan_id`** 下，**完整 QC 三审**（`qc1` + `qc2` + `qc3` 并行）**仅在 dev team 按该 plan 约定范围全部交付之后**执行**一次**，再进入 `project-manager` 汇总与 `qa-engineer` 验证。**不要**在每个中间 **batch** / 子里程碑都跑全套三审：否则 `reports/<plan-id>/` 会堆积多套并列报告，**`Review range` / `Diff basis` 与结论**易混淆，handoff 成本高。
 - **batch 之间**：依赖实现方按 **`mstar-coding-behavior`** 提供完成证据、主 plan 任务勾选与 PM 协调；需要书面中间意见时，用对话、主 plan 批注或**非三审**的定向检查（如单审、架构 review），**不**默认等同「又一轮完整三审」。
 - **After `Request Changes` (default — targeted re-review)**：PM maps each **blocking** finding to the QC seat that raised it (`source` on R#, consolidated table, or the originating `qcN.md` / `F-###`). Dispatch **only** those reviewers (`QC re-review: targeted — reviewers: qc-specialist, qc-specialist-2, …`). Each re-reviewing QC **updates the same** `qc1.md` / `qc2.md` / `qc3.md` in place (add `## Revalidation`, refresh verdict / `generated_at`); **do not** add `qc1-rev2.md` siblings on this path. PM **updates the same** `qc-consolidated.md` in place. Git history is the audit trail.
 - **Full tri re-review (exception)**：Only when Assignment states **`QC re-review: full tri-review`**. Run **three** parallel reviews again; use **new basenames** (`qc1-rev2.md` … `qc3-rev2.md`, `qc-consolidated-rev2.md`) so wave-1 files stay immutable; PM states **active wave** in consolidated decision. See `mstar-review-qc` · `mstar-dispatch-gates`.
@@ -47,17 +47,17 @@
 - **并行 vs 串行**：不同 `plan_id` **相互独立**时，可 **并行**派发多组三审（每组各自的 Assignment 与 `reports/<plan-id>/`）；若 PM 选择串行，须在 Status Update 写明顺序——**每组仍须完整三审 + QA**，不是「一个大 QC」混审。
 - **读 skill**：书写或派发 QC 相关 Assignment 前，PM **必须** Read **`mstar-review-qc`** skill（`mstar-plan-conventions` 不重复 QC 清单与 verdict 规则）。见 `mstar-plan-conventions` SKILL.md **QC pre-dispatch gate** 与 **InReview 与 QC+QA** 小节。
 
-**QC 落盘与宿主权限**：`@qc-specialist` / `@qc-specialist-2` / `@qc-specialist-3` 在支持路径白名单的宿主上（如 OpenCode 的 **`permission.edit`**），**仅可** Write/Edit **`{PLAN_DIR}/reports/`** 下 **`.md`**（全局 agent 提示词中已配置 `.mstar/plans/reports/**`、`.agents/plans/reports/**`、`.plans/reports/**`、`plans/reports/**` 相对路径）。报告文件**必须**以 YAML **frontmatter** 开头（键见各 QC agent 提示词）。**若** 项目的 `{PLAN_DIR}` 不落在上述根下，须在**项目级**宿主配置（如 OpenCode）中为 QC 角色追加对应的 `edit` allow 规则。
+**QC 落盘与宿主权限**：`qc-specialist` / `qc-specialist-2` / `qc-specialist-3` 在支持路径白名单的宿主上（如 OpenCode 的 **`permission.edit`**），**仅可** Write/Edit **`{PLAN_DIR}/reports/`** 下 **`.md`**（全局 agent 提示词中已配置 `.mstar/plans/reports/**`、`.agents/plans/reports/**`、`.plans/reports/**`、`plans/reports/**` 相对路径）。报告文件**必须**以 YAML **frontmatter** 开头（键见各 QC agent 提示词）。**若** 项目的 `{PLAN_DIR}` 不落在上述根下，须在**项目级**宿主配置（如 OpenCode）中为 QC 角色追加对应的 `edit` allow 规则。
 
 **QC 报告与 Git**：报告落盘后，各 QC 角色须在业务仓内对**本次报告文件**执行 **`git add` + `git commit`**（细则与 bash 权限见 `agents/qc-specialist*.md`）；**禁止**仅落盘不提交导致 `clone` 后不可见。**PM / architect / product-manager** 对 **`{HARNESS_DIR}`** / **`{PLAN_DIR}`** 与主 plan 的创建与更新亦须在业务仓内 **commit**（见 `agents/project-manager.md` Plan 初始化与 PM 职责、`agents/architect.md` / `agents/product-manager.md` Git 小节）。
 
 ## 主 plan 内任务清单（Markdown checkbox）
 
-- **谁应更新**：`@fullstack-dev` / `@frontend-dev` / `@fullstack-dev-2`、`@qa-engineer`、`@ops-engineer`、`@architect`、`@product-manager` 在**完成本人 Assignment 范围内的工作后**，须在主 plan（`<plan-id>-<plan-name>.md`）中把**对应条目**的 Markdown 任务标记为已完成（常见：`- [ ]` → `- [x]`；若项目用其它清单记号，保持同文件内一致）。与 Completion Report **并列**，作为跨会话可核对的**落盘痕迹**。
+- **谁应更新**：`fullstack-dev` / `frontend-dev` / `fullstack-dev-2`、`qa-engineer`、`ops-engineer`、`architect`、`product-manager` 在**完成本人 Assignment 范围内的工作后**，须在主 plan（`<plan-id>-<plan-name>.md`）中把**对应条目**的 Markdown 任务标记为已完成（常见：`- [ ]` → `- [x]`；若项目用其它清单记号，保持同文件内一致）。与 Completion Report **并列**，作为跨会话可核对的**落盘痕迹**。
 - **范围**：**只勾选与当前任务直接对应、且已由本角色交付证据支撑的条目**；不得代为勾选他人负责或未完工项。若正文用分段、Owner 或角色标签区分任务，以 Assignment 与文内约定为准。
-- **与 `status.json` / frontmatter 的关系**：勾选任务**不**等于整条计划收口。`plans[].status` 及主 plan frontmatter 的 **`Done`** 仍**仅** `@project-manager` / `@qa-engineer`（见「状态更新权限」）。`@architect` / `@product-manager` **不得**擅自将整条计划标为 `Done`；是否将 `status.json` 推进为 `InReview` 等仍按下文「状态更新权限」与 Assignment。
-- **`@qc-specialist*`**：**不得**修改主 plan（宿主仅允许 `{PLAN_DIR}/reports/**/*.md`）；审查结论落在 `reports/<plan-id>/` 内。若主 plan 需新增或勾选与审查相关的条目，由 `@project-manager` 或 Assignment 明确授权的角色据报告回写。
-- **只读角色**：不直接改主 plan；将建议交给 `@project-manager` 代为更新清单。
+- **与 `status.json` / frontmatter 的关系**：勾选任务**不**等于整条计划收口。`plans[].status` 及主 plan frontmatter 的 **`Done`** 仍**仅** `project-manager` / `qa-engineer`（见「状态更新权限」）。`architect` / `product-manager` **不得**擅自将整条计划标为 `Done`；是否将 `status.json` 推进为 `InReview` 等仍按下文「状态更新权限」与 Assignment。
+- **`qc-specialist*`**：**不得**修改主 plan（宿主仅允许 `{PLAN_DIR}/reports/**/*.md`）；审查结论落在 `reports/<plan-id>/` 内。若主 plan 需新增或勾选与审查相关的条目，由 `project-manager` 或 Assignment 明确授权的角色据报告回写。
+- **只读角色**：不直接改主 plan；将建议交给 `project-manager` 代为更新清单。
 
 Plan 正文与 `status.json` 必须保持一致；不一致时以 `status.json` 的条目状态为准并尽快纠正正文或登记 notes。
 

--- a/skills/mstar-roles/references/architect.md
+++ b/skills/mstar-roles/references/architect.md
@@ -26,7 +26,7 @@ You are the architecture role and technical-spec writer. You are dispatched by `
 If any item below matches, **stop** and return `Blocked` to `project-manager` instead of inventing delegation:
 
 - **NEVER** treat document-level parallelism (“split into N plans”, “Plan 002–010”, “Phase X ∥ Phase Y”, “N parallel tracks”) as permission to **invoke N subagents** in this session. The **plan/spec/ADR artifacts** are your deliverable; **scheduling** parallel execution is **PM’s next round**, not part of this assignment unless `Delegation: allowed (...)` explicitly lists callees.
-- **NEVER** treat `Handoff: @project-manager / @fullstack-dev / @qa-engineer …`, role names inside Completion Report templates, routing tables, or “suggested owner” groupings as **host invoke commands**; they are **narrative**, not authorization.
+- **NEVER** treat `Handoff: project-manager / fullstack-dev / qa-engineer …`, role names inside Completion Report templates, routing tables, or “suggested owner” groupings as **host invoke commands**; they are **narrative**, not authorization.
 - **NEVER** infer you may call `Task` / subagents because the host **lists** `subagent_type` names (`architect`, `fullstack-dev`, …). **Tool availability ≠ delegation authorization**; only **`Delegation: allowed (...)`** grants callees.
 - **NEVER** execute parallel-agent dispatch yourself to fan out child agents; dispatch is **PM-orchestration-only** (see `mstar-dispatch-gates`). If parallel runners are needed, report to PM for re-dispatch.
 - **NEVER** treat `Gate Decision: blocked` (material, high-impact ambiguities still open) as permission to hand off “ready for implement” architecture—finish clarify, update the package, or return `Blocked` to PM.

--- a/skills/mstar-roles/references/frontend-dev.md
+++ b/skills/mstar-roles/references/frontend-dev.md
@@ -26,7 +26,7 @@ You are dispatched by `project-manager` and report back with completion evidence
 If any item below matches, **stop** and return `Blocked` to `project-manager` instead of inventing delegation:
 
 - **NEVER** invoke `frontend-dev`, `fullstack-dev`, `fullstack-dev-2`, or other roles to perform **this** assignment unless `Delegation: allowed (...)` explicitly lists them.
-- **NEVER** offload UI implementation, tests, or evidence to `@explore`; use glob/grep/read first—short read-only `@explore` only per `mstar-harness-core` explore boundaries.
+- **NEVER** offload UI implementation, tests, or evidence to `explore`; use glob/grep/read first—short read-only `explore` only per `mstar-harness-core` explore boundaries.
 - **NEVER** treat `Handoff` lines, route arrows, Completion Report role lists, or routing prose as **invoke instructions**; they are narrative unless `Delegation: allowed` says otherwise.
 - **NEVER** run parallel-agent dispatch as an implementer; this is **PM-only** (`mstar-dispatch-gates`).
 - **NEVER** self-decide branch pivots (including switching to `main`/`master`) beyond PM’s `Working branch` / `Branch policy`; conflicting or missing branch facts => `Blocked` to PM.

--- a/skills/mstar-roles/references/fullstack-dev-shared.md
+++ b/skills/mstar-roles/references/fullstack-dev-shared.md
@@ -38,7 +38,7 @@ Siblings for anti-recursion checks: `fullstack-dev`, `fullstack-dev-2`, `fronten
 If any item below matches, **stop** and return `Blocked` to `project-manager` instead of inventing delegation:
 
 - **NEVER** invoke `fullstack-dev`, `fullstack-dev-2`, `frontend-dev`, or other roles to perform **this** assignment body unless `Delegation: allowed (...)` explicitly lists them.
-- **NEVER** offload implementation, tests, or evidence to `@explore`; use glob/grep/read first—short read-only `@explore` only per `mstar-harness-core` explore boundaries.
+- **NEVER** offload implementation, tests, or evidence to `explore`; use glob/grep/read first—short read-only `explore` only per `mstar-harness-core` explore boundaries.
 - **NEVER** treat `Handoff` lines, route arrows, Completion Report role lists, or routing prose as **invoke instructions**; they are narrative unless `Delegation: allowed` says otherwise.
 - **NEVER** run parallel-agent dispatch as an implementer; this is **PM-only** (`mstar-dispatch-gates`).
 - **NEVER** self-decide branch pivots beyond PM’s `Working branch` / `Branch policy`; if `<base>` is missing or the working tree disagrees with the assignment, **Blocked** to PM.

--- a/skills/mstar-roles/references/ops-engineer.md
+++ b/skills/mstar-roles/references/ops-engineer.md
@@ -30,7 +30,7 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 - **NEVER** treat `Handoff` lines, template role names, or routing tables as **invoke commands**; only `Delegation: allowed` authorizes callees.
 - **NEVER** infer tool exposure (`Task`, subagent menus) implies authorization; **tool availability ≠ delegation**.
 - **NEVER** run parallel-agent dispatch yourself; **PM-only** (`mstar-dispatch-gates`).
-- **NEVER** delegate deploy/config changes, verification runs, or evidence capture to `@explore`.
+- **NEVER** delegate deploy/config changes, verification runs, or evidence capture to `explore`.
 
 ## Responsibilities
 

--- a/skills/mstar-roles/references/product-manager.md
+++ b/skills/mstar-roles/references/product-manager.md
@@ -31,7 +31,7 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 - **NEVER** infer you may call subagents because the host lists `subagent_type` names; **tool availability ≠ authorization**.
 - **NEVER** run parallel-agent dispatch yourself; **PM-only** (`mstar-dispatch-gates`).
 - **NEVER** point planning output to external default plan directories; use `{PLAN_DIR}` per `mstar-plan-conventions`.
-- **NEVER** offload PRD/product-doc drafting to `@explore`; short read-only orientation only per `mstar-harness-core`.
+- **NEVER** offload PRD/product-doc drafting to `explore`; short read-only orientation only per `mstar-harness-core`.
 - **NEVER** label a Prepare package as “ready for implement” while `Gate Decision: blocked` for material ambiguities—resolve, document waivers with PM, or return `Blocked`.
 - **NEVER** split delivery by saying “later / follow-up / next phase” without writing the product roadmap, deferred scope, and final completion definition in the assigned plan/spec.
 

--- a/skills/mstar-roles/references/project-manager.md
+++ b/skills/mstar-roles/references/project-manager.md
@@ -56,18 +56,18 @@ Pick one `Primary` route per Assignment; attach additional gates as needed.
 
 | Task type | Default route |
 | --- | --- |
-| Large feature | `@explore -> @product-manager -> @architect -> dev -> QC tri-review -> @qa-engineer -> @ops-engineer` |
-| Medium feature | `@explore -> (@architect optional) -> dev -> QC tri-review -> @qa-engineer` |
-| Small feature | `dev -> QC tri-review -> @qa-engineer` |
-| Bug fix | `@explore -> RCA brief -> dev -> QC tri-review -> @qa-engineer` |
-| High-ambiguity bug | `@explore -> RCA -> (@architect optional) -> dev -> QC tri-review -> @qa-engineer` |
-| Hotfix | `single dev -> QC single-review -> @qa-engineer fast verify` |
-| Product docs only | `@product-manager` (QC may be skipped with explicit reason) |
-| Tech spec only | `@architect` (QC may be skipped with explicit reason) |
-| Prompt/rules/skills | `@prompt-engineer` |
-| Market/user research | `@product-manager` |
-| QA report-only | `@qa-engineer` (`QA mode: report-only`) |
-| High-risk ops | `@ops-engineer` (+QC/QA by risk) |
+| Large feature | `explore -> product-manager -> architect -> dev -> QC tri-review -> qa-engineer -> ops-engineer` |
+| Medium feature | `explore -> (architect optional) -> dev -> QC tri-review -> qa-engineer` |
+| Small feature | `dev -> QC tri-review -> qa-engineer` |
+| Bug fix | `explore -> RCA brief -> dev -> QC tri-review -> qa-engineer` |
+| High-ambiguity bug | `explore -> RCA -> (architect optional) -> dev -> QC tri-review -> qa-engineer` |
+| Hotfix | `single dev -> QC single-review -> qa-engineer fast verify` |
+| Product docs only | `product-manager` (QC may be skipped with explicit reason) |
+| Tech spec only | `architect` (QC may be skipped with explicit reason) |
+| Prompt/rules/skills | `prompt-engineer` |
+| Market/user research | `product-manager` |
+| QA report-only | `qa-engineer` (`QA mode: report-only`) |
+| High-risk ops | `ops-engineer` (+QC/QA by risk) |
 
 Detailed conflict priority and dev allocation:
 `references/project-manager/routing-and-dev-allocation.md`.
@@ -82,7 +82,7 @@ Detailed conflict priority and dev allocation:
 - Runtime/behavior change requires QA by default.
 - Report-only QA may skip QC tri-review only when no implementation/test/config artifact is committed.
 - Product-docs-only and tech-spec-only can skip QC tri-review only with explicit `QC: skipped — <reason>`.
-- Plan `Done` sign-off authority: `@project-manager` or `@qa-engineer` only.
+- Plan `Done` sign-off authority: `project-manager` or `qa-engineer` only.
 
 ---
 
@@ -113,7 +113,7 @@ If any item below matches, fix the dispatch/plan state or mark `Blocked`—do **
 - **NEVER** use `Task category: quick` to skip mandatory Prepare (`specify → clarify → plan`) for substantive work (`mstar-harness-core` hard rule).
 - **NEVER** omit native dispatch/worktree fields when the batch truly requires parallel dev (`Dispatch mode: parallel independent tracks`) or same-repo multi-writer concurrency (`Worktree isolation: required`) per `mstar-dispatch-gates` and `mstar-branch-worktree`.
 - **NEVER** point QC at a single dev worktree/`Review cwd` that cannot contain **all** claimed changes from parallel tracks until Git integration lands on one `Working branch` `HEAD` (`mstar-branch-worktree` QC/QA alignment).
-- **NEVER** label `QA: skipped` for report-only QA—still dispatch `@qa-engineer` with report-only mode; QC skip rules are separate and explicit.
+- **NEVER** label `QA: skipped` for report-only QA—still dispatch `qa-engineer` with report-only mode; QC skip rules are separate and explicit.
 - **NEVER** let non-PM/non-QA roles mark plan `Done`.
 - **NEVER** accept “temporary workaround”, “follow-up later”, “next plan”, or “split into batches” as narrative-only scope management. If work is deferred or staged, write the roadmap/tracking location before implement GO or Done.
 - **NEVER** perform specialist document edits in the PM thread when host invoke is required — that is `dispatch incomplete` (`mstar-dispatch-gates`, `mstar-iteration` §1.6).
@@ -147,7 +147,7 @@ Use short go/no-go checks before moving phases:
 
 - Do not duplicate full route table in each phase note.
 - "Plan directory maintenance" means indexing/progression, not specialist content authoring.
-- If artifact body belongs to `@product-manager`/`@architect`, delegation is required unless explicit waiver.
+- If artifact body belongs to `product-manager`/`architect`, delegation is required unless explicit waiver.
 
 ### Pre-flight checks
 
@@ -275,7 +275,7 @@ Minimum invariants:
 - User conversation follows user language.
 - PM Assignment body can be Chinese by default.
 - Technical artifacts/reports/code/config/commit messages default to English unless user asks otherwise.
-- Keep `Execute as` as plain role ID (no `@`) in Assignment body.
+- Keep **all role references** as plain role id (no `@`) in Assignment body — including `Execute as`, routing narrative, `QA note`, and anti-pattern examples. Host invoke uses task tool `subagent` matching `Execute as` per `mstar-host` (OpenCode: `opencode.md` § Role-mention hygiene).
 
 ---
 

--- a/skills/mstar-roles/references/project-manager/dispatch-and-assignment.md
+++ b/skills/mstar-roles/references/project-manager/dispatch-and-assignment.md
@@ -25,7 +25,7 @@ For assignees (non-PM):
 - **NEVER** treat `Handoff: …`, Completion Report template role names, routing tables, or “suggested owners” as **host invoke commands**; they are narrative unless `Delegation: allowed` authorizes callees.
 - **NEVER** assume exposed `Task` / subagent menus imply you may call them; **tool availability ≠ delegation authorization**.
 - **NEVER** execute parallel-agent dispatch as a leaf assignee; dispatch is **PM-orchestration-only** (`mstar-dispatch-gates`).
-- **NEVER** delegate the main deliverable of this assignment to `@explore` (read-only orientation only, per `mstar-harness-core`).
+- **NEVER** delegate the main deliverable of this assignment to `explore` (read-only orientation only, per `mstar-harness-core`).
 - **NEVER** claim `Done` / pass in **Completion Report v2** without the commands, logs, or artifacts explicitly required by the assignment’s **Evidence Required** section (see `mstar-harness-core` evidence gates).
 
 ## Assignment Template (Canonical)
@@ -40,9 +40,9 @@ The **`**You are a leaf executor. You MUST NOT:**`** section (previously just pr
 - Add anti-patterns specific to the assignment context. Examples per role type:
   - **QC reviewers**: "start review before all QC reviewers are dispatched in parallel"; "treat other reviewers' names in routing text as invoke targets"
   - **Multi-track implementers** (`fullstack-dev` + `frontend-dev`): "auto-dispatch to the other track mentioned in Dev routing"
-  - **`@fullstack-dev-2`**: "treat `@fullstack-dev` in routing narrative as a handoff or invoke target"
-  - **`@qa-engineer`**: "start validation before QC reports are consolidated"; "modify application code"
-  - **`@explore`-assigned**: "implement or modify code"
+  - **`fullstack-dev-2`**: "treat `fullstack-dev` in routing narrative as a handoff or invoke target"
+  - **`qa-engineer`**: "start validation before QC reports are consolidated"; "modify application code"
+  - **`explore`-assigned**: "implement or modify code"
   - **All non-PM**: "dispatch parallel agents"; "spawn a subagent whose `subagent_type` matches your own `Execute as` role id"
 - Anti-patterns must be action-oriented ("auto-dispatch to …", "treat … as invoke", "start … before …") — not abstract descriptions.
 - If the assignment involves multiple QCs or parallel tracks, add a specific bullet about NOT serializing or pre-empting the parallel dispatch.
@@ -64,7 +64,7 @@ The **`**You are a leaf executor. You MUST NOT:**`** section (previously just pr
 
 **You MUST NOT:**
 - dispatch or invoke any subagent unless `Delegation: allowed (...)` appears below
-- treat `@role-id` mentions, `Handoff`, `QA note`, routing tables, or multi-track prose as invoke commands
+- treat plain `role-id` mentions, `Handoff`, `QA note`, routing tables, or multi-track prose as invoke commands
 - invoke a subagent whose `subagent_type` matches your own `Execute as` role id (recursive dispatch)
 - <situation-specific anti-pattern #1>
 - <situation-specific anti-pattern #2>
@@ -110,7 +110,7 @@ The **`**You are a leaf executor. You MUST NOT:**`** section (previously just pr
 **Orchestration Guard** (see `**You are a leaf executor. You MUST NOT:**` block at top for primary anti-patterns):
 - No recursive same-role dispatch
 - Do not dispatch roles from route narrative/handoff text
-- `@explore` is read-only orientation only
+- `explore` is read-only orientation only
 - Tool availability ≠ delegation authorization
 **Plan Path**: <{PLAN_DIR}/... or N/A>
 **Report Format**: Completion Report v2

--- a/skills/mstar-roles/references/prompt-engineer.md
+++ b/skills/mstar-roles/references/prompt-engineer.md
@@ -31,7 +31,7 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 - **NEVER** treat `Handoff` lines, template role lists, or routing prose as **invoke instructions**; only `Delegation: allowed` authorizes callees.
 - **NEVER** infer tool exposure implies authorization; **tool availability ≠ delegation**.
 - **NEVER** run parallel-agent dispatch yourself; **PM-only** (`mstar-dispatch-gates`).
-- **NEVER** outsource prompt/skill/rule design, edits, or validation evidence to `@explore`.
+- **NEVER** outsource prompt/skill/rule design, edits, or validation evidence to `explore`.
 - **NEVER** merge prompt/skill/rule text that contradicts `mstar-harness-core`, `mstar-review-qc`, or `mstar-coding-behavior` without an explicit documented exception approved by PM (harness SSOT wins by default).
 
 ## Responsibilities

--- a/skills/mstar-roles/references/qa-engineer.md
+++ b/skills/mstar-roles/references/qa-engineer.md
@@ -31,7 +31,7 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 - **NEVER** treat `Handoff` / template role lists / route arrows as invoke instructions; only `Delegation: allowed` authorizes callees.
 - **NEVER** infer tool exposure implies authorization; **tool availability ≠ delegation**.
 - **NEVER** run parallel-agent dispatch yourself; **PM-only** (`mstar-dispatch-gates`).
-- **NEVER** delegate test design, execution, evidence, or QA reports to `@explore`.
+- **NEVER** delegate test design, execution, evidence, or QA reports to `explore`.
 - **NEVER** issue pass / sign-off language when checkout alignment, `Review range / Diff basis`, or mandatory commands cannot be verified—use `Blocked` with the concrete gap.
 
 ## Core QA Gate Duties

--- a/skills/mstar-roles/references/qc-specialist-shared.md
+++ b/skills/mstar-roles/references/qc-specialist-shared.md
@@ -50,7 +50,7 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 - **NEVER** treat `Handoff` lines, template role lists, or routing prose as invoke instructions; only `Delegation: allowed` authorizes callees.
 - **NEVER** infer tool exposure implies authorization; **tool availability ≠ delegation**.
 - **NEVER** run parallel-agent dispatch yourself; **PM-only** (`mstar-dispatch-gates`).
-- **NEVER** outsource review steps, verdict rationale, checklist execution, or report drafting to `@explore`.
+- **NEVER** outsource review steps, verdict rationale, checklist execution, or report drafting to `explore`.
 
 ## Review Context Gate (Hard)
 

--- a/skills/mstar-roles/references/writing-specialist.md
+++ b/skills/mstar-roles/references/writing-specialist.md
@@ -26,7 +26,7 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 - **NEVER** treat `Handoff` lines, template role lists, or routing prose as **invoke instructions**; only `Delegation: allowed` authorizes callees.
 - **NEVER** infer tool exposure implies authorization; **tool availability ≠ delegation**.
 - **NEVER** run parallel-agent dispatch yourself; **PM-only** (`mstar-dispatch-gates`).
-- **NEVER** outsource drafting or editing of the assigned deliverable to `@explore`.
+- **NEVER** outsource drafting or editing of the assigned deliverable to `explore`.
 - **NEVER** mark plan items or harness `status.json` fields implying `Done` for the overall plan—writing-only scope; PM/QA own closure.
 
 ## Responsibilities

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -12,7 +12,7 @@ description: "Morning Star PM orchestration entry. On Cursor/Codex, /pm launches
 | Host | Entry | PM role |
 | --- | --- | --- |
 | **Cursor / Codex** | User invokes **`/pm`** (or explicit "run as PM") | Force **`project-manager`** for the session |
-| **OpenCode** | User may already be on a configured agent | **If active role ≠ `project-manager`**: operate **only** as PM — load `mstar-roles` → `references/project-manager.md`; do **not** stay in dev/QC/architect voice for orchestration. Named invokes still use `@<agent-id>` per Assignment |
+| **OpenCode** | User may already be on a configured agent | **If active role ≠ `project-manager`**: operate **only** as PM — load `mstar-roles` → `references/project-manager.md`; do **not** stay in dev/QC/architect voice for orchestration. Host invoke: task tool **`subagent`** matching Assignment `Execute as` (see `mstar-host` → `opencode.md`); Assignment body uses **plain role ids** |
 
 Detect host → Read `mstar-host` → `references/cursor.md` | `opencode.md` | `codex.md`.
 
@@ -32,7 +32,7 @@ Prepare/Execute gates, routing, Assignment templates, Task Board, QC tri-review,
 | Do | Don't |
 | --- | --- |
 | **Loop:** `## Assignment` → invoke → Completion Report v2 → report-to-status → next batch | Parent **Write/Edit/Shell** on product code to "move faster" |
-| **1 Assignment ⇒ 1 invoke** when host supports Task/@agent (`mstar-dispatch-gates`) | Assignment markdown only, no matching invoke |
+| **1 Assignment ⇒ 1 invoke** when host supports Task/subagent (`mstar-dispatch-gates`) | Assignment markdown only, no matching invoke |
 | Put merge/branch/handoff from **this thread** into Assignment | Skip subagent because context is "already here" |
 
 - **NEVER** implement while staying PM — QC 3× comes later; **implement still delegates** dev roles.


### PR DESCRIPTION
## Summary
- Replace decorative `@role` mentions with plain role ids across Assignment SSOT (PM templates, routing table, dispatch gates, branch-worktree fields, iteration commands, and role NEVER rules).
- Document OpenCode host hygiene: Assignment prose uses plain ids; actual dispatch uses task tool `subagent` matching `Execute as`.
- Reduce accidental OpenCode auto-dispatch triggered by `@` literals in harness warning and template text.

## Test plan
- [x] Read `dispatch-and-assignment.md` template and confirm no `@` in Assignment body examples
- [x] Verify `project-manager.md` routing table uses plain role ids
- [x] Confirm `opencode.md` § Role-mention hygiene aligns with PM Language rule
- [x] Spot-check iteration-start / iteration-drive PM invariant tables for plain ids


Made with [Cursor](https://cursor.com)