### PR TITLE
fix: unblock 1.2.0 release CI and OpenCode init hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,29 @@ on:
       - main
     tags-ignore:
       - "v*"
+    paths:
+      - "packages/cli/**"
+      - "packages/opencode/**"
+      - "skills/**"
+      - "agents/**"
+      - "commands/**"
+      - "package.json"
+      - "bun.lock"
+      - "bun.lockb"
+      - "tsconfig.json"
+      - ".github/workflows/ci.yml"
   pull_request:
+    paths:
+      - "packages/cli/**"
+      - "packages/opencode/**"
+      - "skills/**"
+      - "agents/**"
+      - "commands/**"
+      - "package.json"
+      - "bun.lock"
+      - "bun.lockb"
+      - "tsconfig.json"
+      - ".github/workflows/ci.yml"
 
 jobs:
   validate:
@@ -36,6 +58,9 @@ jobs:
 
       - name: Build OpenCode
         run: bun run opencode:build
+
+      - name: CLI smoke check
+        run: bun run --cwd packages/cli check
 
       - name: Pack CLI tarball
         run: bun run cli:pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,13 @@ jobs:
         with:
           bun-version: 1.2.17
 
+      # Node 24 ships npm with working Trusted Publishing / provenance (sigstore).
+      # Do not `npm install -g npm@latest` on Node 22 — that breaks provenance with MODULE_NOT_FOUND: sigstore.
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
-
-      - name: Upgrade npm for Trusted Publishing
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: bun install
@@ -42,6 +41,11 @@ jobs:
 
       - name: Typecheck
         run: bun run typecheck
+
+      - name: Build packages
+        run: |
+          bun run cli:build
+          bun run opencode:build
 
       - name: Publish @mstar-harness/cli
         run: npm publish --workspace @mstar-harness/cli --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,15 @@ Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG
 ### Harness (`/iteration-loop` + autonomous direction lock)
 
 - **`/iteration-loop`**: new PM command for autonomous full Phase 1→5 (cloud-agent friendly). Optional args `direction` + `scale` (`S`\|`M`\|`L`, default `M`); code-first auto direction lock (no grill-me); sequential Review & Edit chain retained; Continuous execution through Phase 5 merge-ready. Distinct from `/iteration-start` (Phase 1 + grill-me) and `/iteration-drive` (Phase 2→5 only).
-- **`mstar-iteration` §1.2**: direction lock modes `interactive` | `autonomous`; scale budget; autonomous branch resolve order. Detail → `references/autonomous-direction-lock.md` (skills remain capability providers — no command-name reverse refs).
+- **`mstar-iteration` §1.2**: direction lock modes `interactive` | `autonomous`; scale budget counts **business plans only** (harness process excluded); autonomous branch resolve order. Detail → `references/autonomous-direction-lock.md` (skills remain capability providers — no command-name reverse refs).
 - **Docs**: README / README_CN / OpenCode package README command tables distinguish start / drive / loop.
-- **Routing eval v18**: `iteration-loop-autonomous-direction-lock` — no routine direction yes/no; no grill-me; no silent `main` default.
+- **Routing eval v18**: `iteration-loop-autonomous-direction-lock` — no routine direction yes/no; no grill-me; no silent `main` default; no process plans in scale budget.
+
+### CLI / CI / release
+
+- **OpenCode `init` fast path**: no interactive model picking and no `opencode models` discovery (that call could hang with no feedback). Default writes `$schema` + `@mstar-harness/opencode@latest` only; OpenCode default models apply. Optional `--*-model` flags remain as advanced overrides.
+- **CI**: path-filtered builds for `packages/cli`, `packages/opencode`, and bundled `skills`/`agents`/`commands`; includes CLI smoke check + pack.
+- **Release**: use Node 24 bundled npm for Trusted Publishing; remove broken `npm install -g npm@latest` on Node 22 (fixes `MODULE_NOT_FOUND: sigstore`); build packages before publish.
 
 ### Version alignment
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -17,9 +17,15 @@
 ### Harness（`/iteration-loop` + autonomous direction lock）
 
 - **`/iteration-loop`**：新 PM 命令，自动化完整 Phase 1→5（适合 cloud agent）。可选参数 `direction` + `scale`（`S`\|`M`\|`L`，默认 `M`）；代码优先自动锁方向（不跑 grill-me）；保留顺序 Review & Edit 链；Continuous execution 直至 Phase 5 merge-ready。与 `/iteration-start`（仅 Phase 1 + grill-me）、`/iteration-drive`（仅 Phase 2→5）区分。
-- **`mstar-iteration` §1.2**：direction lock 模式 `interactive` | `autonomous`；scale budget；autonomous branch resolve。细则 → `references/autonomous-direction-lock.md`（skill 为能力提供者，不反向引用 command 名）。
+- **`mstar-iteration` §1.2**：direction lock 模式 `interactive` | `autonomous`；scale budget **只计业务 plan**（不计 harness 流程）；autonomous branch resolve。细则 → `references/autonomous-direction-lock.md`（skill 为能力提供者，不反向引用 command 名）。
 - **文档**：README / README_CN / OpenCode 包 README 命令表区分 start / drive / loop。
-- **Routing eval v18**：`iteration-loop-autonomous-direction-lock` — 禁止例行方向确认、禁止 grill-me、禁止静默默认 `main`。
+- **Routing eval v18**：`iteration-loop-autonomous-direction-lock` — 禁止例行方向确认、禁止 grill-me、禁止静默默认 `main`、禁止把流程 plan 计入 scale。
+
+### CLI / CI / 发布
+
+- **OpenCode `init` 快路径**：不再交互选模型，也不再调用 `opencode models`（该命令可能无输出卡住）。默认只写 `$schema` + `@mstar-harness/opencode@latest`，角色模型用 OpenCode 默认；可选 `--*-model` 仍作高级覆盖。
+- **CI**：对 `packages/cli`、`packages/opencode` 及 bundled `skills`/`agents`/`commands` 做 path 过滤构建；含 CLI smoke + pack。
+- **Release**：改用 Node 24 自带 npm 做 Trusted Publishing；去掉 Node 22 上损坏的 `npm install -g npm@latest`（修复 `MODULE_NOT_FOUND: sigstore`）；发布前先 build。
 
 ### 版本对齐
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,17 +8,19 @@ Use this sequence for the quickest user flow.
 
 ### OpenCode
 
-1) Preview what will change:
+1) Preview what will change (schema + plugin only; uses OpenCode default models):
 
-- `npx @mstar-harness/cli init --target opencode --dry-run --yes --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
+- `npx @mstar-harness/cli init --target opencode --dry-run --yes`
 
 2) Apply the setup:
 
-- `npx @mstar-harness/cli init --target opencode --yes --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
+- `npx @mstar-harness/cli init --target opencode --yes`
 
 3) Verify the final config:
 
 - `npx @mstar-harness/cli doctor --target opencode`
+
+Optional advanced: pass `--pm-model` / `--*-models` flags to write explicit `agent.<role>.model` overrides (does **not** call `opencode models`).
 
 ### Cursor
 
@@ -64,13 +66,17 @@ Interactive bootstrap:
 
 `--scope` defaults to `project` when omitted.
 
-OpenCode non-interactive bootstrap:
+OpenCode non-interactive bootstrap (fast path — no model prompts):
 
-- `npx @mstar-harness/cli init --yes --target opencode --scope project --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5,openai/gpt-5.4 --dev-models openai/gpt-5.3-codex,openai/gpt-5.5-fast --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5,openai/gpt-5.4`
+- `npx @mstar-harness/cli init --yes --target opencode --scope project`
 
 Dry-run preview (no file write):
 
-- `npx @mstar-harness/cli init --dry-run --scope project --output .tmp/opencode.json --yes --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
+- `npx @mstar-harness/cli init --dry-run --scope project --output .tmp/opencode.json --yes`
+
+Optional role-model overrides (advanced; skips live model discovery):
+
+- `npx @mstar-harness/cli init --yes --target opencode --pm-model openai/gpt-5.5 --strategic-models openai/gpt-5.5 --dev-models openai/gpt-5.3-codex --qc-models openai/gpt-5.5,openai/gpt-5.4,openai/gpt-5.3-codex --other-models openai/gpt-5.5`
 
 Cursor install:
 
@@ -110,7 +116,7 @@ OpenCode `init` enforces these baseline requirements in `opencode.json`:
 
 - `"$schema": "https://opencode.ai/config.json"`
 - `plugin` contains `@mstar-harness/opencode@latest` (legacy `morning-star@git+…` lines for `btspoony/mstar-harness` are stripped on init, including URLs without `.git`, `ssh://`, or `#tag`)
-- all Morning Star roles have `agent.<role>.model`
+- Role models are **not** required — OpenCode defaults apply unless you pass optional `--*-model` flags
 
 Cursor and Codex `init` ensure a maintained local checkout exists at `~/.mstar/harness`. Codex then creates agent symlinks from that checkout. Cursor clones a **separate real git checkout** at the plugin path (see [Install path layout](#install-path-layout)).
 
@@ -131,7 +137,8 @@ Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` 
 
 ## What `doctor` Checks
 
-- Same schema, role models, and presence of **either** `@mstar-harness/opencode…` **or** a recognized legacy `morning-star@git+…` line (so existing git-based configs still pass).
+- Same schema and presence of **either** `@mstar-harness/opencode…` **or** a recognized legacy `morning-star@git+…` line (so existing git-based configs still pass).
+- Missing per-role `agent.<role>.model` is a **yellow recommendation** only (OpenCode defaults are OK).
 - If only legacy git is present, or legacy and npm are both listed, `doctor` prints **yellow recommendations** and still exits 0; run `init` to normalize to `@mstar-harness/opencode@latest`.
 - For Cursor, `doctor` checks the maintained `~/.mstar/harness` checkout, that the Cursor plugin path is a **real git directory** (not a symlink), and that `agents/*.md` files use Cursor-first frontmatter.
 - For Codex, `doctor` checks the local marketplace entry, the maintained `~/.mstar/harness` checkout, and custom-agent symlinks.
@@ -168,11 +175,11 @@ Or re-run `npx @mstar-harness/cli init --target cursor --scope global`.
 - `--target <opencode|cursor|codex>`
 - `--scope <global|project>` (default: `project`)
 - `--dry-run`
-- `--pm-model <model>`
-- `--strategic-models <a,b,c>`
-- `--dev-models <a,b,c>`
-- `--qc-models <a,b,c>`
-- `--other-models <a,b,c>`
+- `--pm-model <model>` (optional advanced override)
+- `--strategic-models <a,b,c>` (optional)
+- `--dev-models <a,b,c>` (optional)
+- `--qc-models <a,b,c>` (optional)
+- `--other-models <a,b,c>` (optional)
 
 ### `doctor` options
 
@@ -199,7 +206,7 @@ The CLI uses a target adapter layer so new code agents can be added without rewr
 
 To add a new agent target, implement a new adapter with:
 
-- model discovery (`getAvailableModels`)
-- config path resolution (`resolveConfigPath`)
-- init mutation (`mutateConfigForInit`)
+- config path resolution (`resolveConfigPath`) **or** install flow (`runInstallInit` / `runInstallDoctor`)
+- init mutation (`mutateConfigForInit`) for config-mode targets
 - doctor validation (`validateConfig`)
+- optional model discovery (`getAvailableModels`) — OpenCode default init does **not** use this (avoids hanging on `opencode models`)

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,7 +6,8 @@ The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface re
 
 ## 1.2.0
 
-- Version alignment with harness **1.2.0** (no CLI behavior change in this release).
+- OpenCode `init` fast path: schema + plugin only; no interactive model picking / no `opencode models` discovery (avoids silent hangs). Optional `--*-model` flags remain as advanced overrides.
+- Version alignment with harness **1.2.0**.
 
 See root [CHANGELOG.md](../../CHANGELOG.md) **1.2.0**.
 

--- a/packages/cli/src/adapters/opencode.ts
+++ b/packages/cli/src/adapters/opencode.ts
@@ -1,9 +1,8 @@
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
 import { ALL_ROLES } from "../constants";
 import type { AgentAdapter, Scope } from "../types";
-import { ensureObject, normalizeModelList, resolveProjectRoot } from "../utils";
+import { ensureObject, resolveProjectRoot } from "../utils";
 
 const OPENCODE_CONFIG_SCHEMA = "https://opencode.ai/config.json";
 const MSTAR_OPENCODE_PLUGIN = "@mstar-harness/opencode@latest";
@@ -31,13 +30,6 @@ function isMstarHarnessOpencodePlugin(plugin: string): boolean {
 
 function isAnyMstarHarnessOpencodeSlot(plugin: string): boolean {
   return isLegacyMorningStarGitPlugin(plugin) || isMstarHarnessOpencodePlugin(plugin);
-}
-
-function getOpencodeModels() {
-  const raw = execFileSync("opencode", ["models"], { encoding: "utf8" });
-  const models = normalizeModelList(raw);
-  if (!models.length) throw new Error("`opencode models` returned no model entries.");
-  return models;
 }
 
 function resolveOpencodeConfigPath(scope: Scope, outputPath?: string) {
@@ -71,7 +63,9 @@ function updatePluginList(config: Record<string, unknown>) {
   return next;
 }
 
+/** Optional advanced path: write role models only when caller supplied assignments. */
 function applyAssignments(config: Record<string, unknown>, assignments: Record<string, string>) {
+  if (!Object.keys(assignments).length) return config;
   const next = ensureObject(config);
   const agent = ensureObject(next.agent);
   next.agent = agent;
@@ -93,19 +87,15 @@ function validateSetup(config: Record<string, unknown>) {
   const hasMstarOpencode = plugins.some(
     (item) => typeof item === "string" && isAnyMstarHarnessOpencodeSlot(item.trim()),
   );
-  if (!hasMstarOpencode) errors.push("Missing @mstar-harness/opencode plugin entry in `plugin` (or legacy morning-star git plugin).");
-
-  const agent = ensureObject(config.agent);
-  for (const roleId of ALL_ROLES) {
-    const role = ensureObject(agent[roleId]);
-    if (typeof role.model !== "string" || !role.model.trim()) {
-      errors.push(`Missing model for role: ${roleId}`);
-    }
+  if (!hasMstarOpencode) {
+    errors.push("Missing @mstar-harness/opencode plugin entry in `plugin` (or legacy morning-star git plugin).");
   }
+
   return errors;
 }
 
 function getDoctorWarnings(config: Record<string, unknown>): string[] {
+  const warnings: string[] = [];
   const plugins = Array.isArray(config.plugin) ? config.plugin : [];
   const strings = plugins
     .filter((item): item is string => typeof item === "string")
@@ -114,22 +104,33 @@ function getDoctorWarnings(config: Record<string, unknown>): string[] {
   const hasNpm = strings.some(isMstarHarnessOpencodePlugin);
   const hasLegacy = strings.some(isLegacyMorningStarGitPlugin);
   if (hasLegacy && !hasNpm) {
-    return [
-      "Plugin list uses legacy `morning-star@git+…` for this harness; run `mstar-harness init --target opencode` (or `--yes` with model flags) to rewrite to `@mstar-harness/opencode@latest`.",
-    ];
+    warnings.push(
+      "Plugin list uses legacy `morning-star@git+…` for this harness; run `mstar-harness init --target opencode` to rewrite to `@mstar-harness/opencode@latest`.",
+    );
   }
   if (hasLegacy && hasNpm) {
-    return [
+    warnings.push(
       "Both legacy `morning-star@git+…` and `@mstar-harness/opencode` appear in `plugin`; run `init` again to dedupe and keep a single npm plugin line.",
-    ];
+    );
   }
-  return [];
+
+  const agent = ensureObject(config.agent);
+  const missingModels = ALL_ROLES.filter((roleId) => {
+    const role = ensureObject(agent[roleId]);
+    return typeof role.model !== "string" || !role.model.trim();
+  });
+  if (missingModels.length) {
+    warnings.push(
+      `${missingModels.length} role(s) have no explicit agent.<role>.model — OpenCode default model will be used (recommended for fastest setup).`,
+    );
+  }
+  return warnings;
 }
 
 export const opencodeAdapter: AgentAdapter = {
   target: "opencode",
   mode: "config",
-  getAvailableModels: () => getOpencodeModels(),
+  // No getAvailableModels — default init never calls `opencode models` (that command can hang with no feedback).
   resolveConfigPath: (scope, outputPath) => resolveOpencodeConfigPath(scope, outputPath),
   mutateConfigForInit: (config, assignments) => {
     const withSchema = ensureConfigSchema(config);
@@ -141,5 +142,6 @@ export const opencodeAdapter: AgentAdapter = {
   printPostSetupSummary: () => {
     console.log(`Schema: ${OPENCODE_CONFIG_SCHEMA} (ensured)`);
     console.log(`Plugin: ${MSTAR_OPENCODE_PLUGIN} (ensured; legacy git morning-star entries removed)`);
+    console.log("Role models: left to OpenCode defaults (set agent.<role>.model in opencode.json only if you want overrides)");
   },
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,12 +3,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { checkbox, select } from "@inquirer/prompts";
+import { select } from "@inquirer/prompts";
 import pc from "picocolors";
 import { Command } from "commander";
-import { buildModelAssignments, requireValidatedSelection } from "./assignment";
+import { buildModelAssignments } from "./assignment";
 import { getAdapter } from "./adapters";
-import type { DoctorOptions, InitOptions, ModelSelections, Scope, Target } from "./types";
+import type { DoctorOptions, InitOptions, Target } from "./types";
 import { SUPPORTED_TARGETS } from "./types";
 import { parseCsv, readJson, writeJson } from "./utils";
 
@@ -35,85 +35,35 @@ async function pickTargetInteractive() {
   });
 }
 
-const ASCII_ICONS = {
-  checked: "(*)",
-  unchecked: "( )",
-  cursor: ">",
-} as const;
-
-async function pickModelsInteractive(params: {
-  title: string;
-  hint: string;
-  models: string[];
-  maxCount: number;
-  single?: boolean;
-}) {
-  const choices = params.models.map((model) => ({ name: model, value: model }));
-  if (params.single) {
-    const picked = await select<string>({
-      message: `${params.title} (${params.hint})`,
-      choices,
-      theme: { icon: { cursor: ASCII_ICONS.cursor } },
-    });
-    return [picked];
-  }
-  return checkbox<string>({
-    message: `${params.title} (${params.hint})`,
-    choices,
-    theme: { icon: ASCII_ICONS },
-    validate: (picked) => {
-      if (picked.length < 1) return "Pick at least one model.";
-      if (picked.length > params.maxCount) return `Pick at most ${params.maxCount} models.`;
-      return true;
-    },
-  });
+function hasExplicitModelFlags(options: InitOptions): boolean {
+  return Boolean(
+    options.pmModel ||
+      options.strategicModels ||
+      options.devModels ||
+      options.qcModels ||
+      options.otherModels,
+  );
 }
 
-async function resolveSelections(options: InitOptions, models: string[]) {
-  if (options.yes) {
-    return {
-      pm: requireValidatedSelection("pm-model", options.pmModel ? [options.pmModel] : undefined, models, 1, true),
-      strategic: requireValidatedSelection("strategic-models", parseCsv(options.strategicModels), models, 3),
-      dev: requireValidatedSelection("dev-models", parseCsv(options.devModels), models, 3),
-      qc: requireValidatedSelection("qc-models", parseCsv(options.qcModels), models, 3),
-      others: requireValidatedSelection("other-models", parseCsv(options.otherModels), models, 3),
-    } satisfies ModelSelections;
-  }
+/** Advanced override only — never calls `opencode models` (avoids silent hangs). */
+function resolveExplicitModelAssignments(options: InitOptions) {
+  // Trust caller-supplied ids; do not discover/validate against a live model list.
+  const allow = (label: string, values: string[] | undefined, max: number, required: boolean) => {
+    if (!values?.length) {
+      if (required) throw new Error(`${label} is required when any --*-model flag is set.`);
+      return [] as string[];
+    }
+    if (values.length > max) throw new Error(`${label}: pick at most ${max} model(s).`);
+    return values;
+  };
 
-  logStep("Step 4/7 - Configure models by role group");
-  return {
-    pm: await pickModelsInteractive({
-      title: "1) project-manager",
-      hint: "orchestrator role, prefer strong agentic model",
-      models,
-      maxCount: 1,
-      single: true,
-    }),
-    strategic: await pickModelsInteractive({
-      title: "2) architect / product-manager / prompt-engineer",
-      hint: "decision-heavy roles, prefer high intelligence",
-      models,
-      maxCount: 3,
-    }),
-    dev: await pickModelsInteractive({
-      title: "3) fullstack-dev / fullstack-dev-2 / frontend-dev",
-      hint: "prefer coding-focused models",
-      models,
-      maxCount: 3,
-    }),
-    qc: await pickModelsInteractive({
-      title: "4) qc-specialist / qc-specialist-2 / qc-specialist-3",
-      hint: "prefer three distinct models",
-      models,
-      maxCount: 3,
-    }),
-    others: await pickModelsInteractive({
-      title: "5) other roles",
-      hint: "up to 3 models, random assignment",
-      models,
-      maxCount: 3,
-    }),
-  } satisfies ModelSelections;
+  return buildModelAssignments({
+    pm: allow("pm-model", options.pmModel ? [options.pmModel] : undefined, 1, true),
+    strategic: allow("strategic-models", parseCsv(options.strategicModels), 3, true),
+    dev: allow("dev-models", parseCsv(options.devModels), 3, true),
+    qc: allow("qc-models", parseCsv(options.qcModels), 3, true),
+    others: allow("other-models", parseCsv(options.otherModels), 3, true),
+  });
 }
 
 async function runInit(options: InitOptions) {
@@ -140,22 +90,24 @@ async function runInit(options: InitOptions) {
     return;
   }
 
-  logStep(`Step 3/7 - Fetch available models from ${adapter.target}`);
-  const models = adapter.getAvailableModels?.();
-  if (!models) throw new Error(`Adapter ${target} does not implement model discovery.`);
-  const selections = await resolveSelections(options, models);
+  // OpenCode (and any future config-mode targets): default = schema + plugin only.
+  // Skip interactive model picking and `opencode models` discovery (can hang with no output).
+  const useExplicitModels = hasExplicitModelFlags(options);
+  const assignments = useExplicitModels ? resolveExplicitModelAssignments(options) : {};
 
-  logStep("Step 5/7 - Build role model assignments");
-  const assignments = buildModelAssignments(selections);
+  if (useExplicitModels) {
+    logStep("Step 3/4 - Apply explicit role model overrides from CLI flags");
+  } else {
+    logStep("Step 3/4 - Fast setup (schema + plugin; OpenCode default models)");
+  }
 
-  logStep("Step 6/7 - Update config");
+  logStep("Step 4/4 - Update config");
   const configPath = adapter.resolveConfigPath?.(scope, options.output);
   if (!configPath) throw new Error(`Adapter ${target} does not implement config path resolution.`);
   const current = readJson(configPath);
   const updated = adapter.mutateConfigForInit?.(current, assignments);
   if (!updated) throw new Error(`Adapter ${target} does not implement init mutation.`);
 
-  logStep("Step 7/7 - Self-check");
   const checkErrors = adapter.validateConfig?.(updated) || [];
   if (checkErrors.length) {
     throw new Error(`Configuration verification failed:\n- ${checkErrors.join("\n- ")}`);
@@ -173,9 +125,11 @@ async function runInit(options: InitOptions) {
   console.log(`Target: ${target}`);
   console.log(`Config file: ${configPath}`);
   if (adapter.printPostSetupSummary) adapter.printPostSetupSummary(updated);
-  console.log("Assigned roles:");
-  for (const [roleId, modelId] of Object.entries(assignments)) {
-    console.log(`  - ${roleId}: ${modelId}`);
+  if (Object.keys(assignments).length) {
+    console.log("Assigned roles:");
+    for (const [roleId, modelId] of Object.entries(assignments)) {
+      console.log(`  - ${roleId}: ${modelId}`);
+    }
   }
 }
 
@@ -235,11 +189,11 @@ program
   .option("--scope <scope>", "Config scope: global|project (default: project)")
   .option("--output <path>", "Config file path override, relative to project root")
   .option("--dry-run", "Preview result without writing config")
-  .option("--pm-model <model>", "Model for project-manager")
-  .option("--strategic-models <a,b,c>", "Models for architect/product-manager/prompt-engineer")
-  .option("--dev-models <a,b,c>", "Models for fullstack-dev/fullstack-dev-2/frontend-dev")
-  .option("--qc-models <a,b,c>", "Models for qc trio")
-  .option("--other-models <a,b,c>", "Models for random assignment to remaining roles")
+  .option("--pm-model <model>", "Optional: model for project-manager (advanced override)")
+  .option("--strategic-models <a,b,c>", "Optional: models for architect/product-manager/prompt-engineer")
+  .option("--dev-models <a,b,c>", "Optional: models for fullstack-dev/fullstack-dev-2/frontend-dev")
+  .option("--qc-models <a,b,c>", "Optional: models for qc trio")
+  .option("--other-models <a,b,c>", "Optional: models for remaining roles")
   .action(async (options: InitOptions) => {
     await runInit(options);
   });


### PR DESCRIPTION
## Summary
- Fix failed `v1.2.0` npm publish: use Node 24 bundled npm for Trusted Publishing and remove broken `npm install -g npm@latest` on Node 22 (`MODULE_NOT_FOUND: sigstore`); build packages before publish.
- Path-filter CI for `packages/cli`, `packages/opencode`, and bundled `skills`/`agents`/`commands` with build + smoke + pack.
- OpenCode `init` fast path: schema + plugin only; skip interactive model picking and `opencode models` (hangs with no feedback). Optional `--*-model` flags remain as advanced overrides.
- Keep package version at **1.2.0**; remote `v1.2.0` tag was deleted pending a successful re-release after merge.

## Test plan
- [ ] CI on this PR runs and passes package build/pack
- [ ] `bun run cli:build && bun run opencode:build`
- [ ] `npx`/`bun` `init --target opencode --yes --dry-run` completes without prompting or calling `opencode models`
- [ ] `doctor --target opencode` is healthy when only schema + plugin are present
- [ ] After merge: retag `v1.2.0` and confirm Release workflow publishes both packages


Made with [Cursor](https://cursor.com)