### PR TITLE
Tighten iteration artifact boundaries (1.0.2)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,30 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.0.1** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.0.2** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.0.1** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.0.1** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.0.1** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.0.1** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.0.1** |
+| Monorepo root | `morning-star` (`package.json`) | **1.0.2** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.0.2** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.0.2** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.0.2** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.0.2** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [1.0.2] - 2026-07-07
+
+### Harness (iteration artifact boundaries)
+
+- **`mstar-iteration` §1.5.5 / §1.6**: Tighten Phase 1 boundaries — `{SPECS_DIR}/` for locked long-lived specs; `{ITERATION_DIR}/<iteration-id>/` workspace (`guides/`, `specs/`) for iteration-scoped drafts; **no** `{KNOWLEDGE_DIR}/` writes during iteration-start.
+- **`iteration-start` / `mstar-dispatch-gates`**: Review & Edit chain — product-manager / architect edit specs + workspace; writing-specialist **specs corpus hygiene** and existing-knowledge archive only.
+- **`mstar-compound`**: Mandatory **iteration workspace promotion** at iteration-close — inventory `<iteration-id>/` workspace; promote worthy specs/guides to `{KNOWLEDGE_DIR}/` (structured rewrite, not raw copy).
+- **New references**: `iteration-artifact-boundaries.md`, `iteration-corpus-hygiene.md`, `iteration-workspace-readme-template.md`; `knowledge-and-designs.md`, role refs, and `artifact-storage-paths.md` aligned.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex plugin manifests: **→ 1.0.2**.
 
 ## [1.0.1] - 2026-07-07
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,29 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.0.1**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.0.2**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.0.1** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.0.1** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.0.1** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.0.1** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.0.1** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.0.2** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.0.2** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.0.2** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.0.2** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.0.2** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [1.0.2] - 2026-07-07
+
+### Harness（iteration 产物边界收紧）
+
+- **`mstar-iteration` §1.5.5 / §1.6**：Phase 1 边界 — `{SPECS_DIR}/` 为已锁定长期规格；`{ITERATION_DIR}/<iteration-id>/` 工作区（`guides/`、`specs/`）存迭代级草案；**iteration-start 禁止**向 `{KNOWLEDGE_DIR}/` 新增。
+- **`iteration-start` / `mstar-dispatch-gates`**：Review & Edit 链 — product/architect 改 specs + workspace；writing-specialist 做 **specs corpus hygiene** 与既有 knowledge 归档。
+- **`mstar-compound`**：iteration-close **强制盘点** `<iteration-id>/` workspace，将值得保留的 specs/guides **提升**至 `{KNOWLEDGE_DIR}/`（结构化重写，非整文件复制）。
+- **新增 reference**：`iteration-artifact-boundaries.md`、`iteration-corpus-hygiene.md`、`iteration-workspace-readme-template.md`；`knowledge-and-designs.md`、角色引用、`artifact-storage-paths.md` 已对齐。
+
+### 版本对齐
+
+- monorepo、OpenCode、CLI、Cursor/Codex 插件：**→ 1.0.2**。
 
 ## [1.0.1] - 2026-07-07
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Core value:
 - Run with unified `mstar-*` skills instead of scattered rules
 - Reuse one core process across OpenCode, Cursor, and Codex
 
+**1.0.2:** Iteration artifact boundaries — `{SPECS_DIR}/` for long-lived specs; `{ITERATION_DIR}/<id>/` workspace for iteration drafts; **`mstar-compound`** promotes workspace to `{KNOWLEDGE_DIR}/` at iteration-close (no knowledge writes at iteration-start).
+
 **1.0.1:** `iteration-drive` mandates per-task SDD; optional **sticky implementer** (`SDD implementer session: sticky`, Cursor Task `resume`) to reuse dev context across tasks; thin **`pm`** entry shim for general orchestration (iteration → `commands/`).
 
 **1.0.0 highlights:** SDD (`mstar-sdd`) with per-task **task reviewer** + **mandatory plan QC tri-review** (QC#1/#2/#3 cross-review on whole branch). Single-seat `qc.md` only for `inline` / hotfix.

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,6 +23,8 @@
 - 通过统一的 `mstar-*` skills 执行，而不是散落规则
 - 在 OpenCode / Cursor / Codex 下复用同一套核心流程
 
+**1.0.2：** iteration 产物边界 — `{SPECS_DIR}/` 长期规格；`{ITERATION_DIR}/<id>/` 工作区放迭代草案；**iteration-close** 时 **`mstar-compound`** 将 workspace 提升进 `{KNOWLEDGE_DIR}/`（start 阶段不写 knowledge）。
+
 **1.0.1：** `iteration-drive` 强制 per-task SDD；可选 **sticky implementer**（`SDD implementer session: sticky`，Cursor Task `resume`）复用 dev 上下文；精简 **`pm`** 通用入口（iteration 走 `commands/`）。
 
 **1.0.0 亮点：** SDD（`mstar-sdd`）— 每 task **task reviewer** + plan 完成后的 **强制 QC 三审交叉审**（QC#1/#2/#3 看整分支 diff）。仅 `inline`/hotfix 用单席 `qc.md`。

--- a/commands/iteration-drive.md
+++ b/commands/iteration-drive.md
@@ -107,7 +107,7 @@ Execute **`mstar-iteration` § Phase 2** exactly. Summary:
 |------|---------|------|
 | 1 | §3.0 / §3.0.5 | Phase 边界；legacy compass 规范化（frontmatter + `## Roadmap Position`） |
 | 2 | §3.1 | 打印 close entry checklist，全部 `[x]` |
-| 3 | §3.2 | Compound；新增 doc 完成 `mstar-compound` Phase 6（`{KNOWLEDGE_DIR}/README.md`） |
+| 3 | §3.2 | Compound + **`<iteration-id>/` workspace promotion**；新增 doc 完成 `mstar-compound` Phase 6（`{KNOWLEDGE_DIR}/README.md`） |
 | 4 | §3.3 | `## Roadmap Position` current iteration → `delivered`；STRATEGY/tracker 按需更新 |
 | 5 | §3.4 | frontmatter `status: completed` + `end_date`；Compound Summary + Retrospective |
 | 6 | §3.5 | 打印 close exit checklist → commit → push |

--- a/commands/iteration-start.md
+++ b/commands/iteration-start.md
@@ -1,6 +1,6 @@
 ---
 name: iteration-start
-description: Start a new harness iteration — research backlog, lock direction with grill-me, produce compass/plans, run mandatory Review & Edit chain via sequential Task dispatch (product-manager → architect → writing-specialist, each review-and-edit, then PM final lock), then create the integration branch from an explicit base. Not Done until review chain completes, compass is locked, and base/target branches are recorded.
+description: Start a new harness iteration — research, grill-me, compass/plans, Review & Edit chain (long-lived {SPECS_DIR}/ + {ITERATION_DIR}/<id>/ workspace; compound promotes workspace at close only), PM lock, integration branch.
 agent: project-manager
 ---
 
@@ -28,7 +28,7 @@ Detailed workflow → **`mstar-iteration` § Phase 1: iteration-start**（含 §
 
 1. `mstar-harness-core`
 2. `mstar-roles` → `references/project-manager.md`
-3. `mstar-iteration` → **§ Phase 1: iteration-start**（迭代范围、compass 模板、§1.6 Review & Edit chain、状态初始化）
+3. `mstar-iteration` → **§ Phase 1: iteration-start**（迭代范围、compass 模板、**§1.5.5 产物边界**、§1.6 Review & Edit chain、状态初始化）
 4. `mstar-dispatch-gates`
 5. `mstar-phase-gates` → Prepare（specify → clarify → plan）
 6. `mstar-plan-conventions`, `mstar-plan-artifacts`
@@ -98,12 +98,12 @@ Each role below **reviews and directly edits** the documents. Do not just flag i
 
 | # | Role | Required action | Gate |
 |---|------|-----------------|------|
-| 5.1 | **product-manager** | invoke: **edit** compass, plans, `{SPECS_DIR}/`; scope, UX, priorities | 完成后方可 5.2 |
-| 5.2 | **architect** | invoke: **edit** compass, plans, specs（含 5.1 修订后版本）; contracts, SQL, module boundaries | 5.1 返回后；完成后方可 5.3 |
-| 5.3 | **writing-specialist** | invoke: **edit** all iteration docs（含 5.1–5.2 修订后版本）; terminology, structure, clarity | 5.2 返回后 |
+| 5.1 | **product-manager** | invoke: **edit** compass, plans, **`{SPECS_DIR}/`**, **`{ITERATION_DIR}/<iteration-id>/`**（`guides/`、`specs/` 按需）— **禁止** `{KNOWLEDGE_DIR}/` 新增 | 完成后方可 5.2 |
+| 5.2 | **architect** | invoke: **edit** compass, plans, **`{SPECS_DIR}/`**, workspace `specs/`（含 5.1 后版本）— **禁止** `{KNOWLEDGE_DIR}/` 新增 | 5.1 返回后；完成后方可 5.3 |
+| 5.3 | **writing-specialist** | invoke: **edit** compass / plans / specs / iteration 文档; **specs corpus hygiene**（全库 `{SPECS_DIR}/` + 既有 `{KNOWLEDGE_DIR}/` 卫生与错放纠正，**不**新增 knowledge）— `mstar-iteration/references/iteration-artifact-boundaries.md` + `iteration-corpus-hygiene.md` | 5.2 返回后 |
 | 5.4 | **project-manager** | Merge subagent edits; resolve conflicts; **lock** compass (`status: locked`); confirm Prepare gates | 5.3 返回后 |
 
-**Evidence of done** = edited compass / plans / specs on disk + compass `status: locked`. **No** separate iteration review reports under `reports/` — unlike per-plan QC, there is no downstream audit chain to preserve.
+**Evidence of done** = edited compass / plans / **specs** / iteration docs on disk + specs corpus hygiene（及既有 knowledge 归档/错放纠正，如有）+ compass `status: locked`. **No** new `{KNOWLEDGE_DIR}/` from this chain — knowledge → **`mstar-compound`** @ iteration-close. **No** separate iteration review reports under `reports/`.
 
 **Tool rule (hosts with invoke)** — per **`mstar-dispatch-gates`** · specialist review-and-edit dispatch（**顺序链**，非 parallel batch）：
 
@@ -128,9 +128,9 @@ PM must print this block before §6; all `[ ]` must be `[x]`:
 
 - [ ] grill-me decisions recorded in compass
 - [ ] Draft compass + plans + `status.json` registered
-- [ ] product-manager invoke completed — compass / plans / specs edited
-- [ ] architect invoke completed — compass / specs edited
-- [ ] writing-specialist invoke completed — iteration docs edited
+- [ ] product-manager invoke completed — compass / plans / specs / **`<iteration-id>/` workspace**（按需）；**未**向 `{KNOWLEDGE_DIR}/` 新增
+- [ ] architect invoke completed — compass / **specs** edited；**未**向 `{KNOWLEDGE_DIR}/` 新增
+- [ ] writing-specialist invoke completed — specs + iteration docs edited；**specs corpus hygiene** done（全库 `{SPECS_DIR}/`；既有 knowledge 仅卫生/归档；错放已迁回 `iterations/` 或 archive）
 - [ ] PM final lock: compass `status: locked`; Prepare gates pass (blocked plans documented)
 - [ ] Branch policy locked: `iteration_base_branch`, `spec_integration_branch`, and `target_branch` recorded in compass / `status.json`
 - [ ] **THEN**: git commit + push `iteration/<iteration-id>`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.0.2
+
+- Version alignment with harness **1.0.2** (no CLI behavior change in this release).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.0.2**.
+
 ## 1.0.1
 
 - Version alignment with harness **1.0.1** (no CLI behavior change in this release).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex).",
   "license": "MIT",
   "repository": {

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.0.2
+
+- Bundled skills/commands: iteration artifact boundaries (`{ITERATION_DIR}/<id>/` workspace, specs-first start, compound workspace promotion at close); new iteration references; corpus hygiene aligned.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.0.2**.
+
 ## 1.0.1
 
 - Bundled skills/commands: `iteration-drive` + `mstar-iteration` Phase 2 per-task SDD mandate; optional sticky implementer session (`resume` + ledger); thin `pm` skill shim; routing-eval v14.

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -1,0 +1,62 @@
+# @mstar-harness/opencode
+
+Morning Star (启明星) harness plugin for [OpenCode](https://opencode.ai).
+
+Install this package via OpenCode’s `plugin` array — it bundles `mstar-*` skills, role agents, and iteration commands so multi-role workflows (PM routing, SDD implement, QC tri-review, iteration lifecycle) work the same way as in the Cursor and Codex plugins.
+
+## Install
+
+Add to `opencode.json` (global or project):
+
+```json
+{
+  "plugin": ["@mstar-harness/opencode@latest"]
+}
+```
+
+Restart OpenCode.
+
+Or use the installer CLI:
+
+```bash
+npx @mstar-harness/cli init --target opencode
+```
+
+## What you get
+
+| Path in package | Contents |
+|-----------------|----------|
+| `harness-skills/` | `mstar-harness-core`, `mstar-iteration`, `mstar-sdd`, roles, phase/dispatch gates, … |
+| `harness-agents/` | Role shells (`project-manager`, `fullstack-dev`, `qc-specialist`, …) |
+| `harness-commands/` | `/iteration-start`, `/iteration-drive`, `/mstar-bootstrap` |
+
+The plugin resolves **only paths inside this package** — not `process.cwd()/skills`, so your app repo root does not affect harness loading.
+
+## Quick start
+
+1. Install the plugin (above).
+2. In OpenCode, start with the **Project Manager** agent (`project-manager`).
+3. For a full iteration: run **`/iteration-start`**, then **`/iteration-drive`** when plans are ready.
+
+Entry skill: **`mstar-harness-core`** (loaded before other `mstar-*` skills).
+
+## Docs
+
+- [INSTALL.md](./INSTALL.md) — setup, monorepo checkout, migration from legacy git plugin, troubleshooting
+- [Monorepo README](https://github.com/btspoony/mstar-harness#readme) — cross-host overview
+- [CHANGELOG.md](./CHANGELOG.md) — package release notes
+
+## Development (this monorepo)
+
+From the repository root:
+
+```bash
+bun install          # postinstall bundles harness-skills/ + harness-agents/
+bun run opencode:bundle-assets   # if you used --ignore-scripts
+```
+
+Plugin entry: `packages/opencode/src/mstar.ts` → `dist/mstar.js`.
+
+## License
+
+MIT — see [LICENSE](https://github.com/btspoony/mstar-harness/blob/main/LICENSE).

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -16,7 +16,9 @@
     "harness-agents",
     "harness-commands",
     "AGENTS.md",
-    "INSTALL.md"
+    "INSTALL.md",
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "bundle-assets": "bun run scripts/bundle-harness-assets.ts",

--- a/skills/mstar-compound-refresh/SKILL.md
+++ b/skills/mstar-compound-refresh/SKILL.md
@@ -45,7 +45,7 @@ For each candidate document, classify into one of five outcomes:
 3. **Match docs to reality.** When code differs from doc, update the doc — not ask whether the code change was "intentional."
 4. **Be decisive.** When evidence is clear (file renamed, class moved), apply. Only ask PM when genuinely ambiguous.
 5. **Avoid low-value churn.** Don't edit for typos, polish, or cosmetic changes that don't improve accuracy.
-6. **Delete, don't archive.** No `_archived/` directory. Git history is the archive. `git log --diff-filter=D -- <path>` finds deleted docs.
+6. **Delete, don't archive** — **except** formal **iteration-start** §1.6 corpus hygiene (`mstar-iteration/references/iteration-corpus-hygiene.md`), which **moves** superseded/redundant knowledge/specs to `{HARNESS_DIR}/archived/knowledge|specs/`. Outside that gate, git history is the archive; `git log --diff-filter=D -- <path>` finds deleted docs.
 7. **Evaluate document-set design.** Check whether two+ docs overlap and should be consolidated. Redundant docs silently drift apart.
 
 ## Scope selection

--- a/skills/mstar-compound/SKILL.md
+++ b/skills/mstar-compound/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-compound
-description: Morning Star 知识结晶 —— 将已解决问题的经验沉淀为结构化知识文档，存入 `{KNOWLEDGE_DIR}`。支持 Bug track（症状/失败尝试/解决方案）与 Knowledge track（上下文/指南/适用场景）双轨。含重叠检测（更新已有文档）、可发现性检查（AGENTS.md 索引）、CONCEPTS.md 领域词汇协同。触发：迭代收口时（`mstar-iteration` § iteration-close）批量执行；也可独立触发。产出：`{KNOWLEDGE_DIR}/<category>/<slug>.md` + 可选 AGENTS.md 更新。
+description: Morning Star 知识结晶 —— 将已解决问题的经验沉淀为结构化知识文档，存入 `{KNOWLEDGE_DIR}`；迭代收口时从 `{ITERATION_DIR}/<iteration-id>/` 工作区提升 specs/guides。支持 Bug track 与 Knowledge track 双轨。含重叠检测、可发现性检查、CONCEPTS.md 协同。触发：iteration-close（`mstar-iteration` §3.2）或独立触发。产出：`{KNOWLEDGE_DIR}/<category>/<slug>.md`。
 ---
 
 # mstar-compound（知识结晶）
@@ -79,6 +79,26 @@ iteration-start → [plan lifecycle × N: specify→...→Done] → iteration-cl
 
 迭代内所有 plan Done 后，PM 回顾整轮迭代中产生的可结晶知识，批量 compound。per-plan Done 是 per-plan 的闭环终点；compound 是迭代级收口活动。
 
+### Iteration workspace promotion（iteration-close 强制盘点）
+
+正式迭代收口时，compound **除** plan 实现/debug/review 素材外，**必须**盘点当前迭代的 workspace：
+
+**路径**：`{ITERATION_DIR}/<iteration-id>/**`（含 `guides/`、`specs/`、扁平 `.md`；不含根目录 `*-delivery-compass.md` 除非 PM 显式纳入）。
+
+| 步骤 | 动作 |
+|------|------|
+| 1. Inventory | 列出 workspace 下全部 `.md`；读各文件 + workspace `README.md`（若有） |
+| 2. Triage | 每篇：**Promote** / **Keep snapshot** / **Skip**（理由写入 compound 摘要） |
+| 3. Promote | 值得跨迭代复用 → 走 Q1–Q8（或轻量判定）→ Phase 2 重叠检测 → Phase 3–6 **结构化重写**进 `{KNOWLEDGE_DIR}/`（**禁止**无改写整文件复制） |
+| 4. Trace | 源文件顶栏或 workspace README：`Promoted to: <knowledge-path>`；`{KNOWLEDGE_DIR}/README.md` 的 Source 可记 `iteration:<iteration-id>/<relpath>` |
+| 5. Summary | PM 写入 compass `## Compound Round Summary`：提升篇数、保留快照、跳过及原因 |
+
+**Promote 典型**：迭代 spec 已验证且指导未来实现；guide 含非显而易见的过程知识或失败尝试。
+
+**Keep snapshot**：仅迭代史、已被 `{SPECS_DIR}/` 取代的草案、或自检 ≤2 Yes 的琐碎笔记。
+
+边界 SSOT → **`mstar-iteration/references/iteration-artifact-boundaries.md`**。
+
 ## When to use (trigger)
 
 - **迭代收口时**（`mstar-iteration` § iteration-close）：PM 批量回顾所有 plan 的产物
@@ -114,7 +134,9 @@ In Cursor, Full mode dispatches subagents via Task tool. PM selects mode.
 
 ## Phase 1: Gather context
 
-Read the conversation history to understand:
+Read the conversation history **and**, when `iteration_id` is known, scan **`{ITERATION_DIR}/<iteration-id>/`** workspace per **Iteration workspace promotion** above.
+
+Understand:
 - What problem was solved (the concrete issue)
 - What was tried and didn't work
 - What the working solution was

--- a/skills/mstar-dispatch-gates/SKILL.md
+++ b/skills/mstar-dispatch-gates/SKILL.md
@@ -87,7 +87,7 @@ When **`Execution mode: sdd`** (`mstar-sdd`):
 
 - PM 写初稿；各角色通过宿主 invoke **直接编辑**目标文件（**不**另写仅评论式 `reports/` 替代修订）。
 - **1 Assignment ⇒ 1 invoke**。
-- **Phase 1 Review & Edit chain**（`mstar-iteration` §1.6）：**顺序** `product-manager` → `architect` → `writing-specialist`；上一角色落盘修订完成后再派发下一角色。**禁止**本链并行 batch（与 QC 三审不同）。
+- **Phase 1 Review & Edit chain**（`mstar-iteration` §1.6）：主产出 **`{SPECS_DIR}/`** + **`{ITERATION_DIR}/<iteration-id>/`** workspace；**禁止** start 链向 `{KNOWLEDGE_DIR}/` 新增。close 时 **`mstar-compound`** 提升 workspace → knowledge。
 - 其他彼此独立、无先后依赖的文档编辑任务：可并行（同条消息发满 N），见 **`parallel-dispatch.md`**。
 - PM 线程代做全部专业编辑 = **反模式**（`mstar-iteration` §1.6、`mstar-harness-core` 反模式索引）。
 - PM merge / lock（如 compass `status: locked`）在链末 subagent 返回后于 PM 线程完成。**不得**在 review-and-edit 链完成前 commit integration 分支。

--- a/skills/mstar-iteration/SKILL.md
+++ b/skills/mstar-iteration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-iteration
-description: Morning Star 迭代管理 —— iteration-start、Autonomous Execute（per-plan SDD + plan QC tri）、iteration-close、PR 交付（Phase 4）、PR merge-ready loop（Phase 5）。显式分支策略；compass `{ITERATION_DIR}/`；分支 SSOT：`status.json` metadata + compass frontmatter。**必须**在 iteration-start / iteration-drive / 多 plan 编排、integration 分支、iteration-close 或 PR merge-ready 时 Read；`@project-manager` 迭代编排必读。
+description: Morning Star 迭代管理 —— iteration-start（specs + `<iteration-id>/` workspace；禁止直写 knowledge）、Autonomous Execute、iteration-close（compound 提升 workspace → knowledge）、PR 交付、PR merge-ready loop。分支 SSOT：`status.json` + compass frontmatter。
 ---
 
 # mstar-iteration（迭代管理）
@@ -43,7 +43,7 @@ Phase 5: PR merge-ready loop —— 至 mergeable + CI 全绿 + reviews resolved
 | **→ Phase 4** | §3.5 exit checklist 全 `[x]`；frontmatter `status: completed` + `end_date` | 打印 `## Phase 4: PR delivery`；开 PR 到 `metadata.target_branch`（§4） | 跳过 §3.1 entry checklist 或 compound Phase 6 |
 | **→ Phase 5** | Phase 4 PR 已创建 | 打印 `## Phase 5: PR merge-ready`；执行 §5 loop 至 §5.5 exit | 开 PR 后停止；跳过 review resolve / CI loop |
 | **→ 迭代交付完成** | §5.5 exit checklist 全 `[x]` | PR mergeable；required CI 全绿；reviews resolved | Phase 4 开 PR 即宣称完成 |
-| **iteration-start → integration branch** | §1.6 Review & Edit chain | 三角色 **按序** invoke 完成 + compass `status: locked` | PM 线程代做三角色编辑；并行三角色；review 前 commit |
+| **iteration-start → integration branch** | §1.6 Review & Edit chain | 三角色按序 invoke；**specs** 为主产出；**禁止** start 链向 `{KNOWLEDGE_DIR}/` 新增；writing-specialist corpus hygiene + compass `status: locked` | PM 代做专业编辑；并行三角色；product/architect 写 knowledge；临时笔记进 specs |
 
 **误判信号**：对话里出现 compound 摘要、roadmap 更新、或「所有 plan 已完成」但 **未** 打印 §3.1 / §3.5 checklist → 视为 **Phase 3 未执行**，回到 §3.0。
 
@@ -153,18 +153,31 @@ iteration 正式全流程**必须**写入 `{HARNESS_DIR}/status.json`：
 
 compass frontmatter 的 `iteration_base_branch` / `target_branch` **必须与** `status.json` 一致；若仅写在 compass 而 status 缺失，§2.3 同轮 backfill。
 
+### 1.5.5 产物边界（specs · iterations · knowledge）
+
+Phase 1 与 §1.6 须遵守 **`references/iteration-artifact-boundaries.md`**（HARD）：
+
+| 树 | iteration-start 主责 | 说明 |
+|----|---------------------|------|
+| **`{SPECS_DIR}/`** | product-manager、architect | **长期**规范性产出：锁定规格、ADR、契约；plan `primary_spec` / `spec_refs` 主要挂此处 |
+| **`{ITERATION_DIR}/`** | product-manager、architect、PM | compass（根）+ **`<iteration-id>/` workspace**（迭代级 specs & guides） |
+| **`{KNOWLEDGE_DIR}/`** | **非** start/execute 直写；**`mstar-compound`** @ iteration-close（含 workspace **提升**） | 可复用实施 SSOT |
+
+**禁止**：product/architect 在 §1.6 向 `{KNOWLEDGE_DIR}/` **新增**；把迭代级草案写入 `{SPECS_DIR}/`（应进 `<iteration-id>/specs/` 或 guides）。
+
 ### 1.6 Review & Edit chain（integration 分支前强制）
 
 **Phase 1 在 PM lock 前不算完成**——compass/plans 初稿落盘 ≠ Done。
 
 派发机制 → **`mstar-dispatch-gates`**（specialist review-and-edit dispatch，**顺序链**）。PM **不得**将迭代 harness 文档 commit 到 `spec_integration_branch`，直到：
 
-1. **product-manager** → **architect** → **writing-specialist** 已按序通过宿主 invoke **直接编辑**（非仅评论）compass、plans 及受影响 specs；每一环基于上一环落盘修订
-2. PM 将 compass `status` 设为 `locked`，并确认各 plan 的 Prepare gate（specify / clarify / plan）
+1. **product-manager** → **architect** → **writing-specialist** 已按序 invoke 编辑 compass、plans、`{SPECS_DIR}/` 与 **`{ITERATION_DIR}/<iteration-id>/`** workspace（guides/specs，按需）；**不得**在 start 链向 `{KNOWLEDGE_DIR}/` 新增
+2. **writing-specialist** 完成 **corpus hygiene**：全库 `{SPECS_DIR}/` + 既有 `{KNOWLEDGE_DIR}/` 卫生；错放迁回 **`<iteration-id>/`** workspace；细则 → **`iteration-corpus-hygiene.md`**、**`iteration-artifact-boundaries.md`**
+3. PM 将 compass `status` 设为 `locked`，并确认各 plan 的 Prepare gate（specify / clarify / plan）
 
-**顺序理由**：产品范围与优先级 → 架构与契约 → 术语与行文；并行会导致后手重复劳动或覆盖前手未定稿内容。OpenCode：plain role id — **`mstar-host/references/opencode.md`** § Role-mention hygiene。
+**顺序理由**：产品范围与优先级 → 架构与长期契约（specs）→ 行文、规格库卫生与错放纠正（须在 PM/architect 定稿后扫全库 specs）。并行会导致后手重复劳动或覆盖前手未定稿内容。OpenCode：plain role id — **`mstar-host/references/opencode.md`** § Role-mention hygiene。
 
-**完成证据** = 磁盘上的 compass / plans / specs 修订 + compass `status: locked`。**不**要求 `reports/<iteration-id>/` 审查报告——迭代审查的 SSOT 是被编辑的文档本身，无 per-plan QC 式审计链。
+**完成证据** = 磁盘上的 compass / plans / specs / iteration 文档修订 + specs（与既有 knowledge）卫生/归档（如有）+ 索引与 metadata 更新 + compass `status: locked`。**不**要求 `reports/<iteration-id>/` 审查报告——迭代审查的 SSOT 是被编辑的文档本身，无 per-plan QC 式审计链。
 
 **反模式**：PM 线程代替三角色完成全部编辑而不 invoke；或将本链三角色并行派发 —— 见 **`mstar-harness-core`** 反模式索引。
 
@@ -322,11 +335,12 @@ PM **必须**在对话中打印本 checklist；不得默认同过。
 PM 批量触发后须：
 
 1. 收集本迭代 plan 实现 / debug / review 素材，筛候选知识
-2. 逐条过 `mstar-compound` 自检；跳过项记入 compass `## Compound Round Summary`
-3. 写入或更新 `{KNOWLEDGE_DIR}/<category>/<slug>.md`；新领域词更新 `CONCEPTS.md`
-4. **每篇**新 doc 完成 Phase 6（`{KNOWLEDGE_DIR}/README.md` 登记）
+2. **盘点** `{ITERATION_DIR}/<iteration-id>/**` workspace（`guides/`、`specs/`）— **`mstar-compound`**「Iteration workspace promotion」；提升值得保留者进 `{KNOWLEDGE_DIR}/`
+3. 逐条过 `mstar-compound` 自检；跳过项记入 compass `## Compound Round Summary`
+4. 写入或更新 `{KNOWLEDGE_DIR}/<category>/<slug>.md`；新领域词更新 `CONCEPTS.md`
+5. **每篇**新 doc 完成 Phase 6（`{KNOWLEDGE_DIR}/README.md` 登记）
 
-若无结晶，仍在 `## Compound Round Summary` 写明 `无可结晶知识` 及原因。
+若无结晶且无 workspace 提升，仍在 `## Compound Round Summary` 写明 `无可结晶知识` / workspace 盘点结论及原因。
 
 ### 3.3 更新 roadmap
 
@@ -350,7 +364,7 @@ PM 批量触发后须：
 PM 打印 **iteration-close exit checklist**；全部为 `[x]` 后方可 `git commit`；然后进入 **Phase 4**（§4）：
 
 - [ ] §3.1 前置 gate 已打印并满足
-- [ ] §3.2 compound 完成；新增 knowledge doc 均已登记 `{KNOWLEDGE_DIR}/README.md`（或已记录无可结晶原因）
+- [ ] §3.2 compound 完成；**`<iteration-id>/` workspace 已盘点**（提升 / 保留 / 跳过已记入 Compound Summary）；新增 knowledge doc 均已登记 `{KNOWLEDGE_DIR}/README.md`（或已记录无可结晶原因）
 - [ ] §3.3 `## Roadmap Position` current iteration 已标 `delivered`；tracker / STRATEGY 已按需更新
 - [ ] §3.4 frontmatter `status: completed` + `end_date`；Compound Summary + Retrospective 已填
 - [ ] 当前分支是 `spec_integration_branch`
@@ -436,8 +450,11 @@ PR **merge** 本身可仍由用户手动执行，除非 Assignment 明确授权 
 | `mstar-sdd` | SDD implement 波次 — per-plan loop |
 | `mstar-review-qc` | SDD 强制 plan QC tri — per-plan loop |
 | `mstar-branch-worktree` | 分支/merge/worktree 隔离 |
-| `mstar-compound` | iteration-close 中触发知识结晶 |
+| `mstar-compound` | iteration-close 中触发知识结晶（**唯一**默认 knowledge 新增路径） |
 | `mstar-compound-refresh` | iteration-close 后可触发知识维护 |
+| `references/iteration-artifact-boundaries.md` | Phase 1 specs / iterations workspace / knowledge 分工 |
+| `references/iteration-workspace-readme-template.md` | `<iteration-id>/README.md` 可选模板 |
+| `references/iteration-corpus-hygiene.md` | §1.6 writing-specialist specs 卫生细则 |
 | `mstar-strategy` | iteration-start 时读 `STRATEGY.md` 对齐方向 |
 
 ## NOT to do
@@ -453,5 +470,8 @@ PR **merge** 本身可仍由用户手动执行，除非 Assignment 明确授权 
 - 不要跳过 compound Phase 6（`{KNOWLEDGE_DIR}/README.md` 索引）——即使只结晶一篇文档
 - 不要跳过 compound——如果本迭代确实没有可结晶的知识，在 compass `## Compound Round Summary` 写 `无可结晶知识（原因：<简述>）`
 - 不要将 **Phase 4 开 PR** 等同于 **迭代交付完成** — 必须完成 **Phase 5** §5.5 merge-ready loop
-- 不要在 Phase 5 跳过 review comment + resolve 纪律（§5.1 step 5）
+- **不要在 iteration-start §1.6 由 product/architect 向 `{KNOWLEDGE_DIR}/` 新增文档**（知识 → iteration-close **`mstar-compound`**）
+- **不要把迭代级草案写入 `{SPECS_DIR}/`**（应进 `{ITERATION_DIR}/<iteration-id>/specs/` 或 `guides/`）
+- **不要在 iteration-close 跳过 `<iteration-id>/` workspace 盘点**（compound 提升 SSOT → **`mstar-compound`**）
+- **不要在 iteration-start §1.6 跳过 writing-specialist 全库 specs corpus hygiene**（仅改当轮 compass/plans 而不扫 `{SPECS_DIR}/`）
 - **不要在 SDD plan 上以单席 `qc.md` 收尾**（除非用户书面 `QC mode: single — override`）

--- a/skills/mstar-iteration/references/iteration-artifact-boundaries.md
+++ b/skills/mstar-iteration/references/iteration-artifact-boundaries.md
@@ -1,0 +1,94 @@
+# iteration-start 产物边界（specs · iterations · knowledge）
+
+> **When**: Phase 1 — PM 初稿落盘、§1.6 Review & Edit chain；Phase 2 迭代执行期可继续写入 iteration workspace；Phase 3 iteration-close 经 **`mstar-compound`** 提升。
+> **Conflict**: 与 `mstar-plan-artifacts/references/knowledge-and-designs.md` 一致；冲突以 **`mstar-harness-core`** 为准。
+
+## 三棵树分工（HARD）
+
+| 树 | 路径 | 长期价值 | 谁写（何时） | 典型内容 |
+|----|------|----------|--------------|----------|
+| **Specs（仓库级）** | `{SPECS_DIR}/` | **是** — 跨迭代规范性权威 | product / architect @ **iteration-start** | 已锁定产品/API 规格、ADR、契约 |
+| **Iterations** | `{ITERATION_DIR}/` | **迭代级** — 历史快照；可提升 | product / architect / PM @ start & execute | compass + **`<iteration-id>/` workspace** |
+| **Knowledge** | `{KNOWLEDGE_DIR}/` | **是** — 可复用实施 SSOT | **`mstar-compound`** @ **iteration-close**（含 workspace 提升） | 结晶、提升后的长期实施知识 |
+
+```text
+iteration-start / execute
+  product / architect  ──►  {SPECS_DIR}/              已锁定的长期规格
+                         ──►  {ITERATION_DIR}/<id>/   迭代级 specs + guides（工作区）
+                         ✗   {KNOWLEDGE_DIR}/          不直接新增
+
+iteration-close (§3.2)
+  mstar-compound       ──►  读 plan 素材 + {ITERATION_DIR}/<id>/**
+                         ──►  {KNOWLEDGE_DIR}/          提升值得保留的 specs/guides
+```
+
+## `{ITERATION_DIR}/<iteration-id>/` 工作区（迭代级 specs & guides）
+
+compass 仍在根目录：`**{ITERATION_DIR}/<iteration-id>-delivery-compass.md**`（现有约定）。**迭代级** specs / guides 放入同名子目录工作区：
+
+```text
+{ITERATION_DIR}/
+  README.md
+  <iteration-id>-delivery-compass.md
+  <iteration-id>/
+    README.md              # 可选：本迭代工作区索引
+    guides/                # 探索笔记、过程指南、未锁定权衡
+    specs/                 # 迭代级规格草案（尚未升格到 {SPECS_DIR}/ 或 knowledge）
+    <flat-files>.md        # 允许；大迭代可再分子目录
+```
+
+| 子路径 | 放什么 | 不放什么 |
+|--------|--------|----------|
+| **`<iteration-id>/guides/`** | 候选方案、调研、会议记录、实施过程说明 | 已锁定的仓库级规范 |
+| **`<iteration-id>/specs/`** | 本迭代演进中的规格、迭代内契约草稿 | 已锁定、跨迭代 `{SPECS_DIR}/` 级权威（应升格或已在 `{SPECS_DIR}/`） |
+| **compass（根）** | 范围、plans 表、验收、分支策略 | 长文探索正文（链到 workspace） |
+
+**何时用 workspace 而非单文件 working guide**：一篇 guide 不够时，**默认**用 `<iteration-id>/` 目录；单文件 `<iteration-id>-working-guide.md` 仍允许作轻量入口（可链接进 workspace）。
+
+**索引**：`{ITERATION_DIR}/README.md` 登记 compass 行 + workspace 目录行；workspace 内 `README.md` 列出 `guides/`、`specs/` 下文档。
+
+## `{SPECS_DIR}/` 准入（仓库级长期）
+
+写入 `{SPECS_DIR}/` 前须满足 **至少一条**（与 iteration workspace 区分）：
+
+- 决策**已锁定**，变更需显式评审
+- 跨 plan、跨迭代仍成立
+- 本迭代及后续 plan 的 **`primary_spec` / `spec_refs`** 权威来源
+
+**不应**进 `{SPECS_DIR}/`：
+
+- 仍在迭代内演进的草案 → **`<iteration-id>/specs/`**
+- 探索 scratch → **`<iteration-id>/guides/`**
+- 实施踩坑（未整理）→ 留 workspace 或 plan 素材，**close 时 compound 提升**
+
+## Knowledge 与 compound 提升
+
+- **`{KNOWLEDGE_DIR}/` 新增**：默认仅在 **iteration-close** §3.2 **`mstar-compound`**。
+- **提升来源（iteration-close）**：除 plan 实现/debug/review 素材外，**必须盘点** `{ITERATION_DIR}/<iteration-id>/**`（`guides/`、`specs/`、扁平文件）。值得跨迭代复用的内容 → 按 compound 双轨模板**重写**进 `{KNOWLEDGE_DIR}/`（非整文件复制）；细则 → **`mstar-compound`**「Iteration workspace promotion」。
+- **提升后**：在源文件顶部或 workspace `README.md` 标注 `Promoted to: {KNOWLEDGE_DIR}/...`；源文件**保留**为迭代历史（或迁入 `<iteration-id>/archived/` 若团队约定）。
+- **iteration-start §1.6**：product / architect **不得**向 `{KNOWLEDGE_DIR}/` **新增**；误写由 writing-specialist 迁回 **workspace**。
+
+## §1.6 各角色编辑范围
+
+| 角色 | 必须编辑 | 禁止 |
+|------|----------|------|
+| **product-manager** | compass、plans、`{SPECS_DIR}/`、`{ITERATION_DIR}/<iteration-id>/`（guides/specs） | `{KNOWLEDGE_DIR}/` **新增**；迭代草案写入 `{SPECS_DIR}/` |
+| **architect** | 同上 + workspace `specs/` 技术向 | 同上；在 `{SPECS_DIR}/` 堆实施踩坑 |
+| **writing-specialist** | 当轮文档 + `{SPECS_DIR}/` corpus hygiene + 既有 knowledge 卫生 | 代替 compound **提升**；跳过 specs 全库审查 |
+
+Phase 2 执行期：各角色可继续向 **`<iteration-id>/`** 追加 guides/specs；**仍不**直写 `{KNOWLEDGE_DIR}/`。
+
+## plans[].metadata 挂接
+
+| 内容 | 挂接键 | 路径 |
+|------|--------|------|
+| 仓库级锁定规格 | `primary_spec` / `spec_refs` | `{SPECS_DIR}/` |
+| 迭代上下文 | `iteration_compass` / `iteration_refs` | compass + `{ITERATION_DIR}/<iteration-id>/...` |
+| 知识库（已有） | 仅历史链接 | `{KNOWLEDGE_DIR}/` — **start 不新增** |
+
+## 反模式
+
+- 用 `{KNOWLEDGE_DIR}/` 存迭代探索（应进 `<iteration-id>/guides/`）
+- 把迭代 workspace 草案直接复制进 `{SPECS_DIR}/` 而不锁定评审
+- iteration-close **只做** plan 素材 compound、**不**盘点 `<iteration-id>/` workspace
+- 提升时整文件复制到 knowledge（应 compound 结构化重写）

--- a/skills/mstar-iteration/references/iteration-compass-template.md
+++ b/skills/mstar-iteration/references/iteration-compass-template.md
@@ -71,6 +71,20 @@ Status values: `Todo` | `InProgress` | `InReview` | `Done` | `Blocked`
 |------|-----------|--------|------------|
 | <risk> | Low/Med/High | Low/Med/High | <mitigation> |
 
+## Iteration workspace (optional)
+
+> Iteration-level **specs** and **guides** live under `{ITERATION_DIR}/<iteration-id>/` — not in `{SPECS_DIR}/` or `{KNOWLEDGE_DIR}/`. Promoted to knowledge at iteration-close via **`mstar-compound`**.
+
+| Path | Purpose |
+|------|---------|
+| `<iteration-id>/guides/` | Exploration, process notes |
+| `<iteration-id>/specs/` | Iteration-scoped spec drafts |
+| `<iteration-id>/README.md` | Workspace index (recommended when non-trivial) |
+
+Link from compass when used:
+
+- Workspace: `<iteration-id>/` | <one-line purpose>
+
 ## Compound Round Summary
 
 > Filled at iteration-close.
@@ -105,6 +119,7 @@ Status values: `Todo` | `InProgress` | `InReview` | `Done` | `Blocked`
 | `## Non-Goals` | Yes | Phase 1 |
 | `## Roadmap Position` | **Yes** | Phase 1（必填节，非散落于 general context prose）；Phase 3 §3.3（current iteration → `delivered`） |
 | `## Risk Register` | Optional | Phase 1, Phase 2 (update) |
+| Iteration workspace (`<iteration-id>/`) | Optional | Phase 1 §1.5.5 — `guides/` + `specs/`; index in `{ITERATION_DIR}/README.md` |
 | `## Compound Round Summary` | Yes | Phase 3 §3.4 |
 | `## Iteration Retrospective` | Recommended | Phase 3 §3.4 |
 

--- a/skills/mstar-iteration/references/iteration-corpus-hygiene.md
+++ b/skills/mstar-iteration/references/iteration-corpus-hygiene.md
@@ -1,0 +1,51 @@
+# iteration-start corpus hygiene（specs primary · knowledge read-only）
+
+> **When**: Phase 1 §1.6 — **writing-specialist** only, after product/architect landed compass / plans / `{SPECS_DIR}/` / **`{ITERATION_DIR}/<iteration-id>/`** workspace.
+> **Boundaries**: **`iteration-artifact-boundaries.md`** — no `{KNOWLEDGE_DIR}/` adds @ start; iteration drafts → **`<iteration-id>/guides/`** or **`specs/`**.
+
+## Scope (HARD)
+
+| Priority | Tree | Action |
+|----------|------|--------|
+| **Primary** | `{SPECS_DIR}/**` | Full active corpus review |
+| **Included** | `{ITERATION_DIR}/<iteration-id>/**` | Workspace guides/specs + compass cross-links |
+| **Secondary** | `{KNOWLEDGE_DIR}/**` (existing) | Archive / relocate only — **no** new docs |
+| **Included** | `{PLAN_DIR}/` plans touched this iteration | Spec refs, terminology |
+
+**Out of scope**: compound promotion (iteration-close); `{PLAN_DIR}/reports/`; code.
+
+## Misplaced content (relocate)
+
+| Found in | Target |
+|----------|--------|
+| `{SPECS_DIR}/` | Iteration-only draft → `{ITERATION_DIR}/<iteration-id>/specs/` or `guides/` |
+| `{SPECS_DIR}/` | Implementation/debug notes → workspace `guides/` (compound @ close) |
+| `{KNOWLEDGE_DIR}/` | New exploration from start chain → `<iteration-id>/guides/` or archive |
+| Flat `{ITERATION_DIR}/*-working-guide.md` | OK as entry; or merge into `<iteration-id>/guides/` when workspace exists |
+
+## Classification
+
+Same as before for specs + existing knowledge: Active / Superseded / Redundant / Obsolete / Unclear → archive under `archived/specs/` or `archived/knowledge/` with relative path preserved.
+
+## Index and metadata
+
+1. `{SPECS_DIR}/README.md` — update as needed
+2. `{KNOWLEDGE_DIR}/README.md` — archive rows only; no new iteration exploration rows
+3. `{ITERATION_DIR}/README.md` — compass + **`<iteration-id>/` workspace** directory row
+4. `{ITERATION_DIR}/<iteration-id>/README.md` — list guides/specs (create if non-trivial)
+5. `plans[].metadata` — `primary_spec` / `spec_refs` → `{SPECS_DIR}/`; `iteration_refs` → workspace paths
+
+## Evidence of done
+
+- No iteration scratch left in `{SPECS_DIR}/`
+- Workspace used for iteration-level drafts (`<iteration-id>/guides|specs/`)
+- No new `{KNOWLEDGE_DIR}/` from §1.6 chain
+- Completion Report lists workspace paths + spec hygiene moves
+
+## Distinction from compound @ iteration-close
+
+| | §1.6 hygiene | compound workspace promotion |
+|--|--------------|------------------------------|
+| When | iteration-start | iteration-close §3.2 |
+| `{ITERATION_DIR}/<id>/` | Create/edit drafts | **Inventory → promote** to `{KNOWLEDGE_DIR}/` |
+| `{KNOWLEDGE_DIR}/` | No new writes | Structured new docs |

--- a/skills/mstar-iteration/references/iteration-workspace-readme-template.md
+++ b/skills/mstar-iteration/references/iteration-workspace-readme-template.md
@@ -1,0 +1,29 @@
+# Iteration workspace README (template)
+
+Optional index inside `{ITERATION_DIR}/<iteration-id>/`. Copy when the workspace has more than a few files.
+
+```markdown
+# <iteration-id> workspace
+
+Iteration-scoped **specs** and **guides** — not `{KNOWLEDGE_DIR}/`. Worthy content is **promoted** at iteration-close via `mstar-compound`.
+
+## Guides
+
+| Document | Description | Status |
+|----------|-------------|--------|
+| [guides/<name>.md](guides/<name>.md) | <purpose> | draft / active / promoted |
+
+## Specs (iteration-level)
+
+| Document | Description | Status |
+|----------|-------------|--------|
+| [specs/<name>.md](specs/<name>.md) | <purpose> | draft / locked-in-{SPECS_DIR} / promoted |
+
+## Promotion log (filled at iteration-close)
+
+| Source | Promoted to | Date | Notes |
+|--------|-------------|------|-------|
+| | | | |
+```
+
+**Status values**: `draft` | `active` | `promoted` (link knowledge path) | `superseded` | `snapshot-only`

--- a/skills/mstar-plan-artifacts/references/knowledge-and-designs.md
+++ b/skills/mstar-plan-artifacts/references/knowledge-and-designs.md
@@ -12,9 +12,9 @@
 | 区域 | 典型内容 | 受众 / 权威 |
 |------|----------|-------------|
 | **`docs/`**（或项目约定的用户文档根） | 安装/quickstart、稳定架构概览、贡献指南、对外 API 说明 | 人类贡献者与终端用户；clone 后应可读 |
-| **`{SPECS_DIR}`**（可选） | 冻结 v1-spec、ADR、program roadmap | 产品/API 规范性最高权威；变更须显式流程 |
-| **`{ITERATION_DIR}`**（可选） | `*-delivery-compass-*`、`*-program-compass-*`、版本范围/验收/风险、遗留 `v1.*` 规划快照 | Agent handoff；**不**替代 `{SPECS_DIR}` |
-| **`{KNOWLEDGE_DIR}`**（可选） | 实现细节 SSOT、架构细则、契约说明、跨版本 tracker、性能基线 | Agent handoff；**不**覆盖 `{SPECS_DIR}` 中的规范性条款 |
+| **`{SPECS_DIR}`**（可选） | 冻结 v1-spec、ADR、program roadmap — **跨迭代长期权威** | 产品/API 规范性最高权威；**iteration-start** 由 product/architect 主写 |
+| **`{ITERATION_DIR}`**（可选） | delivery compass + **`<iteration-id>/` workspace**（`guides/`、`specs/`） | Agent handoff；迭代级草稿；close 时 compound **提升** → knowledge |
+| **`{KNOWLEDGE_DIR}`**（可选） | 实现细节 SSOT、架构细则、契约说明、跨版本 tracker — **经 `mstar-compound` 结晶** | Agent handoff；**不**在 iteration-start 由 product/architect 新增 |
 | **`{PLAN_DIR}/`** | 单 plan 主文件、`reports/`、可选 `residuals/` | 计划执行与审查留档 |
 
 
@@ -23,15 +23,21 @@
 ## `{ITERATION_DIR}`（可选·迭代/版本级 compass）
 
 - **物理路径**：`**{ITERATION_DIR}/**`（推荐布局下常为 `**.mstar/iterations/**`，与 `{KNOWLEDGE_DIR}`、`{PLAN_DIR}` 并列；legacy 项目可继续为 `.agents/iterations/`）。
-- **放什么**：某一**交付版本或迭代**的范围、里程碑、验收、风险、program 备注；命名示例 `v1.15-delivery-compass-v1.md`、`*-program-compass-*.md`；遗留非标准 `v1.*` 规划快照可保留于此并列入索引。
-- **不放什么**：可跨版本复用的实现 SSOT（进 `{KNOWLEDGE_DIR}`）；冻结产品/API 规范（进 `{SPECS_DIR}`）；单 plan 的 QC 留档（进 `{PLAN_DIR}/reports/`）。
-- **索引**：**必须**维护 `**{ITERATION_DIR}/README.md**`：至少 **Document**、**Version / iteration**、**Description**；可按「Delivery compasses」与「Legacy artifacts」分表。
-- **与 plan 的链接**：在 `**plans[].metadata**` 中可用 `**iteration_compass**`（单文件）或 `**iteration_refs**`（`string[]`）登记仓库内相对路径；PM 在 Assignment 点名本轮须读的 compass。
-- **维护**：`@product-manager` / `@architect` 起草；`**@project-manager**` 维护 README 与 metadata 挂接；compass 定稿后**少改多版本**（新版本优先新文件名 `v<N>` 或新 compass 文件）。
+- **放什么**：delivery compass（根目录 `*-delivery-compass*.md`）；**`<iteration-id>/` 工作区** — `guides/`（探索、过程）、`specs/`（迭代级规格草案）；遗留规划快照。
+- **不放什么**：已锁定的仓库级规范（→ **`{SPECS_DIR}/`**）；已提升的跨迭代实施 SSOT（→ **`{KNOWLEDGE_DIR}/`**，经 compound）；单 plan QC（→ `reports/`）。
+- **索引**：`**{ITERATION_DIR}/README.md**` 登记 compass + workspace 目录；`<iteration-id>/README.md` 登记工作区内文档。
+- **维护**：`@product-manager` / `@architect` 起草 workspace；`**@project-manager**` 维护索引与 metadata；**iteration-close** 时 **`mstar-compound`** 盘点 workspace 并**提升**至 `{KNOWLEDGE_DIR}/`。
+
+## `{SPECS_DIR}`（可选·长期规格）
+
+- `{SPECS_DIR}` 解析：优先 `{HARNESS_DIR}/specs/`，否则 `{HARNESS_DIR}/designs/`；皆无则建议新建 `specs/`。
+- **放什么**：跨迭代有效、已锁定或待锁定的产品/API 规范、ADR、契约 — **iteration-start 主产出**（product/architect）。
+- **不放什么**：本迭代-only 探索（→ `<iteration-id>/guides/`）；迭代级 spec 草案（→ `<iteration-id>/specs/`）；实施踩坑原文（→ workspace 或 plan 素材，**close 时 compound 提升**）。
+- **索引**：非 trivial 树建议 `{SPECS_DIR}/README.md`；plan **`primary_spec` / `spec_refs`** 主要指向此处。
 
 ## `{KNOWLEDGE_DIR}`（可选·实施知识库）
 
-- `{SPECS_DIR}` 定义：优先 `{HARNESS_DIR}/specs/`，否则 `{HARNESS_DIR}/designs/`；若两者都不存在，建议新建 `{HARNESS_DIR}/specs/`。
+- **新增 SSOT 默认路径**：**iteration-close** 时经 **`mstar-compound`** 写入；**iteration-start §1.6 禁止** product/architect 新增（见 **`mstar-iteration/references/iteration-artifact-boundaries.md`**）。
 - **必须**维护 `**{KNOWLEDGE_DIR}/README.md**` 作为**目录索引**：至少包含表格列 **Document（链接）**、**Source Plan（`plans[].id`）**、**Description**、**Status**（如 `Active` / `Superseded by implementation (<plan-id>)` / `Archived`）。
 - 可选：目录级 `**{KNOWLEDGE_DIR}/AGENTS.md**` 承载命名、维护节奏、与 `{SPECS_DIR}` 的权威边界（Nexus 模式）；harness 宽规则仍以 `mstar-plan-conventions` 与本 reference 为准。
 - 初始化启用知识库时：创建空表头的 `README.md`，随文档递增行。
@@ -44,16 +50,21 @@
 
 ## 与 `status.json` 的链接
 
-- 某 plan 的**权威设计输入**在知识库、迭代 compass 或规格目录中时，在 `**plans[].metadata**` 中登记路径，推荐使用已列标准键：`**primary_spec**`（单文件）、`**spec_refs**`（`string[]`）、`**iteration_compass**` / `**iteration_refs**`（迭代级，可选）。路径为**仓库内相对路径**（推荐布局下常写作 `**.mstar/knowledge/....md**`、`**.mstar/iterations/....md**` 或 `**.mstar/specs/....md**`；兼容旧目录时也可为 `.agents/...`）。
+- 某 plan 的**权威设计输入**在规格、迭代 compass 或（已有）知识库中时，在 `**plans[].metadata**` 中登记路径：`**primary_spec**` / `**spec_refs**` → 优先 **`{SPECS_DIR}/`**；`**iteration_compass**` / `**iteration_refs**` → **`{ITERATION_DIR}/`**；已有 **`{KNOWLEDGE_DIR}/`** 链接保留，但 **iteration-start 不得新增** knowledge 路径。
 - 执行方在 **implement 前**须按 metadata 读取这些文件，并与主 plan 核对；不得在未读链接文档的情况下**静默偏离**其中已写明的决策（若需偏离，先回写 knowledge 或 plan 并走 PM/architect 门禁）。
 
 ## 维护规则
 
-1. **新增**：按命名规则添加 `.md` → 在 `{KNOWLEDGE_DIR}/README.md` 或 `{ITERATION_DIR}/README.md` 索引表增加一行 → 在相关 `plans[].metadata` 更新 `primary_spec` / `spec_refs` / `iteration_*`（若该文档为本 plan 输入/输出）。
+1. **新增**：
+   - **Specs（长期）**：`{SPECS_DIR}/` → spec 索引（若有）→ `plans[].metadata` 的 `primary_spec` / `spec_refs`
+   - **迭代 workspace**：`{ITERATION_DIR}/<iteration-id>/guides|specs/` → `{ITERATION_DIR}/README.md` + workspace README → `iteration_refs`
+   - **Knowledge**：**`mstar-compound`** @ iteration-close（含 workspace **提升**）→ `{KNOWLEDGE_DIR}/README.md`
 2. **阅读**：开发类 agent 在开始编码前，**必须**阅读当前 plan 在 `metadata` 中指向的 knowledge 文档（若存在）；`@project-manager` 在 Assignment 中可再次点名路径。
 3. **修订**：评审或规格变更若改动了 knowledge 文件，同步更新 README 中 **Status** 或 Description；版本迭代优先新文件名 `v<N+1>` 或保留旧版并标明 Superseded。
-4. **归档**：当文档内容已完全反映到已合并代码中时：**保留文件不删除**（保留设计考据）；将索引 **Status** 标为 `Superseded by implementation (...)` 或 `Archived`。**不要**把知识库产物搬进 `**{HARNESS_DIR}/archived/plans/`**（该处用于**计划行**冷快照）；知识库用索引状态表达生命周期即可。
-5. **结晶（Compound）**：PM 在迭代收口时（`mstar-iteration` § iteration-close）批量触发 `mstar-compound`，将整轮迭代的经验沉淀为结构化知识文档（`{KNOWLEDGE_DIR}/<category>/<slug>.md`，YAML frontmatter + 双轨模板）。compound 是迭代级活动，不在 per-plan Done 后单独执行。定期维护由 `mstar-compound-refresh` 执行。详见 **`mstar-compound`**、**`mstar-iteration`** 与 **`mstar-compound-refresh`**。
+4. **归档**：
+   - **iteration-start（强制）**：`writing-specialist` §1.6 以 **`{SPECS_DIR}/` 全库卫生为主**；对**既有** `{KNOWLEDGE_DIR}/` 仅归档/错放纠正，**不**新增 knowledge。细则 → **`mstar-iteration/references/iteration-corpus-hygiene.md`**。
+   - **其它时机**：当文档内容已完全反映到已合并代码中、且非 iteration-start 扫库时：可将索引 **Status** 标为 `Superseded by implementation (...)` 或 `Archived`；可保留原位或迁入 `archived/knowledge/`。**不要**把知识库产物搬进 `{HARNESS_DIR}/archived/plans/`（该处用于**计划行**冷快照）。
+5. **结晶（Compound）**：PM 在 **iteration-close** 触发 **`mstar-compound`**：plan 素材 + **`{ITERATION_DIR}/<iteration-id>/` workspace 提升** → `{KNOWLEDGE_DIR}/`。不在 per-plan Done 后单独执行。维护 → **`mstar-compound-refresh`**。
 
 ## 与 `reports/`、`{PLAN_DIR}/residuals/` 的区分
 

--- a/skills/mstar-plan-conventions/references/artifact-storage-paths.md
+++ b/skills/mstar-plan-conventions/references/artifact-storage-paths.md
@@ -17,9 +17,12 @@
 | **SDD scratch** | `{HARNESS_DIR}/sdd/<plan-id>/`（gitignored） | `mstar-sdd` |
 | **status.json** | `.mstar/status.json` | `mstar-plan-artifacts` |
 | **迭代 compass** | `.mstar/iterations/<iteration-id>-delivery-compass.md` | `mstar-iteration`（读写） |
+| **迭代工作区** | `.mstar/iterations/<iteration-id>/`（`guides/`、`specs/` 等） | `mstar-iteration`（读写）；close 时 `mstar-compound`（提升读） |
 | **迭代索引** | `.mstar/iterations/README.md` | `mstar-iteration`（读写） |
 | **规格** | `specs/`（优先），否则 `designs/` | `mstar-plan-artifacts` |
 | **archived residuals** | `.mstar/archived/residuals/<plan-id>.json` | `mstar-plan-artifacts` |
+| **archived knowledge** | `.mstar/archived/knowledge/`（保留原 `{KNOWLEDGE_DIR}` 相对路径） | `mstar-iteration` §1.6 corpus hygiene、`mstar-plan-artifacts` |
+| **archived specs** | `.mstar/archived/specs/`（保留原 `{SPECS_DIR}` 相对路径） | `mstar-iteration` §1.6 corpus hygiene、`mstar-plan-artifacts` |
 
 ## 仓库根目录（`<repo-root>/`，与 `.git/` 同级）
 

--- a/skills/mstar-roles/references/architect.md
+++ b/skills/mstar-roles/references/architect.md
@@ -4,7 +4,7 @@
 
 **Always:** `mstar-harness-core`, `mstar-dispatch-gates`, `mstar-phase-gates` (Prepare: specify/clarify/plan), `mstar-plan-conventions` (`{PLAN_DIR}`, plan-writing path).
 
-**Typically:** `mstar-plan-artifacts` (knowledge/specs/ADR placement); `mstar-design-md` (DESIGN.md design system spec — architect is primary creator); `mstar-coding-behavior` (surgical doc edits).
+**Typically:** `mstar-plan-artifacts` (specs, **`{ITERATION_DIR}/<id>/` workspace**); `mstar-design-md`; `mstar-coding-behavior`. Boundaries → **`mstar-iteration/references/iteration-artifact-boundaries.md`**.
 
 **On demand:** `mstar-branch-worktree` (when committing architecture docs to the business repo).
 

--- a/skills/mstar-roles/references/product-manager.md
+++ b/skills/mstar-roles/references/product-manager.md
@@ -4,7 +4,7 @@
 
 **Always:** `mstar-harness-core`, `mstar-dispatch-gates`, `mstar-phase-gates` (Prepare / clarify), `mstar-plan-conventions` (`{PLAN_DIR}`, plan-writing path).
 
-**Typically:** `mstar-plan-artifacts` (specs, knowledge index); `mstar-design-md` (DESIGN.md design intent and requirements for UI planning); `mstar-coding-behavior` (surgical doc edits).
+**Typically:** `mstar-plan-artifacts` (specs, **`{ITERATION_DIR}/<id>/` workspace** — not knowledge @ start); `mstar-design-md`; `mstar-coding-behavior`. Boundaries → **`mstar-iteration/references/iteration-artifact-boundaries.md`**.
 
 **On demand:** `mstar-branch-worktree` (when committing product docs to the business repo).
 

--- a/skills/mstar-roles/references/writing-specialist.md
+++ b/skills/mstar-roles/references/writing-specialist.md
@@ -36,6 +36,7 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 3. Marketing/copy writing
 4. Script writing
 5. Tone/style adaptation by audience
+6. **iteration-start corpus hygiene** (§1.6 step 3): specs-first hygiene; misplaced drafts → **`{ITERATION_DIR}/<iteration-id>/`** workspace — **`iteration-artifact-boundaries.md`** + **`iteration-corpus-hygiene.md`**. **Promotion** workspace → knowledge is **`mstar-compound`** @ iteration-close only.
 
 ## Scope Boundaries
 


### PR DESCRIPTION
## Summary

- Define clear Phase 1 artifact boundaries: `{SPECS_DIR}/` for long-lived locked specs, `{ITERATION_DIR}/<iteration-id>/` workspace (`guides/`, `specs/`) for iteration-scoped drafts, and no `{KNOWLEDGE_DIR}/` writes during iteration-start.
- Extend the iteration-start Review & Edit chain: product/architect focus on specs + workspace; writing-specialist runs specs corpus hygiene and archives misplaced or stale docs.
- Add mandatory iteration-close workspace promotion in `mstar-compound` to uplift worthy iteration specs/guides into structured `{KNOWLEDGE_DIR}/` entries.
- Bump all harness surfaces to **1.0.2** with bilingual changelogs and README highlights.

## Test plan

- [ ] Read `skills/mstar-iteration/references/iteration-artifact-boundaries.md` and confirm specs / workspace / knowledge split matches intent
- [ ] Verify `iteration-start` §5 role table and pre-commit checklist align with §1.5.5 / §1.6
- [ ] Confirm `mstar-compound` documents workspace promotion at iteration-close
- [ ] Spot-check version **1.0.2** in root/package manifests, plugin JSON, and `CHANGELOG.md` / `CHANGELOG_CN.md`


Made with [Cursor](https://cursor.com)