### PR TITLE
Harden iteration continuous execution (1.0.3)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
+++ b/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
@@ -1,6 +1,6 @@
 {
   "harness_name": "pm-routing-evals",
-  "version": 14,
+  "version": 15,
   "updated_at": "2026-07-07",
   "cases": [
     {
@@ -480,6 +480,7 @@
         "serial implementer then task reviewer per task",
         "SDD dir path and task-N-brief.md handoffs",
         "progress.md ledger",
+        "continuous execution — next action is dispatch not user check-in",
         "three QC invokes N=3 in one dispatch turn",
         "qc1.md qc2.md qc3.md",
         "qc-consolidated.md",
@@ -487,11 +488,38 @@
       ],
       "hard_fail_if": [
         "missing Context Loaded declaration",
+        "asks user whether to continue mid Autonomous Execute",
+        "ends turn with confirmation question instead of next dispatch",
+        "parallel implement dispatches across multiple plans without user override",
         "single qc-specialist only in iteration Phase 2 per-plan loop without user override",
         "QC without MERGE_BASE..HEAD review-package",
         "tri-review split across multiple dispatch messages",
         "bulk inline implement Assignment with full plan or T1-Tn pasted for multi-task plan",
         "parallel SDD implementer dispatches",
+        "assignment uses non-English field keys"
+      ]
+    },
+    {
+      "id": "iteration-drive-continuous-after-plan-wave",
+      "prompt": "iteration-drive：plan A 刚 QC 通过并 merge 回 integration，plan B 仍为 Todo，继续 Autonomous Execute",
+      "expected_route": [
+        "@project-manager",
+        "@fullstack-dev",
+        "QC-3-reviewers",
+        "@qa-engineer"
+      ],
+      "must_have_artifacts": [
+        "Context Loaded declaration",
+        "continuous execution — next action is dispatch not user check-in",
+        "immediate plan B implement dispatch without user check-in",
+        "Execution mode: sdd",
+        "serial implementer then task reviewer per task"
+      ],
+      "hard_fail_if": [
+        "missing Context Loaded declaration",
+        "asks user whether to continue before plan B dispatch",
+        "ends turn with confirmation question instead of next dispatch",
+        "parallel implement dispatches across multiple plans without user override",
         "assignment uses non-English field keys"
       ]
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,31 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.0.2** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.0.3** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.0.2** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.0.2** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.0.2** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.0.2** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.0.2** |
+| Monorepo root | `morning-star` (`package.json`) | **1.0.3** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.0.3** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.0.3** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.0.3** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.0.3** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [1.0.3] - 2026-07-07
+
+### Harness (iteration continuous execution)
+
+- **`iteration-drive`**: Add **Continuous execution (HARD)** for Phase 2–5 — no routine yes/no check-ins after progress reports; turn must end with in-flight dispatch; per-plan serial implement loop; explicit legal STOP boundaries.
+- **`mstar-iteration` §2.6**: Expand **Push discipline (Autonomous Execute)** — continuous execution through Phase 5 merge-ready exit; no confirmation questions between tasks, plans, or phases.
+- **`pm` skill**: Restore **Autonomous Execute push** as rule 4; iteration semantics SSOT → **`mstar-iteration`** only (no command names in runtime skills).
+- **Skills command-agnostic cleanup**: Remove `iteration-drive` references from runtime `mstar-*` skills (host refs, project-manager, sticky implementer, dispatch-and-assignment).
+- **Routing eval v15**: Hard-fail mid-execute user check-ins; new `iteration-drive-continuous-after-plan-wave` case.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex plugin manifests: **→ 1.0.3**.
 
 ## [1.0.2] - 2026-07-07
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,30 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.0.2**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.0.3**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.0.2** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.0.2** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.0.2** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.0.2** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.0.2** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.0.3** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.0.3** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.0.3** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.0.3** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.0.3** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [1.0.3] - 2026-07-07
+
+### Harness（iteration 连续推进）
+
+- **`iteration-drive`**：新增 Phase 2–5 **Continuous execution（HARD）** — 进度汇报后禁止例行 yes/no；turn 须以 in-flight dispatch 收束；per-plan 串行 implement；明确合法 STOP 边界。
+- **`mstar-iteration` §2.6**：扩展 **Push 纪律（Autonomous Execute）** — Phase 5 merge-ready exit 前连续编排；task/plan/phase 间禁止确认问句。
+- **`pm` skill**：恢复 **Autonomous Execute push** 为第 4 条规则；迭代语义 SSOT 仅 **`mstar-iteration`**（runtime skills 不引用 command 名）。
+- **Skills 与 command 分层**：自 runtime `mstar-*` skills 移除 `iteration-drive` 反向引用（host、project-manager、sticky implementer、dispatch-and-assignment）。
+- **Routing eval v15**：mid-execute 向用户 check-in 硬失败；新增 `iteration-drive-continuous-after-plan-wave` 场景。
+
+### 版本对齐
+
+- monorepo、OpenCode、CLI、Cursor/Codex 插件：**→ 1.0.3**。
 
 ## [1.0.2] - 2026-07-07
 

--- a/commands/iteration-drive.md
+++ b/commands/iteration-drive.md
@@ -25,11 +25,33 @@ Phase 2: Autonomous Execute  →  Phase 3: iteration-close  →  Phase 4: Create
 
 **Done 定义**：**仅** Phase 5 §5.5 exit checklist 全 `[x]`。**Phase 3 close ≠ Done；Phase 4 开 PR ≠ Done。**
 
+## Continuous execution（HARD — Phase 2–5）
+
+**Autonomous Execute push**：自 Phase 2 进入至 Phase 5 §5.5 exit 全 `[x]` 前，PM **连续编排**，不得把进度汇报、phase 标题或子 agent 返回当作**回合结束**。
+
+| 禁止 | 必须 |
+|------|------|
+| plan / task / phase 边界问用户「是否继续」「要不要现在启动」「是否开 PR」等例行 yes/no | 进度摘要后**下一条动作** = **dispatch**（`Task`）或下一 phase 步骤（打印 checklist → 执行） |
+| 用完整 Phase 2 汇报收束 turn 后等待用户 | 同 plan 内 task 间 → **`mstar-sdd` Continuous execution**；当前 plan Done 后 → **立刻**下一 plan dispatch |
+| 把 `## Phase 3/4/5` 标题当作可停下协商点（除合法 STOP） | Phase 3 checklist `[x]` → **立刻** Phase 4；PR 创建后 → **立刻** Phase 5 loop |
+| 跨 plan **并行** implement dispatch（多 plan 同时跑 implementer） | Per-plan **串行**：plan A implement→QC→QA→Done 后再 plan B（除非用户书面 override） |
+
+**合法 STOP（仅此升级用户）**：
+
+- §2.0 / Phase 4 branch metadata 缺失（`iteration_base_branch` / `target_branch`）
+- **`Blocked`**：真冲突、secrets、不可逆范围缺口、Phase 5 多轮仍无法 merge-ready
+- 用户本轮显式打断
+
+**Turn 收束纪律**：若 host 即将结束本轮，最后一条 assistant 内容必须是 **in-flight 动作**（invoke 已发出、或写明下一 dispatch 的 Assignment 字段），**不得**以对用户的确认问句结尾。
+
+SSOT 细化：`mstar-sdd`（task 级）· `mstar-iteration` §2.6（push 纪律）。
+
 ## PM invariants（Phase 2–5 全程有效）
 
 | 禁止（PM 线程） | 必须 |
 |-----------------|------|
 | Write/Edit/Shell 产品代码、写测试、跑 QC 审查（Phase 2） | 每条 implement/QC/QA Assignment ⇒ **1 次 `Task`** |
+| **进度汇报后问「是否继续」或以 phase 摘要收束 turn** | 汇报后**立刻** dispatch 或进入下一 phase 动作（见上节 Continuous execution） |
 | **多 task plan 用 inline 大包派发**（整份 plan / T1–Tn 贴进一个 dev Assignment） | **SDD**：`mstar-sdd` per-task 循环 — `task-brief` → implementer → `review-package` → task reviewer → `progress.md` |
 | 只写 Assignment 就进入下一 gate | 同轮 dispatch：`Subagent invokes issued: N`（N = Assignment 条数） |
 | 最后一个 plan `Done` 后直接开 PR / 汇报结束 | **Phase 3 → 4 → 5** 顺序执行 |
@@ -59,6 +81,8 @@ Phase 2: Autonomous Execute  →  Phase 3: iteration-close  →  Phase 4: Create
 8. `mstar-plan-artifacts`, `mstar-plan-conventions`, `mstar-branch-worktree`
 
 ## Phase 2: Autonomous Execute
+
+**Continuous execution applies** — 本节全程遵守上节 **Continuous execution（HARD）**；Completion Report / 进度同步后不得 check-in，下一条必须是 dispatch 或下一 plan。
 
 **Branch policy first** — before any plan dispatch（`mstar-iteration` §2.3）:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.0.3
+
+- Version alignment with harness **1.0.3** (no CLI behavior change in this release).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.0.3**.
+
 ## 1.0.2
 
 - Version alignment with harness **1.0.2** (no CLI behavior change in this release).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex).",
   "license": "MIT",
   "repository": {

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.0.3
+
+- Bundled skills/commands: iteration continuous execution (Phase 2–5 HARD push discipline in `iteration-drive` + `mstar-iteration` §2.6); skills command-agnostic cleanup; `pm` Autonomous Execute push rule; routing-eval v15.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.0.3**.
+
 ## 1.0.2
 
 - Bundled skills/commands: iteration artifact boundaries (`{ITERATION_DIR}/<id>/` workspace, specs-first start, compound workspace promotion at close); new iteration references; corpus hygiene aligned.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-host/references/cursor.md
+++ b/skills/mstar-host/references/cursor.md
@@ -6,7 +6,7 @@ Parallel PM dispatch: **`parallel-dispatch.md`** (Task tool uses same turn model
 
 ## Cursor-only context
 
-- Role prompts: `mstar-roles`; **`/pm`** or **`pm` skill** → general PM orchestration (per-plan dispatch, gates, QC) without an iteration command. **`commands/`** (`iteration-start`, `iteration-drive`, `mstar-bootstrap`) only when running formal iteration Phase 1–5.
+- Role prompts: `mstar-roles`; **`/pm`** or **`pm` skill** → general PM orchestration (per-plan dispatch, gates, QC) without an iteration command. Host **`commands/`** for formal iteration Phase 1–5 (semantics → **`mstar-iteration`**).
 - Routing-eval: `.cursor/skills/mstar-routing-eval/` — regression tooling only; not runtime load order.
 
 ## Plan mode × harness dual-write

--- a/skills/mstar-host/references/opencode.md
+++ b/skills/mstar-host/references/opencode.md
@@ -6,7 +6,7 @@ Parallel PM dispatch: **`parallel-dispatch.md`** (read in dispatch rounds).
 
 ## Role loading
 
-- **PM entry**: **`/pm`** or **`pm` skill** → `project-manager` for general orchestration; **`commands/`** (`iteration-start`, `iteration-drive`, `mstar-bootstrap`) for formal iteration only.
+- **PM entry**: **`/pm`** or **`pm` skill** → `project-manager` for general orchestration; host **`commands/`** for formal iteration Phase 1–5 (semantics → **`mstar-iteration`**).
 - **Role shell**: `agents/<id>.md` referenced by `opencode.json` `agent.<id>` (frontmatter + role binding only).
 - **Role body**: `mstar-roles` `references/<id>.md` (or shared references + parameters).
 - Implementation evidence and RCA behavior: `mstar-coding-behavior`.

--- a/skills/mstar-iteration/SKILL.md
+++ b/skills/mstar-iteration/SKILL.md
@@ -283,11 +283,15 @@ Iteration Phase 2 附加：
 - `Subagent invokes issued: 0` 而 Assignment 已写出 → **`dispatch incomplete`**；下一条补发 invoke，禁止 PM 顶替
 - QC 初轮：**SDD → N=3**；**inline → N=1**；双轨 implement → **N=2**（同条消息发满 N）
 
-### 2.6 Push 纪律
+### 2.6 Push 纪律（Autonomous Execute）
 
-- 不因 harness 基础问题常问"是否继续"—— 决策、记录、**dispatch**
-- 未知 → 读 `mstar-*`；**`Blocked`** 或仅对 stop/secrets/不可逆范围缺口/冲突后升级
+**Continuous execution（HARD）**：Phase 2 Autonomous Execute 经 Phase 5 merge-ready exit 全程 — 不向用户做例行 yes/no check-in。
+
+- 不因 harness 流程问题常问「是否继续」「要不要现在启动」—— **决策、记录、dispatch**
+- 进度汇报 / subagent Completion Report 后，下一条必须是 **dispatch 或下一 gate 动作**，不得以确认问句收束 turn
+- 未知 → 读 `mstar-*`；仅 **`Blocked`**、secrets、不可逆范围缺口、branch metadata 缺失、或 Phase 5 多轮仍 blocked 时升级用户
 - 实际 Git ≠ `working_branch` → **同轮**更新 plan + status
+- Per-plan loop **串行**（plan A Done 后再 plan B）；plan 内 SDD task **串行** — 见 §2.4、§2.5、`mstar-sdd` Continuous execution
 
 ---
 

--- a/skills/mstar-roles/references/project-manager.md
+++ b/skills/mstar-roles/references/project-manager.md
@@ -143,7 +143,7 @@ If any fail -> do not dispatch implement.
 | Entry | Next reads |
 |-------|------------|
 | **`/pm`** or **`pm` skill** (Codex, Cursor; OpenCode when no command) | This shim → **`project-manager.md`** § Required Reading + topic skills on demand |
-| **Cursor / OpenCode** **`commands/`** (`iteration-start`, `iteration-drive`, `mstar-bootstrap`) | Command **Boot** + **`project-manager.md`** — iteration lifecycle only; **not** required for ordinary per-plan PM |
+| **Cursor / OpenCode** host iteration `commands/` | Command Boot + **`project-manager.md`** — iteration lifecycle only; **not** required for ordinary per-plan PM |
 | **OpenCode** (no command, not `/pm`) | `project-manager` + `mstar-host` → `opencode.md` |
 
 **Dispatch-first**, iteration branch policy（`iteration_base_branch` / `spec_integration_branch` / `target_branch`）, Autonomous Execute → **`mstar-iteration`** §2. Routing, gates, Task Board, QC, templates → this file + topic `mstar-*` skills.

--- a/skills/mstar-roles/references/project-manager/dispatch-and-assignment.md
+++ b/skills/mstar-roles/references/project-manager/dispatch-and-assignment.md
@@ -177,4 +177,4 @@ read `mstar-host` → the active host reference and `references/parallel-dispatc
 
 - 把整份 plan 或 T1–Tn 全文贴进 **一个** `fullstack-dev` leaf Assignment。
 - 省略 `Execution mode` / `SDD dir` / `Model tier` 却期望 SDD 产物（`progress.md`、per-task review）。
-- 期望 leaf `fullstack-dev` 载入 `mstar-sdd` 并自编排 per-task 循环 — **编排仅 PM**（`iteration-drive` / `mstar-iteration` §2.4–2.5）。
+- 期望 leaf `fullstack-dev` 载入 `mstar-sdd` 并自编排 per-task 循环 — **编排仅 PM**（`mstar-iteration` §2.4–2.5）。

--- a/skills/mstar-sdd/references/sticky-implementer-session.md
+++ b/skills/mstar-sdd/references/sticky-implementer-session.md
@@ -11,7 +11,7 @@ SSOT for mode selection and host resume → this file. Per-task artifacts → **
 | **`fresh`** (default) | Independent tasks, module boundaries, different dev tracks, or first task on a plan |
 | **`sticky`** | Same `fullstack-dev` (or same role id), sequential tasks on one branch, strong file/context continuity (e.g. T3+T4 daemon stderr + DB reset) |
 
-**Prefer `sticky`** on iteration-drive Phase 2 when PM will dispatch many tasks to the same dev on one plan feature branch.
+**Prefer `sticky`** on iteration Phase 2 Autonomous Execute when PM will dispatch many tasks to the same dev on one plan feature branch.
 
 ## Assignment fields (implement dispatch)
 

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm
-description: "PM entry shim — force project-manager orchestration when user invokes /pm or this skill (Codex and Cursor). General per-plan PM work: this skill + project-manager.md. Formal iteration lifecycle on Cursor/OpenCode: commands (iteration-start, iteration-drive, mstar-bootstrap). Boot, routing, dispatch SSOT → mstar-roles/references/project-manager.md and topic mstar-* skills — not here."
+description: "PM entry shim — force project-manager orchestration when user invokes /pm or this skill (Codex and Cursor). General per-plan PM work: this skill + project-manager.md. Formal iteration lifecycle: mstar-iteration (host commands/ may orchestrate Phase 1–5). Boot, routing, dispatch SSOT → mstar-roles/references/project-manager.md and topic mstar-* skills — not here."
 ---
 
 # PM (entry shim)
@@ -12,10 +12,10 @@ description: "PM entry shim — force project-manager orchestration when user in
 | Host | Use |
 |------|-----|
 | **Codex** | **`/pm`** or this skill → **`project-manager`** for the session |
-| **Cursor** | **`/pm`** or this skill → general PM orchestration (single-plan, hotfix, QC waves, dispatch) **without** starting an iteration. Formal iteration → **`commands/`** below |
+| **Cursor** | **`/pm`** or this skill → general PM orchestration (single-plan, hotfix, QC waves, dispatch) **without** starting an iteration. Formal iteration → host **`commands/`** + **`mstar-iteration`** |
 | **OpenCode** | Same as Cursor when no command: **`project-manager`** via `mstar-roles` → `references/project-manager.md` |
 
-**Iteration commands** (optional; carry their own Boot): `iteration-start`, `iteration-drive`, `mstar-bootstrap` — use when running Phase 1–5 iteration lifecycle, not required for ordinary PM work.
+**Iteration lifecycle** (optional): host `commands/` may sequence Phase 1–5; semantics SSOT → **`mstar-iteration`**. Not required for ordinary PM work.
 
 Detect host → **`mstar-host`** → `references/codex.md` | `cursor.md` | `opencode.md`.
 
@@ -25,10 +25,11 @@ Detect host → **`mstar-host`** → `references/codex.md` | `cursor.md` | `open
 2. `mstar-roles` → **`references/project-manager.md`** — required reading list, routing, dispatch-first, iteration branch policy
 3. Topic skills **on demand** per that file and the active workflow (`mstar-dispatch-gates`, `mstar-iteration`, `mstar-sdd`, `mstar-review-qc`, …)
 
-## Three rules (everything else is a pointer)
+## Four rules (everything else is a pointer)
 
 1. **Delegate** — PM does not implement, QC, or QA in-thread (`project-manager.md` Execution Boundary; hotfix → `mstar-phase-gates`).
 2. **Dispatch** — when host has invoke/Task tools: **1 Assignment ⇒ 1 invoke** (`mstar-dispatch-gates`). Markdown alone is not dispatch.
-3. **SSOT** — iteration lifecycle → **`mstar-iteration`** (or **`commands/`** on Cursor/OpenCode); Cursor Plan mode → **`mstar-host/references/cursor-plan-mode-bridge.md`**.
+3. **SSOT** — iteration lifecycle → **`mstar-iteration`**; Cursor Plan mode → **`mstar-host/references/cursor-plan-mode-bridge.md`**.
+4. **Autonomous Execute push** — multi-plan iteration Phase 2–5: continuously dispatch implement → QC → QA → Done through merge-ready exit without routine yes/no prompts; **Blocked** only on true conflicts or metadata gaps → **`mstar-iteration` §2.6**.
 
 Conflict: user instructions → project `AGENTS.md` / `CLAUDE.md` → `mstar-harness-core` → this file.


### PR DESCRIPTION
## Summary

- Add **Continuous execution (HARD)** to `iteration-drive` for Phase 2–5 so PM does not pause with routine yes/no check-ins after progress reports; turns must end with in-flight dispatch.
- Expand `mstar-iteration` §2.6 push discipline and restore **Autonomous Execute push** in the `pm` skill shim.
- Remove `iteration-drive` references from runtime `mstar-*` skills (commands consume skills, not vice versa).
- Extend routing-eval to **v15** with hard-fails for mid-execute user check-ins and a post-plan-wave continuation case.
- Bump all harness surfaces to **1.0.3** with bilingual changelog entries.

## Test plan

- [ ] Review `commands/iteration-drive.md` Continuous execution section and PM invariants
- [ ] Confirm `skills/` has zero `iteration-drive` references
- [ ] Validate `routing-evals.json` parses and version is 15
- [ ] Verify package/plugin manifests are aligned at 1.0.3

Made with [Cursor](https://cursor.com)