### PR TITLE
release: harness 1.0.1 — SDD iteration-drive, sticky implementer, pm shim

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor/LOCAL-VALIDATION.md
+++ b/.cursor/LOCAL-VALIDATION.md
@@ -44,7 +44,7 @@ git rev-parse HEAD | xargs -I{} skills/mstar-sdd/scripts/review-package {} {}
 
 - Confirm outputs land under `{SDD_DIR}` printed by `sdd-workspace` (default `.mstar/sdd/<plan-id>/`).
 - `git status` must **not** list `{HARNESS_DIR}/sdd/` scratch files (directory should be gitignored).
-- PM-style routing: **`Execution mode: sdd`** → plan QC **N=3** tri + branch review-package; **`inline`/hotfix** → **N=1** `qc.md`. SDD implement/reviewer dispatches are **serial**.
+- PM-style routing: **`Execution mode: sdd`** → plan QC **N=3** tri + branch review-package; **`inline`/hotfix** → **N=1** `qc.md`. SDD implement/reviewer dispatches are **serial**. Optional **`SDD implementer session: sticky`** (Cursor Task `resume`) — reviewers stay **fresh** per task (`mstar-sdd/references/sticky-implementer-session.md`).
 
 ## 4) Packaging guardrails
 

--- a/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
+++ b/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
@@ -1,6 +1,6 @@
 {
   "harness_name": "pm-routing-evals",
-  "version": 12,
+  "version": 14,
   "updated_at": "2026-07-07",
   "cases": [
     {
@@ -475,7 +475,11 @@
       "must_have_artifacts": [
         "Context Loaded declaration",
         "mstar-iteration Phase 2 context",
+        "mstar-sdd loaded before first implement dispatch",
         "Execution mode: sdd or QC mode: full tri-review on Assignment",
+        "serial implementer then task reviewer per task",
+        "SDD dir path and task-N-brief.md handoffs",
+        "progress.md ledger",
         "three QC invokes N=3 in one dispatch turn",
         "qc1.md qc2.md qc3.md",
         "qc-consolidated.md",
@@ -486,6 +490,8 @@
         "single qc-specialist only in iteration Phase 2 per-plan loop without user override",
         "QC without MERGE_BASE..HEAD review-package",
         "tri-review split across multiple dispatch messages",
+        "bulk inline implement Assignment with full plan or T1-Tn pasted for multi-task plan",
+        "parallel SDD implementer dispatches",
         "assignment uses non-English field keys"
       ]
     },
@@ -508,6 +514,35 @@
         "missing Context Loaded declaration",
         "only one qc-specialist when Assignment requires full tri-review",
         "tri-review without Execution mode: sdd or explicit QC mode: full tri-review",
+        "assignment uses non-English field keys"
+      ]
+    },
+    {
+      "id": "sdd-sticky-implementer-multi-task",
+      "prompt": "同一 plan 上 T3–T6 都是 fullstack-dev 做，任务强相关，希望 sticky 省 token，但每 task 仍要 reviewer",
+      "expected_route": [
+        "@project-manager",
+        "@fullstack-dev",
+        "QC-3-reviewers",
+        "@qa-engineer"
+      ],
+      "must_have_artifacts": [
+        "Context Loaded declaration",
+        "Execution mode: sdd",
+        "SDD implementer session: sticky on implement Assignment",
+        "implementer-session.json with host_agent_id",
+        "task-N-brief.md per task",
+        "fresh task reviewer per task (no reviewer resume)",
+        "progress.md ledger",
+        "plan QC tri N=3 + branch review-package"
+      ],
+      "hard_fail_if": [
+        "missing Context Loaded declaration",
+        "sticky without implementer-session.json or host_agent_id",
+        "resume task reviewer session",
+        "parallel SDD implementer dispatches",
+        "bulk inline Assignment with full plan pasted instead of per-task briefs",
+        "skip per-task L2 review because implementer session is sticky",
         "assignment uses non-English field keys"
       ]
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ After `mstar-harness-core`, load **only** what the role and round need (see `ski
 |-------|-----------------|
 | `mstar-phase-gates` | PM; product/architect in Prepare |
 | `mstar-dispatch-gates` | PM; **all leaf executors** before Task/subagent |
-| `mstar-sdd` | PM on `Execution mode: sdd`; SDD implementer/reviewer subagents (SUBAGENT-STOP) |
+| `mstar-sdd` | PM on `Execution mode: sdd`; SDD implementer/reviewer subagents (SUBAGENT-STOP); optional **`SDD implementer session: sticky`** (`references/sticky-implementer-session.md`) |
 | `mstar-branch-worktree` | PM, dev*, QC*, QA, ops when Git/write or QC checkout |
 | `mstar-plan-conventions` | PM; dev* for path symbols / metadata |
 | `mstar-plan-artifacts` | PM (status/residual, InReview/QC waves), architect, product-manager, QC* (reports), QA (R#) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,31 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.0.0** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.0.1** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.0.0** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.0.0** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.0.0** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.0.0** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.0.0** |
+| Monorepo root | `morning-star` (`package.json`) | **1.0.1** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.0.1** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.0.1** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.0.1** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.0.1** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [1.0.1] - 2026-07-07
+
+### Harness (SDD iteration-drive + sticky implementer + pm shim)
+
+- **`iteration-drive` / `mstar-iteration`**: Phase 2 explicitly mandates per-task SDD loop (`mstar-sdd` in Boot, `task-brief` → implementer → `review-package` → task reviewer); forbids bulk inline implement Assignments for multi-task plans.
+- **Sticky implementer session** (`SDD implementer session: sticky`): optional same dev subagent across tasks via host resume (Cursor Task `resume`); `implementer-session.json` ledger; **task reviewers stay fresh** per task. Docs: `mstar-sdd/references/sticky-implementer-session.md`, `implementer-continuation-prompt.md`.
+- **`pm` skill**: thinned to cross-host entry shim (Codex/Cursor `/pm`); iteration lifecycle Boot lives in **`commands/`**; SSOT → `project-manager.md` + topic skills.
+- **Assignment / dispatch**: `dispatch-and-assignment.md` SDD vs inline table; `SDD implementer session` field on template.
+- **Routing eval v14**: iteration Phase 2 SDD hard-fails; new `sdd-sticky-implementer-multi-task` case.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex plugin manifests: **→ 1.0.1**.
 
 ## [1.0.0] - 2026-07-07
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,30 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.0.0**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.0.1**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.0.0** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.0.0** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.0.0** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.0.0** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.0.0** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.0.1** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.0.1** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.0.1** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.0.1** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.0.1** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [1.0.1] - 2026-07-07
+
+### Harness（SDD iteration-drive + sticky implementer + pm shim）
+
+- **`iteration-drive` / `mstar-iteration`**：Phase 2 显式强制 per-task SDD 循环（Boot 载入 `mstar-sdd`）；禁止多 task plan 用 inline 大包派发。
+- **Sticky implementer**（`SDD implementer session: sticky`）：可选同一 dev subagent 跨 task 续会话（Cursor Task `resume`）；`implementer-session.json` 账本；**task reviewer 仍每 task fresh**。
+- **`pm` skill**：精简为跨宿主入口 shim；iteration 编排 Boot 在 **`commands/`**；SSOT → `project-manager.md`。
+- **派发模板**：`SDD implementer session` 字段；SDD vs inline Assignment 对照表。
+- **Routing eval v14**：iteration Phase 2 SDD 硬失败项；新增 `sdd-sticky-implementer-multi-task`。
+
+### 版本对齐
+
+- monorepo、OpenCode、CLI、Cursor/Codex 插件：**→ 1.0.1**。
 
 ## [1.0.0] - 2026-07-07
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Core value:
 - Run with unified `mstar-*` skills instead of scattered rules
 - Reuse one core process across OpenCode, Cursor, and Codex
 
+**1.0.1:** `iteration-drive` mandates per-task SDD; optional **sticky implementer** (`SDD implementer session: sticky`, Cursor Task `resume`) to reuse dev context across tasks; thin **`pm`** entry shim for general orchestration (iteration → `commands/`).
+
 **1.0.0 highlights:** SDD (`mstar-sdd`) with per-task **task reviewer** + **mandatory plan QC tri-review** (QC#1/#2/#3 cross-review on whole branch). Single-seat `qc.md` only for `inline` / hotfix.
 
 ## Quick Start

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,6 +23,8 @@
 - 通过统一的 `mstar-*` skills 执行，而不是散落规则
 - 在 OpenCode / Cursor / Codex 下复用同一套核心流程
 
+**1.0.1：** `iteration-drive` 强制 per-task SDD；可选 **sticky implementer**（`SDD implementer session: sticky`，Cursor Task `resume`）复用 dev 上下文；精简 **`pm`** 通用入口（iteration 走 `commands/`）。
+
 **1.0.0 亮点：** SDD（`mstar-sdd`）— 每 task **task reviewer** + plan 完成后的 **强制 QC 三审交叉审**（QC#1/#2/#3 看整分支 diff）。仅 `inline`/hotfix 用单席 `qc.md`。
 
 ## 快速开始（推荐方式）

--- a/commands/iteration-drive.md
+++ b/commands/iteration-drive.md
@@ -30,6 +30,7 @@ Phase 2: Autonomous Execute  →  Phase 3: iteration-close  →  Phase 4: Create
 | 禁止（PM 线程） | 必须 |
 |-----------------|------|
 | Write/Edit/Shell 产品代码、写测试、跑 QC 审查（Phase 2） | 每条 implement/QC/QA Assignment ⇒ **1 次 `Task`** |
+| **多 task plan 用 inline 大包派发**（整份 plan / T1–Tn 贴进一个 dev Assignment） | **SDD**：`mstar-sdd` per-task 循环 — `task-brief` → implementer → `review-package` → task reviewer → `progress.md` |
 | 只写 Assignment 就进入下一 gate | 同轮 dispatch：`Subagent invokes issued: N`（N = Assignment 条数） |
 | 最后一个 plan `Done` 后直接开 PR / 汇报结束 | **Phase 3 → 4 → 5** 顺序执行 |
 | Phase 4 开 PR 后停止 | Phase 5 loop 至 merge-ready；**禁止**未过 §5.5 就结束会话 |
@@ -50,11 +51,12 @@ Phase 2: Autonomous Execute  →  Phase 3: iteration-close  →  Phase 4: Create
 
 1. `mstar-harness-core`
 2. `mstar-roles` → `references/project-manager.md`
-3. `skills/pm/SKILL.md` → **§ Host entry** + **§ Boot**（PM role identity + dispatch-first rules）
-4. `mstar-iteration` → **§ Phase 2–5**（§3 close gate；§4 PR delivery；§5 merge-ready loop）
-5. `mstar-compound` — Phase 3 §3.2 前加载（含 Phase 6 索引登记）
-6. `mstar-dispatch-gates` + host reference
-7. `mstar-plan-artifacts`, `mstar-plan-conventions`, `mstar-branch-worktree`
+3. `mstar-iteration` → **§ Phase 2–5**（§3 close gate；§4 PR delivery；§5 merge-ready loop）
+4. `mstar-compound` — Phase 3 §3.2 前加载（含 Phase 6 索引登记）
+5. `mstar-dispatch-gates` + host reference
+6. **`mstar-sdd`** — **before first implement dispatch** in Phase 2（per-task loop SSOT；多 task plan 默认 `Execution mode: sdd`）
+7. `mstar-review-qc` — before first QC dispatch in Phase 2
+8. `mstar-plan-artifacts`, `mstar-plan-conventions`, `mstar-branch-worktree`
 
 ## Phase 2: Autonomous Execute
 
@@ -74,9 +76,17 @@ Execute **`mstar-iteration` § Phase 2** exactly. Summary:
 4. **Integration branch** (§ 2.3) — `git checkout -b <spec_integration_branch> <iteration_base_branch>` when creating（**not** implicit `main`）
 5. **Per-plan loop** (§ 2.4) — for each non-`Done` plan:
    - Create plan feature branch from integration
-   - Dispatch implement subagents (dispatch-first)
+   - **SDD implement**（默认 `Execution mode: sdd`；`mstar-sdd` 已载入）— per task **串行**：
+     1. `sdd-workspace <plan-id>` → `{SDD_DIR}`
+     2. `task-brief <plan> N` → `{SDD_DIR}/task-N-brief.md`
+     3. Dispatch **one** implementer subagent（brief + report 路径；`references/implementer-prompt.md` 或 sticky 时 `implementer-continuation-prompt.md`）
+     4. `review-package BASE HEAD` → task diff
+     5. Dispatch **one** task reviewer subagent
+     6. Append `{SDD_DIR}/progress.md`；更新 `status.json` `task_commits[]`（如使用）
+     7. Next task — **never** parallel implementers；同 plan 同 dev 可用 **`SDD implementer session: sticky`**（`mstar-sdd/references/sticky-implementer-session.md`）
+   - **禁止**：把整份 plan 或 T1–Tn 全文贴进 implement dispatch；文件交接 SSOT → `mstar-sdd/references/file-handoffs.md`
    - Update `status.json` + main plan after each Completion Report v2
-   - QC **full tri-review** (`QC mode: full tri-review`, **N=3**, `mstar-review-qc`) + QA per plan
+   - QC **full tri-review** (`QC mode: full tri-review`, **N=3**, `mstar-review-qc`) + branch `review-package` + QA per plan
    - Merge plan branch → integration branch
    - Cross-plan progress sync → compass
    - Next plan

--- a/commands/iteration-start.md
+++ b/commands/iteration-start.md
@@ -28,12 +28,11 @@ Detailed workflow → **`mstar-iteration` § Phase 1: iteration-start**（含 §
 
 1. `mstar-harness-core`
 2. `mstar-roles` → `references/project-manager.md`
-3. `skills/pm/SKILL.md` → **§ Host entry** + **§ Boot**
-4. `mstar-iteration` → **§ Phase 1: iteration-start**（迭代范围、compass 模板、§1.6 Review & Edit chain、状态初始化）
-5. `mstar-dispatch-gates`
-6. `mstar-phase-gates` → Prepare（specify → clarify → plan）
-7. `mstar-plan-conventions`, `mstar-plan-artifacts`
-8. `mstar-host` → active host reference（invoke 能力）
+3. `mstar-iteration` → **§ Phase 1: iteration-start**（迭代范围、compass 模板、§1.6 Review & Edit chain、状态初始化）
+4. `mstar-dispatch-gates`
+5. `mstar-phase-gates` → Prepare（specify → clarify → plan）
+6. `mstar-plan-conventions`, `mstar-plan-artifacts`
+7. `mstar-host` → active host reference（invoke 能力）
 
 ## 1. Research
 

--- a/commands/mstar-bootstrap.md
+++ b/commands/mstar-bootstrap.md
@@ -14,11 +14,10 @@ Distill a coherent knowledge baseline from the current project — useful when t
 
 1. `mstar-harness-core`
 2. `mstar-roles` → `references/project-manager.md`
-3. `skills/pm/SKILL.md` → **§ Host entry** + **§ Boot**
-4. `mstar-plan-conventions`（路径符号）
-5. `mstar-strategy` → **§ STRATEGY.md structure** + **§ Creating STRATEGY.md**
-6. `mstar-compound` → **references/concepts-vocabulary.md**（CONCEPTS.md 规则）
-7. `mstar-compound-refresh` → **§ Core rules**（知识维护基线）
+3. `mstar-plan-conventions`（路径符号）
+4. `mstar-strategy` → **§ STRATEGY.md structure** + **§ Creating STRATEGY.md**
+5. `mstar-compound` → **references/concepts-vocabulary.md**（CONCEPTS.md 规则）
+6. `mstar-compound-refresh` → **§ Core rules**（知识维护基线）
 
 ## Phase 1: Survey — understand what exists
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.0.1
+
+- Version alignment with harness **1.0.1** (no CLI behavior change in this release).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.0.1**.
+
 ## 1.0.0
 
 - Project `init`/`doctor`: append/check `.mstar/sdd/` and `.agents/sdd/` gitignore entries for SDD scratch.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex).",
   "license": "MIT",
   "repository": {

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.0.1
+
+- Bundled skills/commands: `iteration-drive` + `mstar-iteration` Phase 2 per-task SDD mandate; optional sticky implementer session (`resume` + ledger); thin `pm` skill shim; routing-eval v14.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.0.1**.
+
 ## 1.0.0
 
 - Bundle `mstar-sdd` skill + scripts; SDD mandatory plan QC tri-review (`Execution mode: sdd`); inline/hotfix single-seat; plan template and SDD metadata fields.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-dispatch-gates/SKILL.md
+++ b/skills/mstar-dispatch-gates/SKILL.md
@@ -69,7 +69,8 @@ description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent
 
 When **`Execution mode: sdd`** (`mstar-sdd`):
 
-- **串行**：one implementer at a time; one task reviewer after each — **never** parallel implementers (write conflicts).
+- **串行**：one implementer at a time; one **fresh** task reviewer after each — **never** parallel implementers (write conflicts).
+- **`SDD implementer session: sticky`**：same implementer subagent may **resume** across tasks when host supports it; **reviewers never resume** — see **`mstar-sdd/references/sticky-implementer-session.md`**.
 - File handoffs only — no pasted plan/diff/history in dispatch prompts.
 - Record per-task BASE SHA; use `review-package` for diffs — **never `HEAD~1`**.
 - After all tasks: branch `review-package` → **mandatory tri-review N=3** when `Execution mode: sdd`; **N=1** only for `inline` / explicit single override.

--- a/skills/mstar-host/references/codex.md
+++ b/skills/mstar-host/references/codex.md
@@ -11,7 +11,7 @@ Parallel PM dispatch: read **`parallel-dispatch.md`** only when Codex exposes an
 - Plugin source: `.codex-plugin/plugin.json`.
 - Runtime skills: repo `skills/` mounted by the Codex plugin (`"skills": "./skills/"`).
 - Custom agent source: repo `codex/agents/*.toml`; CLI/manual install links these into `~/.codex/agents/` or project `.codex/agents/`.
-- `/pm`: shared force entry via the `pm` skill; after that, role behavior comes from `mstar-roles`.
+- **`/pm`** or **`pm` skill**: force PM entry → `mstar-roles` → `project-manager.md` (Codex primary; Cursor/OpenCode for general per-plan work). **`commands/`** when running iteration Phase 1–5.
 - Role files under root `agents/` are for hosts that load OpenCode/Cursor-style agent shells; Codex uses `codex/agents/*.toml` and still loads `mstar-roles` references directly.
 - Tool and plugin availability can be lazy-loaded or session-dependent. Use the tools actually present in the current session; do not infer capability from documentation alone.
 

--- a/skills/mstar-host/references/cursor.md
+++ b/skills/mstar-host/references/cursor.md
@@ -6,7 +6,7 @@ Parallel PM dispatch: **`parallel-dispatch.md`** (Task tool uses same turn model
 
 ## Cursor-only context
 
-- Role prompts: `mstar-roles`; **`/pm`** → `project-manager` via `pm` skill + `mstar-roles`.
+- Role prompts: `mstar-roles`; **`/pm`** or **`pm` skill** → general PM orchestration (per-plan dispatch, gates, QC) without an iteration command. **`commands/`** (`iteration-start`, `iteration-drive`, `mstar-bootstrap`) only when running formal iteration Phase 1–5.
 - Routing-eval: `.cursor/skills/mstar-routing-eval/` — regression tooling only; not runtime load order.
 
 ## Plan mode × harness dual-write
@@ -43,6 +43,22 @@ Enforcement: `rules/mstar-cursor-plan-mode.mdc` when plugin active.
 - **`Execution mode: sdd`**: **N=3** Tasks (`qc-specialist`, `qc-specialist-2`, `qc-specialist-3`) + branch review-package path.
 - **`inline`**: **N=1** per `parallel-dispatch.md`.
 - SDD implement/reviewer: **serial** — see **`mstar-sdd`**.
+
+## SDD sticky implementer (Cursor Task resume)
+
+When Assignment has **`SDD implementer session: sticky`** (`mstar-sdd/references/sticky-implementer-session.md`):
+
+| Turn | Task tool |
+|------|-----------|
+| **First task** (or after `fresh` reset) | `subagent_type: <Execute as>` + `implementer-prompt.md` body; capture returned **agent id** → `{SDD_DIR}/implementer-session.json` → `host_agent_id` |
+| **Task 2+** | `resume: <host_agent_id>` + `implementer-continuation-prompt.md` body (new brief path + report path only) |
+
+**Rules:**
+
+- **1 implement dispatch ⇒ 1 Task** per task id (resume counts as the implement dispatch for that task).
+- **Task reviewer**: always **new** Task — **no** `resume` for reviewers.
+- After each task reviewer passes, PM updates `progress.md` and `implementer-session.json` `last_task`.
+- If `resume` fails or agent id missing → reset to **`fresh`** for that task; log reason in Status Update.
 
 ## Dispatch execution（canonical）
 

--- a/skills/mstar-host/references/opencode.md
+++ b/skills/mstar-host/references/opencode.md
@@ -6,6 +6,7 @@ Parallel PM dispatch: **`parallel-dispatch.md`** (read in dispatch rounds).
 
 ## Role loading
 
+- **PM entry**: **`/pm`** or **`pm` skill** → `project-manager` for general orchestration; **`commands/`** (`iteration-start`, `iteration-drive`, `mstar-bootstrap`) for formal iteration only.
 - **Role shell**: `agents/<id>.md` referenced by `opencode.json` `agent.<id>` (frontmatter + role binding only).
 - **Role body**: `mstar-roles` `references/<id>.md` (or shared references + parameters).
 - Implementation evidence and RCA behavior: `mstar-coding-behavior`.
@@ -29,6 +30,8 @@ Harness **dispatch** on OpenCode = **one or more `task` tool calls**, each with 
 | No task tool call | **Not dispatched** — paste-only / `dispatch incomplete` |
 
 PM workflow: finalize Assignment → **call task tool** with **subagent** + generated prompt → wait for subagent Completion Report → update plan / status.
+
+**SDD sticky implementer:** if the task tool exposes **resume** / agent id, follow **`mstar-sdd/references/sticky-implementer-session.md`** and the active host reference. If resume is **not** available, use **micro-batch** (2–3 tasks, one invoke) or **`SDD implementer session: fresh`** per task — do not assume sticky without host support.
 
 ## Role-mention hygiene (OpenCode)
 

--- a/skills/mstar-host/references/parallel-dispatch.md
+++ b/skills/mstar-host/references/parallel-dispatch.md
@@ -63,4 +63,4 @@ Formal iteration Phase 2 uses the same SDD + tri rule — not a separate carve-o
 2. Prerequisite-only message? → **zero** batch dispatches unless `N = 1`.
 3. Dispatch message contains **exactly `N`** invocation calls?
 4. QC initial: **`Execution mode: sdd`** → **N=3**? **`inline`** → **N=1**? Targeted re-review → **N** = Assignment reviewer count?
-5. SDD implement → **serial** (never batch implementers)?
+5. SDD implement → **serial** (never batch implementers); sticky = **resume** same implementer, not parallel

--- a/skills/mstar-iteration/SKILL.md
+++ b/skills/mstar-iteration/SKILL.md
@@ -7,7 +7,7 @@ description: Morning Star 迭代管理 —— iteration-start、Autonomous Execu
 
 ## Load order
 
-**Read `mstar-harness-core` first.** Path symbols → **`mstar-plan-conventions`**. Per-plan gates → **`mstar-phase-gates`**. Knowledge crystallization → **`mstar-compound`**. On conflict, **`mstar-harness-core` wins**.
+**Read `mstar-harness-core` first.** Path symbols → **`mstar-plan-conventions`**. Per-plan gates → **`mstar-phase-gates`**. Knowledge crystallization → **`mstar-compound`**. **Phase 2 implement 波次**（进入 per-plan implement 前）→ **`mstar-sdd`** + **`mstar-dispatch-gates`**。Phase 2 QC 前 → **`mstar-review-qc`**。On conflict, **`mstar-harness-core` wins**.
 
 ## 设计思路
 
@@ -227,7 +227,17 @@ SSOT = `{HARNESS_DIR}/status.json` + `{PLAN_DIR}/`。todos 只追踪本轮下一
 对每个 active `plan_id`：
 
 1. **Plan start — feature branch**：Assignment 用 `Working branch: create <plan-feature-branch> from <spec_integration_branch>`。一个 plan 一条专用实现分支；内部并行 → topic branches + worktrees（`mstar-branch-worktree`）
-2. **Implement → InReview**：dispatch-only 循环（`§ 2.5`）；每次 Completion Report v2 后更新 `status.json` + 主 plan
+2. **Implement → InReview**（`§ 2.5`）：
+   - **默认 `Execution mode: sdd`**（多 task plan；hotfix 可 `inline`）。
+   - PM 载入 **`mstar-sdd`** 后，按 plan task 顺序 **串行** per-task 循环（**不是**一次派发 dev 做全部 tasks）：
+     1. `sdd-workspace <plan-id>` → `{SDD_DIR}`
+     2. `task-brief <plan-file> N` → `{SDD_DIR}/task-N-brief.md`；记录 `BASE_SHA`
+     3. Dispatch **one** implementer subagent（`references/implementer-prompt.md`：brief 路径 + report 路径 + `Model tier`；**禁止**贴整份 plan）
+     4. Implementer `DONE` → `review-package BASE HEAD` → task diff 文件
+     5. Dispatch **one** task reviewer subagent（brief + report + diff + Global Constraints）
+     6. Fix loop 直至 review clean；append `{SDD_DIR}/progress.md`；更新 `status.json` / plan checkbox
+     7. Next task
+   - 每次 Completion Report v2 后更新 `status.json` + 主 plan
 3. **QC → QA → Done**：per-plan 审查链 → **`mstar-sdd`**（L1–L2）+ **`mstar-review-qc/references/review-responsibility-boundaries.md`**（L3 tri / inline 单席）+ QA。
 4. **Plan complete — merge back**：合并 plan feature branch → `spec_integration_branch`；在下一 plan 或 QC 前解决冲突
 5. **Cross-plan 进度同步**：更新 `{ITERATION_DIR}/<iteration-id>-delivery-compass.md` 的 `## Plans` 表状态列
@@ -241,7 +251,18 @@ SSOT = `{HARNESS_DIR}/status.json` + `{PLAN_DIR}/`。todos 只追踪本轮下一
 
 ### 2.5 Dispatch-first（implement 派发约束）
 
-派发纪律 SSOT → **`mstar-dispatch-gates`** · **`mstar-host/references/parallel-dispatch.md`** · **`skills/pm/SKILL.md`**（Dispatch-first）。
+派发纪律 SSOT → **`mstar-dispatch-gates`** · **`mstar-sdd`** · **`mstar-host/references/parallel-dispatch.md`**。
+
+**SDD implement（Phase 2 默认）** — PM **已载入 `mstar-sdd`** 后执行：
+
+| 规则 | 说明 |
+|------|------|
+| 串行 | 同一 plan 内 **one implementer at a time**；每 task 后 **one fresh task reviewer** |
+| Sticky（可选） | Assignment **`SDD implementer session: sticky`** + `implementer-session.json`；implementer **resume**，reviewer **fresh** — `mstar-sdd/references/sticky-implementer-session.md` |
+| 文件交接 | brief / report / diff / `progress.md` 在 `{SDD_DIR}`；dispatch prompt **只给路径**，不贴 plan 全文或 task 历史 |
+| Assignment 字段 | 每个 implement dispatch 须含 `Execution mode: sdd`、`SDD dir`、`Model tier`；**禁止**省略 `Model tier` |
+| 大包 inline | **禁止**把 T1–Tn 或整份 plan 写进 **一个** `fullstack-dev` leaf Assignment 冒充 SDD |
+| 分支 diff | 全部 task 完成后 `review-package MERGE_BASE HEAD` → branch diff → plan QC tri（N=3） |
 
 Iteration Phase 2 附加：
 
@@ -423,6 +444,7 @@ PR **merge** 本身可仍由用户手动执行，除非 Assignment 明确授权 
 
 - 不要在 per-plan Done 后立即单独 compound——等 iteration-close 统一做
 - 不要在 Autonomous Execute（Phase 2）中修改 per-plan gate 判定
+- **不要在 Phase 2 用 inline 大包 Assignment 替代 SDD per-task 循环**（除非 plan 显式 `Execution mode: inline` / hotfix）
 - 不要用 compass 替代 `status.json` 作为 plan 状态 SSOT
 - 不要在没有完成 per-plan 前置检查的情况下进入 iteration-close
 - 不要在缺少 `iteration_base_branch` / `target_branch` 时默认使用 `main` / `master`

--- a/skills/mstar-roles/references/project-manager.md
+++ b/skills/mstar-roles/references/project-manager.md
@@ -138,9 +138,15 @@ Before first implement dispatch (non-hotfix):
 
 If any fail -> do not dispatch implement.
 
-### PM entry sessions (`/pm` or OpenCode PM switch)
+### PM entry sessions
 
-When the session entered via **`/pm`**, **`pm` skill**, or OpenCode PM orchestration, follow **`skills/pm/SKILL.md`** — especially **Host entry**, **iteration branch policy**（`iteration_base_branch` / `spec_integration_branch` / `target_branch`）, **Autonomous Execute**（status.json backlog, per-plan feature branches）, and **Dispatch-first**. Routing, gates, Task Board, QC, and templates remain in this file and topic `mstar-*` skills.
+| Entry | Next reads |
+|-------|------------|
+| **`/pm`** or **`pm` skill** (Codex, Cursor; OpenCode when no command) | This shim → **`project-manager.md`** § Required Reading + topic skills on demand |
+| **Cursor / OpenCode** **`commands/`** (`iteration-start`, `iteration-drive`, `mstar-bootstrap`) | Command **Boot** + **`project-manager.md`** — iteration lifecycle only; **not** required for ordinary per-plan PM |
+| **OpenCode** (no command, not `/pm`) | `project-manager` + `mstar-host` → `opencode.md` |
+
+**Dispatch-first**, iteration branch policy（`iteration_base_branch` / `spec_integration_branch` / `target_branch`）, Autonomous Execute → **`mstar-iteration`** §2. Routing, gates, Task Board, QC, templates → this file + topic `mstar-*` skills.
 
 ---
 

--- a/skills/mstar-roles/references/project-manager/dispatch-and-assignment.md
+++ b/skills/mstar-roles/references/project-manager/dispatch-and-assignment.md
@@ -73,6 +73,7 @@ The **`**You are a leaf executor. You MUST NOT:**`** section (previously just pr
 **Execute as**: <role-id>
 **Delegation**: forbidden | allowed (...)
 **Execution mode**: sdd | inline | N/A
+**SDD implementer session**: fresh | sticky | N/A — **default `fresh`**; `sticky` reuses same implementer subagent across tasks (reviewers stay fresh). See `mstar-sdd/references/sticky-implementer-session.md`
 **SDD dir**: `{HARNESS_DIR}/sdd/<plan-id>/` | N/A
 **Model tier**: fast | standard | capable | N/A
 **QC mode**: full tri-review | single | N/A — **default `full tri-review` when `Execution mode: sdd`**; `single` only for `inline` / override
@@ -163,3 +164,17 @@ The **`**You are a leaf executor. You MUST NOT:**`** section (previously just pr
 
 For host behavior details (dispatch turn shape, paste-only failure mode, invoke-count discipline),
 read `mstar-host` → the active host reference and `references/parallel-dispatch.md` as host SSOT for dispatch.
+
+## SDD vs inline implement Assignment（PM）
+
+| Mode | Who loads `mstar-sdd` | Assignment shape |
+|------|----------------------|------------------|
+| **`Execution mode: sdd`**（多 task 默认；iteration Phase 2 默认） | **PM** before first implement dispatch | **Per task**：one implementer dispatch + one **fresh** task reviewer；prompt 只含 `{SDD_DIR}/task-N-brief.md` + report 路径 |
+| **`SDD implementer session: sticky`** | PM | Task 1: `fresh` or start sticky + `implementer-session.json`; Task 2+: host **resume** + continuation prompt — **still** per-task review |
+| **`Execution mode: inline`**（hotfix / 单 task） | PM optional | One leaf Assignment；可含完整 scope，但仍须 canonical 字段 |
+
+**NEVER（SDD）**：
+
+- 把整份 plan 或 T1–Tn 全文贴进 **一个** `fullstack-dev` leaf Assignment。
+- 省略 `Execution mode` / `SDD dir` / `Model tier` 却期望 SDD 产物（`progress.md`、per-task review）。
+- 期望 leaf `fullstack-dev` 载入 `mstar-sdd` 并自编排 per-task 循环 — **编排仅 PM**（`iteration-drive` / `mstar-iteration` §2.4–2.5）。

--- a/skills/mstar-sdd/SKILL.md
+++ b/skills/mstar-sdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-sdd
-description: Morning Star subagent-driven development (SDD) — file handoff, per-task implementer + task reviewer (L2), progress ledger, branch review-package for plan QC tri (L3). **Must** Read when project-manager runs `Execution mode: sdd` (multi-task plan, single-plan, or iteration Phase 2), dispatches SDD implementer/reviewer subagents, or prepares review-package paths. Leaf implementer/reviewer subagents skip PM sections via SUBAGENT-STOP in dispatch prompts.
+description: Morning Star subagent-driven development (SDD) — file handoff, per-task implementer + task reviewer (L2), progress ledger, branch review-package for plan QC tri (L3). **Implementer session** `fresh` (default) or **`sticky`** (same dev subagent across tasks — `references/sticky-implementer-session.md`). **Must** Read when project-manager runs `Execution mode: sdd` (multi-task plan, single-plan, or iteration Phase 2), dispatches SDD implementer/reviewer subagents, or prepares review-package paths. Leaf implementer/reviewer subagents skip PM sections via SUBAGENT-STOP in dispatch prompts.
 ---
 
 ## Load order
@@ -19,7 +19,9 @@ If you were dispatched as an SDD implementer or task reviewer, skip PM orchestra
 
 ## Core principle
 
-Fresh subagent per task + task review (spec + quality) + plan-level QC on whole branch = quality with isolated context.
+**Default:** fresh implementer subagent per task + task review (spec + quality) + plan-level QC on whole branch = quality with isolated context.
+
+**Optional:** **`SDD implementer session: sticky`** — same implementer subagent across sequential tasks on one plan/branch; **task reviewers stay fresh per task**. SSOT → **`references/sticky-implementer-session.md`**.
 
 **Narration:** at most one short line between tool calls — ledger and file paths carry the record.
 
@@ -39,11 +41,13 @@ Batch all findings for the human in one message. If clean, proceed silently.
 1. Record `BASE_SHA` (never use `HEAD~1` later)
 2. `sdd-workspace <plan-id>` → `SDD_DIR`
 3. `task-brief <plan> N` → brief file
-4. Dispatch implementer (brief + report paths, model tier) — templates: `references/implementer-prompt.md`
+4. Dispatch implementer:
+   - **`SDD implementer session: fresh`** (default) — new subagent; templates: `references/implementer-prompt.md`
+   - **`SDD implementer session: sticky`** — first task: same as fresh + write `{SDD_DIR}/implementer-session.json` with `host_agent_id`; later tasks: host **resume** + `references/implementer-continuation-prompt.md` (see **`references/sticky-implementer-session.md`**)
 5. On `DONE`: `review-package BASE HEAD` → diff file
-6. Dispatch task reviewer (brief, report, diff, Global Constraints) — `references/task-reviewer-prompt.md`
+6. Dispatch **fresh** task reviewer (brief, report, diff, Global Constraints) — `references/task-reviewer-prompt.md` — **never** sticky resume for reviewers
 7. Fix loop for Critical/Important; re-review until approved
-8. Append `progress.md`; update `status.json` `task_commits[]` if used
+8. Append `progress.md`; update `status.json` `task_commits[]` and `implementer-session.json` `last_task` if sticky
 9. Next task
 
 **Never** dispatch multiple implementers in parallel (write conflicts).
@@ -100,6 +104,8 @@ Minor findings → `## Minor (for plan QC)` section in same file.
 - Skip task review or accept missing verdict
 - Re-dispatch tasks listed complete in ledger
 - PM thread implements instead of subagent dispatch
+- Sticky **resume** for task reviewers
+- Resume implementer without `host_agent_id` in `implementer-session.json`
 
 ## Scripts
 
@@ -114,5 +120,7 @@ From repo: `skills/mstar-sdd/scripts/` (bundled in OpenCode as `harness-skills/m
 ## References
 
 - `references/file-handoffs.md` — paths and fix-loop evidence
+- `references/sticky-implementer-session.md` — `fresh` vs `sticky`, ledger, host resume, micro-batch fallback
 - `references/implementer-prompt.md`
+- `references/implementer-continuation-prompt.md`
 - `references/task-reviewer-prompt.md`

--- a/skills/mstar-sdd/references/file-handoffs.md
+++ b/skills/mstar-sdd/references/file-handoffs.md
@@ -13,6 +13,7 @@ PM and subagents move artifacts as **files**, not pasted text. Pasted content st
    - Interfaces / decisions brief cannot know
    - Report path: `$SDD_DIR/task-N-report.md`
    - `Model tier` → host-specific model (required)
+   - **`SDD implementer session`**: `fresh` (new subagent) or `sticky` (resume — see **`sticky-implementer-session.md`**)
 
 ## Implementer report file
 
@@ -71,3 +72,5 @@ Do not paste:
 - Full diff content
 
 Fresh subagent gets: brief + interfaces + constraints + file paths only.
+
+**Sticky implementer** (task 2+): resume same session; read new brief path + `progress.md` — do not re-paste prior task summaries. PM updates `implementer-session.json`.

--- a/skills/mstar-sdd/references/implementer-continuation-prompt.md
+++ b/skills/mstar-sdd/references/implementer-continuation-prompt.md
@@ -1,0 +1,44 @@
+# Implementer continuation prompt (sticky session)
+
+Use when PM continues **`SDD implementer session: sticky`** for Task N>1. Host: **resume** same agent when supported (`sticky-implementer-session.md`).
+
+```
+Task / subagent:
+  resume: [HOST_AGENT_ID from implementer-session.json]
+  description: "SDD continue Task N: <name>"
+  model: [same tier as session start unless PM upgrades]
+  prompt: |
+    <SUBAGENT-STOP> Skip PM orchestration skills. You are a leaf implementer continuing a sticky SDD session.</SUBAGENT-STOP>
+
+    Continue as the same implementer on plan <plan-id>, Working branch: <branch>.
+
+    ## Completed (do not redo)
+
+    Read: [SDD_DIR]/progress.md and [SDD_DIR]/implementer-session.json
+
+    ## This task
+
+    Task N: <name>
+
+    Read first — your spec (verbatim): [BRIEF_FILE]
+
+    ## Context not in the brief
+
+    [Interfaces from earlier tasks only if not already in your session]
+
+    ## Report file
+
+    Write your full report to: [REPORT_FILE]
+
+    ## Your job
+
+    1. Implement exactly what this brief specifies (prior tasks are done)
+    2. Run tests; commit on Working branch
+    3. Write report file; return short summary only
+
+    ## When stuck
+
+    Report BLOCKED or NEEDS_CONTEXT — PM may reset session to fresh.
+```
+
+First task on a plan uses **`implementer-prompt.md`** (not this file).

--- a/skills/mstar-sdd/references/implementer-prompt.md
+++ b/skills/mstar-sdd/references/implementer-prompt.md
@@ -1,6 +1,8 @@
 # Implementer subagent prompt template
 
-Use when PM dispatches an SDD implementer (`mstar-sdd`).
+Use when PM dispatches an SDD implementer (`mstar-sdd`) — **first task** or **`SDD implementer session: fresh`**.
+
+For **sticky** continuation (task 2+), use **`implementer-continuation-prompt.md`** instead.
 
 ```
 Task / subagent:

--- a/skills/mstar-sdd/references/sticky-implementer-session.md
+++ b/skills/mstar-sdd/references/sticky-implementer-session.md
@@ -1,0 +1,103 @@
+# Sticky implementer session (SDD token optimization)
+
+Reuse the **same implementer subagent** across multiple tasks in one plan when tasks are tightly coupled, same `Execute as` role, and same `Working branch`. **L2 task reviewers stay fresh per task** — do not sticky reviewers.
+
+SSOT for mode selection and host resume → this file. Per-task artifacts → **`file-handoffs.md`**.
+
+## When to use
+
+| `SDD implementer session` | Use |
+|---------------------------|-----|
+| **`fresh`** (default) | Independent tasks, module boundaries, different dev tracks, or first task on a plan |
+| **`sticky`** | Same `fullstack-dev` (or same role id), sequential tasks on one branch, strong file/context continuity (e.g. T3+T4 daemon stderr + DB reset) |
+
+**Prefer `sticky`** on iteration-drive Phase 2 when PM will dispatch many tasks to the same dev on one plan feature branch.
+
+## Assignment fields (implement dispatch)
+
+```markdown
+**Execution mode**: sdd
+**SDD implementer session**: sticky | fresh
+**SDD dir**: `{HARNESS_DIR}/sdd/<plan-id>/`
+**Model tier**: standard
+**Execute as**: fullstack-dev
+**Working branch**: <branch>
+**Covers task**: N | N–M   # single task id for this dispatch turn
+```
+
+- **Task 1** (or first task after `fresh` reset): `SDD implementer session: fresh` or `sticky` (starts sticky ledger).
+- **Task 2+** with sticky: `SDD implementer session: sticky` + host **resume** (Cursor) or continuation prompt (fallback).
+
+## Session ledger: `implementer-session.json`
+
+PM writes/updates at `{SDD_DIR}/implementer-session.json` when starting or continuing sticky mode:
+
+```json
+{
+  "plan_id": "<plan-id>",
+  "execute_as": "fullstack-dev",
+  "session_mode": "sticky",
+  "host": "cursor",
+  "host_agent_id": "<agent-id from first Task return — required for resume>",
+  "working_branch": "feature/...",
+  "started_task": 1,
+  "last_task": 1,
+  "started_at": "2026-07-07T00:00:00Z"
+}
+```
+
+After each completed task review, PM sets `last_task` to N. **Do not** resume if `host_agent_id` is missing — fall back to `fresh` for that task.
+
+## Per-task loop (sticky implementer)
+
+Same as default SDD for artifacts and L2 review; only implementer dispatch differs:
+
+1. `task-brief` → `{SDD_DIR}/task-N-brief.md`
+2. Record `BASE_SHA`
+3. **Implementer dispatch**
+   - **First task** (`fresh` or sticky start): normal Task/subagent invoke → save `host_agent_id` to ledger
+   - **Next tasks** (`sticky`): host **resume** with same `host_agent_id` + continuation prompt (`implementer-prompt.md` § Continuation)
+4. On `DONE` → `review-package` → **fresh** task reviewer (never resume reviewer)
+5. Append `progress.md`; update ledger `last_task`
+6. Next task
+
+**Still required per task:** commit, `task-N-report.md`, task-level diff, task reviewer, `progress.md` line.
+
+## When to reset to `fresh`
+
+Start a **new** implementer session (`session_mode: fresh` or new ledger) when any:
+
+- `BLOCKED` / `NEEDS_CONTEXT` not resolved in one continuation turn
+- `Execute as` role changes (`fullstack-dev` → `fullstack-dev-2`)
+- `Working branch` changes
+- Host does not support resume (OpenCode without resume → use **micro-batch** or `fresh`)
+- Context clearly degraded (implementer confuses prior tasks) — PM judgment
+- Switching from another dev track mid-plan
+
+Delete or archive `implementer-session.json` when resetting.
+
+## Micro-batch fallback (no host resume)
+
+When resume is unavailable, PM may dispatch **one** implementer for **2–3** tightly coupled tasks:
+
+- Prompt lists `task-N-brief.md` … `task-M-brief.md` and matching report paths only
+- Implementer completes tasks **in order** in one session
+- PM still runs **per-task** `review-package` + **fresh** task reviewer after each task (or after batch if PM documents per-task SHAs in Assignment)
+
+Max **3** tasks per micro-batch without user override. See `project-manager.md` batch sizing.
+
+## Host mapping
+
+| Host | Sticky implementer |
+|------|-------------------|
+| **Cursor** | `Task` with `resume: <host_agent_id>` — **`mstar-host/references/cursor.md`** § SDD sticky |
+| **OpenCode** | Resume only if task tool supports it; else micro-batch or `fresh` per task |
+| **Codex** | Thread resume only when callable multi-agent tool documents agent id; else micro-batch or `fresh` |
+
+## PM NEVER (sticky)
+
+- Resume task **reviewer** sessions — reviewers stay fresh per task
+- Parallel sticky implementers on the same branch
+- Resume without updating `implementer-session.json` / `progress.md`
+- Skip per-task review because implementer "remembers" prior tasks
+- Paste full plan into continuation prompt — only new brief path + report path

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -1,59 +1,34 @@
 ---
 name: pm
-description: "Morning Star PM orchestration entry. On Cursor/Codex, /pm launches project-manager. On OpenCode, switch to project-manager when the active agent is not PM. The autonomous Execute flow (per-plan dispatch, iteration management, compound) lives in mstar-iteration — this skill covers PM role identity, host entry, dispatch-first rules, and host-specific concerns."
+description: "PM entry shim — force project-manager orchestration when user invokes /pm or this skill (Codex and Cursor). General per-plan PM work: this skill + project-manager.md. Formal iteration lifecycle on Cursor/OpenCode: commands (iteration-start, iteration-drive, mstar-bootstrap). Boot, routing, dispatch SSOT → mstar-roles/references/project-manager.md and topic mstar-* skills — not here."
 ---
 
-# PM — Morning Star orchestration entry
+# PM (entry shim)
 
-**PM role launcher and host adapter.** Iteration flow (start → Execute → close) → **`mstar-iteration`** (canonical SSOT). This skill handles: PM role identity per host, boot order, dispatch-first rules, Cursor Plan mode.
+**Thin launcher only.** Boot lists, iteration phases, Assignment templates, and SDD loops are **not** maintained in this file.
 
-## Host entry (read `mstar-host` first)
+## Host entry
 
-| Host | Entry | PM role |
-| --- | --- | --- |
-| **Cursor / Codex** | User invokes **`/pm`** (or explicit "run as PM") | Force **`project-manager`** for the session |
-| **OpenCode** | User may already be on a configured agent | **If active role ≠ `project-manager`**: operate **only** as PM — load `mstar-roles` → `references/project-manager.md`; do **not** stay in dev/QC/architect voice for orchestration. Host invoke: task tool **`subagent`** matching Assignment `Execute as` (see `mstar-host` → `opencode.md`); Assignment body uses **plain role ids** |
+| Host | Use |
+|------|-----|
+| **Codex** | **`/pm`** or this skill → **`project-manager`** for the session |
+| **Cursor** | **`/pm`** or this skill → general PM orchestration (single-plan, hotfix, QC waves, dispatch) **without** starting an iteration. Formal iteration → **`commands/`** below |
+| **OpenCode** | Same as Cursor when no command: **`project-manager`** via `mstar-roles` → `references/project-manager.md` |
 
-Detect host → Read `mstar-host` → `references/cursor.md` | `opencode.md` | `codex.md`.
+**Iteration commands** (optional; carry their own Boot): `iteration-start`, `iteration-drive`, `mstar-bootstrap` — use when running Phase 1–5 iteration lifecycle, not required for ordinary PM work.
 
-## Boot (order)
+Detect host → **`mstar-host`** → `references/codex.md` | `cursor.md` | `opencode.md`.
+
+## Read next (in order)
 
 1. `mstar-harness-core`
-2. `mstar-roles` → `references/project-manager.md`
-3. Before first **implement** dispatch: `mstar-dispatch-gates` + host reference
-4. Before **QC**: `mstar-review-qc`
-5. **SDD implement** (`Execution mode: sdd`): `mstar-sdd` before first implement dispatch
-6. **Iteration flow** (start / Execute / close): **`mstar-iteration`** — canonical SSOT for per-plan dispatch loop, integration branch, compound round. Do **not** re-describe the flow in this skill.
-7. **On demand:** `mstar-phase-gates`, `mstar-plan-conventions`, `mstar-plan-artifacts`, `mstar-branch-worktree`, `mstar-skill-authoring` for skill work
+2. `mstar-roles` → **`references/project-manager.md`** — required reading list, routing, dispatch-first, iteration branch policy
+3. Topic skills **on demand** per that file and the active workflow (`mstar-dispatch-gates`, `mstar-iteration`, `mstar-sdd`, `mstar-review-qc`, …)
 
-Prepare/Execute gates, routing, Assignment templates, Task Board, QC (SDD → tri; inline → single), residuals, compound → topic skills + PM references (not repeated here).
+## Three rules (everything else is a pointer)
 
-## Dispatch-first (`implement`)
+1. **Delegate** — PM does not implement, QC, or QA in-thread (`project-manager.md` Execution Boundary; hotfix → `mstar-phase-gates`).
+2. **Dispatch** — when host has invoke/Task tools: **1 Assignment ⇒ 1 invoke** (`mstar-dispatch-gates`). Markdown alone is not dispatch.
+3. **SSOT** — iteration lifecycle → **`mstar-iteration`** (or **`commands/`** on Cursor/OpenCode); Cursor Plan mode → **`mstar-host/references/cursor-plan-mode-bridge.md`**.
 
-| Do | Don't |
-| --- | --- |
-| **Loop:** `## Assignment` → invoke → Completion Report v2 → report-to-status → next batch | Parent **Write/Edit/Shell** on product code to "move faster" |
-| **1 Assignment ⇒ 1 invoke** when host supports Task/subagent (`mstar-dispatch-gates`) | Assignment markdown only, no matching invoke |
-| Put merge/branch/handoff from **this thread** into Assignment | Skip subagent because context is "already here" |
-
-- **NEVER** implement while staying PM — SDD ends with **plan QC tri** (N=3); **implement still delegates** dev + task reviewer subagents.
-- **Delegate scope / PM whitelist:** `mstar-roles` → PM Execution Boundary.
-
-**Exceptions:** user explicitly asks PM thread to implement; hotfix per `mstar-phase-gates`.
-
-## Iteration
-
-Formal iteration（Phase 1 → Phase 2 → Phase 3）→ **`mstar-iteration`** only. Do not duplicate phase gates, branch policy, or close checklists here.
-
-## Cursor Plan mode
-
-CreatePlan / SwitchMode: Read **`mstar-host/references/cursor-plan-mode-bridge.md`**. Bootstrap todos `harness-init` → `spec-register` → `mirror-plan` before implement todos; evidence on **subagent** work.
-
-## Conflict order
-
-1. User explicit instructions  
-2. Project `AGENTS.md` / `CLAUDE.md`  
-3. `mstar-harness-core` + runtime `mstar-*`  
-4. This skill  
-
-**Dispatch-first + `mstar-dispatch-gates`** win over "fast parent agent" unless user overrides.
+Conflict: user instructions → project `AGENTS.md` / `CLAUDE.md` → `mstar-harness-core` → this file.


### PR DESCRIPTION
## Summary

- **iteration-drive / mstar-iteration**: Phase 2 explicitly mandates per-task SDD orchestration (`mstar-sdd` in Boot, `task-brief` → implementer → `review-package` → task reviewer); forbids bulk inline implement Assignments for multi-task plans.
- **Sticky implementer session** (`SDD implementer session: sticky`): optional same dev subagent across tasks via Cursor Task `resume`; `implementer-session.json` ledger; task reviewers stay fresh per task.
- **`pm` skill**: thinned to cross-host entry shim (`/pm` on Codex/Cursor for general orchestration); formal iteration lifecycle remains in `commands/`.
- **Routing eval v14**: iteration Phase 2 SDD hard-fails + `sdd-sticky-implementer-multi-task` case.
- **Release**: bump all published surfaces to **1.0.1** with bilingual changelogs and README highlights.

## Test plan

- [x] `bun run typecheck`
- [x] SDD scripts smoke (`sdd-workspace`, `task-brief`, `review-package`)
- [x] `routing-evals.json` v14 validates (22 cases)
- [ ] Manual: `iteration-drive` on a multi-task plan — PM loads `mstar-sdd`, per-task dispatch (not inline bulk)
- [ ] Manual: Cursor sticky flow — Task 1 dispatch → save agent id → Task 2 `resume` + continuation prompt


Made with [Cursor](https://cursor.com)