### PR TITLE
release: Morning Star harness 1.3.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, and Codex.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,36 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.2.1** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.3.0** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.2.1** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.2.1** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.2.1** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.2.1** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.2.1** |
+| Monorepo root | `morning-star` (`package.json`) | **1.3.0** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.3.0** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.3.0** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.3.0** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.3.0** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
+
+## [1.3.0] - 2026-07-11
+
+### Harness (bootstrap absorb)
+
+- **Retire `/mstar-bootstrap` command**: the 7-phase project knowledge bootstrap procedure moves to `mstar-compound-refresh/references/project-knowledge-bootstrap.md`; `mstar-compound-refresh` and `mstar-harness-core` carry short pointers.
+
+### CLI (Codex iteration skills)
+
+- **Project-scoped Codex install**: materializes `iteration-start`, `iteration-drive`, and `iteration-loop` as `.agents/skills/*/SKILL.md` symlinks from bundled harness commands; `doctor` validates links; global install skips with an explicit warning.
+
+### Docs
+
+- **Root `INSTALL.md`**: machine-readable install steps extracted from READMEs.
+- **Slim bilingual READMEs**: CLI-first Quick Start; clarify `/iteration-start` → `/iteration-drive` vs `/iteration-loop` usage paths.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex plugin manifests: **→ 1.3.0**.
 
 ## [1.2.1] - 2026-07-10
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,16 +1,35 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.2.1**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.3.0**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.2.1** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.2.1** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.2.1** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.2.1** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.2.1** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.3.0** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.3.0** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.3.0** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.3.0** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.3.0** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
+
+## [1.3.0] - 2026-07-11
+
+### Harness（bootstrap 吸收）
+
+- **退役 `/mstar-bootstrap` 命令**：7 阶段项目知识 bootstrap 流程迁入 `mstar-compound-refresh/references/project-knowledge-bootstrap.md`；`mstar-compound-refresh` 与 `mstar-harness-core` 保留简短指针。
+
+### CLI（Codex iteration skills）
+
+- **项目级 Codex 安装**：将 `iteration-start`、`iteration-drive`、`iteration-loop` 物化为 `.agents/skills/*/SKILL.md` 符号链接（源自 harness commands）；`doctor` 校验链接；全局安装跳过并给出明确警告。
+
+### 文档
+
+- **根目录 `INSTALL.md`**：从 README 抽离的可机读安装步骤。
+- **精简双语 README**：CLI 优先 Quick Start；厘清 `/iteration-start` → `/iteration-drive` 与 `/iteration-loop` 使用路径。
+
+### 版本对齐
+
+- monorepo、OpenCode、CLI、Cursor/Codex 插件：**→ 1.3.0**。
 
 ## [1.2.1] - 2026-07-10
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,207 @@
+# Morning Star — Installation
+
+> 中文安装说明的叙述性导读见 [README_CN.md](README_CN.md)；本文档为结构化安装参考（英文为主）。
+
+## Prerequisites
+
+- **Node.js** 18+ (for `npx` / `bunx` CLI)
+- Target host installed:
+  - [OpenCode](https://opencode.ai)
+  - [Cursor](https://cursor.com)
+  - [Codex](https://github.com/openai/codex) (with `codex` CLI for marketplace install)
+
+## Recommended: CLI install
+
+Package: `@mstar-harness/cli` (command: `mstar-harness`).
+
+```bash
+npx @mstar-harness/cli init
+# or
+bunx @mstar-harness/cli init
+```
+
+`init` is target-aware and writes baseline config in one flow. `--scope` defaults to `project` when omitted.
+
+### OpenCode
+
+```bash
+npx @mstar-harness/cli init --target opencode --yes
+npx @mstar-harness/cli doctor --target opencode
+```
+
+Non-interactive preview:
+
+```bash
+npx @mstar-harness/cli init --target opencode --dry-run --yes
+```
+
+### Cursor
+
+Global (recommended for personal use):
+
+```bash
+npx @mstar-harness/cli init --target cursor --scope global
+```
+
+Project (plugin checkout under `.cursor/plugins/morning-star-harness`, gitignored):
+
+```bash
+npx @mstar-harness/cli init --target cursor --scope project
+```
+
+Verify:
+
+```bash
+npx @mstar-harness/cli doctor --target cursor --scope global
+# or --scope project
+```
+
+Restart Cursor or run **Developer: Reload Window** after install.
+
+**Layout note:** Cursor does **not** discover symlinked plugin directories. The CLI maintains a shared checkout at `~/.mstar/harness` and a **separate real git checkout** at the Cursor plugin path. See [Install path layout](docs/cli.md#install-path-layout) in [`docs/cli.md`](docs/cli.md).
+
+### Codex
+
+Global marketplace + custom agents:
+
+```bash
+npx @mstar-harness/cli init --target codex --scope global
+codex plugin add morning-star-harness --marketplace personal
+npx @mstar-harness/cli doctor --target codex
+```
+
+Project marketplace + custom agents:
+
+```bash
+npx @mstar-harness/cli init --target codex --scope project
+codex plugin add morning-star-harness --marketplace personal
+npx @mstar-harness/cli doctor --target codex --scope project
+```
+
+#### Codex: project vs global scope
+
+| Scope | Iteration commands (`iteration-start`, `iteration-drive`, `iteration-loop`) |
+|-------|-------------------------------------------------------------------------------|
+| **Project** | Installed as project-local skills under `.agents/skills/<name>/SKILL.md` (symlinked from harness `commands/`; gitignored by CLI) |
+| **Global** | **Not** installed (avoids polluting other projects); `init` prints a warning — re-run with `--scope project` to enable |
+
+Full CLI flags, `doctor` checks, and path tables: [`docs/cli.md`](docs/cli.md).
+
+## Manual install
+
+Use when you cannot run the CLI or need to mirror the same layout by hand.
+
+Supported targets: `opencode`, `cursor`, `codex`.
+
+### OpenCode
+
+Add to `opencode.json` (global or project):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "@mstar-harness/opencode@latest"
+  ]
+}
+```
+
+Restart OpenCode.
+
+The OpenCode plugin resolves **skills and agents only inside `@mstar-harness/opencode`** (not `process.cwd()`). Published builds ship `harness-skills/` and `harness-agents/`. If you work from a **git checkout** of this repo, run **`bun install` / `npm install` at the repo root** so `postinstall` runs `opencode:bundle-assets` and populates those directories under `packages/opencode/`.
+
+Detailed OpenCode setup, migration, and troubleshooting: [`packages/opencode/INSTALL.md`](packages/opencode/INSTALL.md).
+
+### Cursor
+
+Recommended equivalent:
+
+```bash
+npx @mstar-harness/cli init --target cursor --scope global
+```
+
+Manual (same layout the CLI uses; **do not symlink** the Cursor plugin path):
+
+```bash
+git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness
+mkdir -p ~/.cursor/plugins/local
+git clone https://github.com/btspoony/mstar-harness.git ~/.cursor/plugins/local/morning-star-harness
+```
+
+Restart Cursor or run **Developer: Reload Window**.
+
+**Maintainers** (develop in a separate workspace; refresh after merge):
+
+```bash
+cd ~/.cursor/plugins/local/morning-star-harness && git pull --ff-only
+# or
+npx @mstar-harness/cli init --target cursor --scope global
+```
+
+### Codex
+
+Personal marketplace (without the CLI):
+
+```bash
+git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness
+```
+
+Create or update `~/.agents/plugins/marketplace.json`:
+
+```json
+{
+  "name": "personal",
+  "interface": {
+    "displayName": "Personal"
+  },
+  "plugins": [
+    {
+      "name": "morning-star-harness",
+      "source": {
+        "source": "local",
+        "path": "./.mstar/harness"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}
+```
+
+Install and link agents:
+
+```bash
+codex plugin add morning-star-harness --marketplace personal
+mkdir -p ~/.codex/agents
+ln -s ~/.mstar/harness/codex/agents/*.toml ~/.codex/agents/
+```
+
+Codex plugin source in this repository:
+
+- Manifest: `.codex-plugin/plugin.json`
+- Runtime skills: `skills/`
+- Custom agents: `codex/agents/`
+- Host adapter: `skills/mstar-host/references/codex.md`
+
+For project-local iteration skills, prefer `npx @mstar-harness/cli init --target codex --scope project` (see [Codex: project vs global scope](#codex-project-vs-global-scope)).
+
+## Post-install
+
+1. **Enter PM orchestration**
+   - OpenCode: start with the `Project Manager` role (`agents/project-manager.md`, typically `agent.project-manager` in `opencode.json`).
+   - Cursor / Codex: use `/pm`.
+
+2. **Run an iteration** (see [README — Harness Commands](README.md#harness-commands))
+   - **Deep / first iteration:** `/iteration-start` (Phase 1) → `/iteration-drive` (Phase 2–5).
+   - **Fast autonomous loop:** `/iteration-loop` (Phase 1→5, optional `direction` + `scale`).
+
+3. **Project knowledge** — bootstrap or refresh via the `mstar-compound-refresh` skill (`references/project-knowledge-bootstrap.md`), not a separate install step.
+
+## Further reading
+
+- CLI reference: [`docs/cli.md`](docs/cli.md)
+- OpenCode package install: [`packages/opencode/INSTALL.md`](packages/opencode/INSTALL.md)
+- User guide (narrative): [`README.md`](README.md) / [`README_CN.md`](README_CN.md)

--- a/README.md
+++ b/README.md
@@ -27,123 +27,49 @@ Latest release: **1.2.1** — see [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.m
 
 ## Quick Start
 
-### CLI Install
+Recommended install uses the CLI (`@mstar-harness/cli`):
 
-- Use the `mstar-harness` CLI (npm package `@mstar-harness/cli`):
-  - `npx @mstar-harness/cli init`
-  - or `bunx @mstar-harness/cli init`
-- `init` provides a target-aware guided setup so installation and baseline config happen in one flow.
-- CLI target support currently includes:
-  - OpenCode: `npx @mstar-harness/cli init --target opencode`
-  - Cursor: `npx @mstar-harness/cli init --target cursor`
-  - Codex:
-    - `npx @mstar-harness/cli init --target codex`
-    - `codex plugin add morning-star-harness --marketplace personal`
-- Cursor and Codex installs maintain a shared checkout at `~/.mstar/harness` (Codex marketplace + agent sources). **Cursor** installs a separate **real git checkout** at the plugin path — Cursor does not discover symlinked plugin directories (see [`docs/cli.md`](docs/cli.md#install-path-layout)).
+```bash
+npx @mstar-harness/cli init
+# or: bunx @mstar-harness/cli init
+```
 
-For full CLI usage and advanced options (`--yes`, `--dry-run`, `--output`, `doctor`) including Cursor and Codex target install modes, see [`docs/cli.md`](docs/cli.md).
+Per-target examples:
 
-### Manual Install
+- OpenCode: `npx @mstar-harness/cli init --target opencode`
+- Cursor: `npx @mstar-harness/cli init --target cursor`
+- Codex: `npx @mstar-harness/cli init --target codex` then `codex plugin add morning-star-harness --marketplace personal`
 
-Manual install targets currently include:
+`init` provides target-aware guided setup (scopes, path layout, baseline config). Verify with `npx @mstar-harness/cli doctor --target <opencode|cursor|codex>`.
 
-- `opencode`
-- `cursor`
-- `codex`
-
-#### OpenCode
-
-- Plugin install:
-  - Add plugin config in `opencode.json`:
-    ```json
-    {
-      "$schema": "https://opencode.ai/config.json",
-      "plugin": [
-        "@mstar-harness/opencode@latest"
-      ]
-    }
-    ```
-  - Restart OpenCode
-- The OpenCode plugin resolves **skills and agents only inside `@mstar-harness/opencode`** (not `process.cwd()`). Published builds ship `harness-skills/` and `harness-agents/`. If you work from a **git checkout** of this repo, run **`bun install` / `npm install` at the repo root** so `postinstall` runs `opencode:bundle-assets` and populates those directories under `packages/opencode/`.
-
-For detailed OpenCode setup and migration, see `packages/opencode/INSTALL.md`.
-
-#### Cursor
-
-- Recommended:
-  - `npx @mstar-harness/cli init --target cursor --scope global`
-  - Restart Cursor or run `Developer: Reload Window`
-- Manual install (same layout the CLI uses; **do not symlink** the Cursor plugin path):
-  - `git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness`
-  - `mkdir -p ~/.cursor/plugins/local`
-  - `git clone https://github.com/btspoony/mstar-harness.git ~/.cursor/plugins/local/morning-star-harness`
-  - Restart Cursor or run `Developer: Reload Window`
-- **Maintainers**: develop in your workspace; refresh the Cursor plugin checkout after merge:
-  - `cd ~/.cursor/plugins/local/morning-star-harness && git pull --ff-only`
-  - or re-run `npx @mstar-harness/cli init --target cursor --scope global`
-
-#### Codex
-
-- Personal marketplace install (without the CLI):
-  - Clone or update the maintained local checkout:
-    - `git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness`
-  - Create or update `~/.agents/plugins/marketplace.json`:
-    ```json
-    {
-      "name": "personal",
-      "interface": {
-        "displayName": "Personal"
-      },
-      "plugins": [
-        {
-          "name": "morning-star-harness",
-          "source": {
-            "source": "local",
-            "path": "./.mstar/harness"
-          },
-          "policy": {
-            "installation": "AVAILABLE",
-            "authentication": "ON_INSTALL"
-          },
-          "category": "Productivity"
-        }
-      ]
-    }
-    ```
-  - Install the plugin:
-    - `codex plugin add morning-star-harness --marketplace personal`
-  - Link Codex custom agents:
-    - `mkdir -p ~/.codex/agents`
-    - `ln -s ~/.mstar/harness/codex/agents/*.toml ~/.codex/agents/`
-- This repository is also the **Morning Star Harness Codex plugin source**:
-  - Plugin manifest: `.codex-plugin/plugin.json`
-  - Runtime skills: `skills/`
-  - Codex custom agents: `codex/agents/`
-  - Codex runtime adaptation: `skills/mstar-host/references/codex.md`
-
-That completes installation.
+**Detailed install** (manual steps, path layout, Codex project vs global): [`INSTALL.md`](INSTALL.md). **CLI flags and advanced options:** [`docs/cli.md`](docs/cli.md).
 
 ## How to use
 
 - **OpenCode**: start with the `Project Manager` role (`agents/project-manager.md`, typically `agent.project-manager` in `opencode.json`).
 - **Cursor**: use `/pm` to force-start with the `Project Manager` role.
-- **Codex**: use `/pm` to force-start with the `Project Manager` role after installing the plugin.
-  Codex loads shared skills and custom agents from `codex/agents/` when linked by the CLI/manual install.
+- **Codex**: use `/pm` after installing the plugin. Custom agents are linked from `codex/agents/` by the CLI or manual install.
 
 ### Harness Commands
 
-The shared `commands/` directory currently provides these PM-led harness commands:
+Three PM-led iteration entry points. Pick by how much human direction you need:
 
-| Command | Available in | Use when |
-|---------|--------------|----------|
-| `/mstar-bootstrap` | Cursor, OpenCode | Bootstrap or refresh project knowledge scaffolding: `STRATEGY.md`, `CONCEPTS.md`, `{KNOWLEDGE_DIR}`, and related indexes. |
-| `/iteration-start` | Cursor, OpenCode | Start a new harness iteration (Phase 1 only): research backlog, **grill-me** lock direction, write compass/plans, run the review chain, create the integration branch. |
-| `/iteration-drive` | Cursor, OpenCode | Drive an **already locked** iteration (Phase 2 execute → Phase 3 close → Phase 4 PR → Phase 5 merge-ready). |
-| `/iteration-loop` | Cursor, OpenCode | **Autonomous full loop** (Phase 1→5) for cloud agents: code-first auto direction lock (optional `direction` + `scale` S\|M\|L), review chain, then execute through merge-ready — minimal human check-ins. |
+| Path | When | Flow |
+|------|------|------|
+| `/iteration-start` → `/iteration-drive` | First iteration, or deep work that needs human direction lock (**grill-me**) before execution | Phase 1 only → Phase 2–5 (execute, close, PR, merge-ready) |
+| `/iteration-loop` | Fast autonomous full loop (cloud-agent friendly); optional `direction` + `scale` (S\|M\|L) | Phase 1→5 continuous with minimal check-ins |
 
-In OpenCode, install or update `@mstar-harness/opencode` and restart OpenCode; the plugin bundles these markdown commands from `harness-commands/`.
+**Where commands load:**
 
-In Cursor, install or update the Cursor plugin link and reload the window; the commands are discovered from this repository's `commands/` directory alongside the shared agents, skills, and rules.
+| Host | Discovery |
+|------|-----------|
+| **Cursor / OpenCode** | Bundled from this repo's `commands/` (OpenCode: `harness-commands/` in the plugin) |
+| **Codex (project install)** | Same three commands as project-local skills: `.agents/skills/<name>/SKILL.md` (CLI symlinks from `commands/`) |
+| **Codex (global install)** | Iteration skills are **not** installed — use `--scope project` to avoid polluting other projects |
+
+Project knowledge bootstrap/refresh: `mstar-compound-refresh` skill (`references/project-knowledge-bootstrap.md`).
+
+After install, reload the host (restart OpenCode / Cursor **Developer: Reload Window** / re-open Codex).
 
 ## Harness Workflow
 
@@ -154,33 +80,36 @@ flowchart TD
     C --> B
     B -->|Yes| D["PM: initialize/load HARNESS_DIR and PLAN_DIR"]
     D --> E{"Iteration scope needed"}
-    E -->|Yes| F["iteration-start: create compass, plans, and review chain"]
+    E -->|Deep / first iteration| F["iteration-start: compass, plans, review chain"]
+    E -->|Fast autonomous loop| F2["iteration-loop: Phase 1→5 continuous"]
     F --> G["PM: lock compass and create integration branch"]
-    E -->|No| H["PM: select active plan from status.json"]
-    G --> H
-    H --> I{"Any plan not Done"}
-    I -->|Yes| J["PM: dispatch one plan on a feature branch"]
-    J --> K["Dev roles: implement and report"]
-    K --> L["PM: update plan and status.json"]
-    L --> M["QC trio: review gate"]
-    M --> N{"QC decision"}
-    N -->|Request Changes| J
-    N -->|Approve| O{"QA gate"}
-    O -->|mandatory| O1["qa-engineer: acceptance verification"]
-    O -->|pm-acceptance| O2["PM: acceptance checklist"]
-    O1 --> P{"Residual findings remain"}
-    O2 --> P
-    P -->|Yes| Q["PM/QA: register or accept residuals in status.json"]
-    Q --> R["PM: mark plan Done and merge to integration branch"]
-    P -->|No| R
-    R --> S["PM: sync compass plan status"]
-    S --> I
-    I -->|No| T["iteration-close: close entry checklist"]
-    T --> U["PM: compound round and knowledge index"]
-    U --> V["PM: update roadmap and compass completed frontmatter"]
-    V --> W["PM: close exit checklist and commit"]
-    W --> X["Phase 4: create PR"]
-    X --> Y["Phase 5: merge-ready loop until CI green and reviews resolved"]
+    F2 --> G
+    G --> H["iteration-drive or loop continues: execute → close → PR → merge-ready"]
+    E -->|No| I["PM: select active plan from status.json"]
+    H --> I
+    I --> J{"Any plan not Done"}
+    J -->|Yes| K["PM: dispatch one plan on a feature branch"]
+    K --> L["Dev roles: implement and report"]
+    L --> M["PM: update plan and status.json"]
+    M --> N["QC trio: review gate"]
+    N --> O{"QC decision"}
+    O -->|Request Changes| K
+    O -->|Approve| P{"QA gate"}
+    P -->|mandatory| P1["qa-engineer: acceptance verification"]
+    P -->|pm-acceptance| P2["PM: acceptance checklist"]
+    P1 --> Q{"Residual findings remain"}
+    P2 --> Q
+    Q -->|Yes| R["PM/QA: register or accept residuals in status.json"]
+    R --> S["PM: mark plan Done and merge to integration branch"]
+    Q -->|No| S
+    S --> T["PM: sync compass plan status"]
+    T --> J
+    J -->|No| U["iteration-close: close entry checklist"]
+    U --> V["PM: compound round and knowledge index"]
+    V --> W["PM: update roadmap and compass completed frontmatter"]
+    W --> X["PM: close exit checklist and commit"]
+    X --> Y["Phase 4: create PR"]
+    Y --> Z["Phase 5: merge-ready loop until CI green and reviews resolved"]
 ```
 
 For single-plan or non-iteration work, use the same per-plan gates (`Prepare → Execute → QC → QA gate → Done`) without the iteration-start / iteration-close wrapper.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Core value:
 - Run with unified `mstar-*` skills instead of scattered rules
 - Reuse one core process across OpenCode, Cursor, and Codex
 
-Latest release: **1.2.1** — see [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md).
+Latest release: **1.3.0** — see [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
 ## Quick Start
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -27,121 +27,92 @@
 
 ## 快速开始（推荐方式）
 
-### CLI Install
+推荐使用 CLI（`@mstar-harness/cli`）安装：
 
-- 使用 `mstar-harness` CLI（npm 包名 `@mstar-harness/cli`）：
-  - `npx @mstar-harness/cli init`
-  - 或 `bunx @mstar-harness/cli init`
-- `init` 提供按 target 的引导式安装流程，将安装与基础配置一步完成。
-- CLI 当前支持的 target：
-  - OpenCode：`npx @mstar-harness/cli init --target opencode`
-  - Cursor：`npx @mstar-harness/cli init --target cursor`
-  - Codex：
-    - `npx @mstar-harness/cli init --target codex`
-    - `codex plugin add morning-star-harness --marketplace personal`
-- Cursor 与 Codex 共享 `~/.mstar/harness` 长期 checkout（Codex marketplace 与 agent 源）。**Cursor** 在插件路径使用**独立的 git 实目录**——Cursor **无法发现**软链接形式的插件目录（见 [`docs/cli.md`](docs/cli.md#install-path-layout)）。
+```bash
+npx @mstar-harness/cli init
+# 或：bunx @mstar-harness/cli init
+```
 
-完整 CLI 用法和高级参数（`--yes`、`--dry-run`、`--output`、`doctor`），以及 Cursor / Codex target 的安装模式说明，见 [`docs/cli.md`](docs/cli.md)。
+按 target 示例：
 
-### Manual Install
+- OpenCode：`npx @mstar-harness/cli init --target opencode`
+- Cursor：`npx @mstar-harness/cli init --target cursor`
+- Codex：`npx @mstar-harness/cli init --target codex`，然后 `codex plugin add morning-star-harness --marketplace personal`
 
-当前支持手动安装的 target：
+`init` 提供按 target 的引导式安装（scope、路径布局、基础配置）。可用 `npx @mstar-harness/cli doctor --target <opencode|cursor|codex>` 校验。
 
-- `opencode`
-- `cursor`
-- `codex`
-
-#### OpenCode
-
-- 推荐使用 plugin 安装：
-  - 在 `opencode.json` 增加插件配置：
-    ```json
-    {
-      "$schema": "https://opencode.ai/config.json",
-      "plugin": [
-        "@mstar-harness/opencode@latest"
-      ]
-    }
-    ```
-  - 重启 OpenCode
-- OpenCode 插件**只从 `@mstar-harness/opencode` 包内路径**解析 skills/agents（**不**依赖 `process.cwd()`）。发布包内含 `harness-skills/`、`harness-agents/`。若在本仓库 **git 工作区**开发，请在**仓库根**执行 **`bun install` / `npm install`**，以便 `postinstall` 执行 `opencode:bundle-assets`，在 `packages/opencode/` 下生成上述目录。
-
-OpenCode 的详细安装与迁移说明见 `packages/opencode/INSTALL.md`。
-
-#### Cursor
-
-- 推荐：
-  - `npx @mstar-harness/cli init --target cursor --scope global`
-  - 重启 Cursor 或运行 `Developer: Reload Window`
-- 手动安装（与 CLI 相同布局；Cursor 插件路径**不要用软链接**）：
-  - `git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness`
-  - `mkdir -p ~/.cursor/plugins/local`
-  - `git clone https://github.com/btspoony/mstar-harness.git ~/.cursor/plugins/local/morning-star-harness`
-  - 重启 Cursor 或运行 `Developer: Reload Window`
-- **维护者**：在 workspace 开发后，更新 Cursor 插件 checkout：
-  - `cd ~/.cursor/plugins/local/morning-star-harness && git pull --ff-only`
-  - 或重新运行 `npx @mstar-harness/cli init --target cursor --scope global`
-
-#### Codex
-
-- Personal marketplace 安装（不使用 CLI）：
-  - clone 或更新长期本地 checkout：
-    - `git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness`
-  - 创建或更新 `~/.agents/plugins/marketplace.json`：
-    ```json
-    {
-      "name": "personal",
-      "interface": {
-        "displayName": "Personal"
-      },
-      "plugins": [
-        {
-          "name": "morning-star-harness",
-          "source": {
-            "source": "local",
-            "path": "./.mstar/harness"
-          },
-          "policy": {
-            "installation": "AVAILABLE",
-            "authentication": "ON_INSTALL"
-          },
-          "category": "Productivity"
-        }
-      ]
-    }
-    ```
-  - 安装插件：
-    - `codex plugin add morning-star-harness --marketplace personal`
-  - 链接 Codex custom agents：
-    - `mkdir -p ~/.codex/agents`
-    - `ln -s ~/.mstar/harness/codex/agents/*.toml ~/.codex/agents/`
-- 本仓库也是 **Morning Star Harness Codex 插件源码**：
-  - 插件 manifest：`.codex-plugin/plugin.json`
-  - 运行时 skills：`skills/`
-  - Codex custom agents：`codex/agents/`
-  - Codex 运行时适配：`skills/mstar-host/references/codex.md`
+**详细安装**（手动步骤、路径布局、Codex project vs global）：[`INSTALL.md`](INSTALL.md)。**CLI 参数与高级选项：** [`docs/cli.md`](docs/cli.md)。
 
 ## 使用方式
 
 - **OpenCode**：以 `Project Manager` 角色开局（对应 `agents/project-manager.md`，通常是 `opencode.json` 里的 `agent.project-manager`）。
 - **Cursor**：使用 `/pm` 强制以 `Project Manager` 角色启动。
-- **Codex**：安装插件后，使用 `/pm` 强制以 `Project Manager` 角色启动。
-  CLI / 手动安装链接 `codex/agents/` 后，Codex 可通过 custom agents 执行 Morning Star 角色派发。
+- **Codex**：安装插件后使用 `/pm`。CLI 或手动安装会链接 `codex/agents/` 下的 custom agents。
 
 ### Harness Commands
 
-共享的 `commands/` 目录目前提供这些由 PM 驱动的 harness commands：
+三个由 PM 驱动的 iteration 入口。按你需要的人工参与程度选择：
 
-| Command | 可用宿主 | 使用场景 |
-|---------|----------|----------|
-| `/mstar-bootstrap` | Cursor、OpenCode | 初始化或刷新项目知识脚手架：`STRATEGY.md`、`CONCEPTS.md`、`{KNOWLEDGE_DIR}` 及相关索引。 |
-| `/iteration-start` | Cursor、OpenCode | 仅 Phase 1：调研 backlog、**grill-me** 锁定方向、产出 compass/plans、执行 review chain，并创建 integration branch。 |
-| `/iteration-drive` | Cursor、OpenCode | 推进**已锁定**的 iteration：Phase 2 execute → Phase 3 close → Phase 4 开 PR → Phase 5 merge-ready。 |
-| `/iteration-loop` | Cursor、OpenCode | **自动化完整闭环**（Phase 1→5，适合 cloud agent）：代码优先自动锁方向（可选参数 `direction` + `scale` S\|M\|L），review chain 后连续执行至 merge-ready，尽量少人工确认。 |
+| 路径 | 适用场景 | 流程 |
+|------|----------|------|
+| `/iteration-start` → `/iteration-drive` | 首次 iteration，或需要人工方向锁定（**grill-me**）的深度工作 | 仅 Phase 1 → Phase 2–5（执行、收尾、开 PR、merge-ready） |
+| `/iteration-loop` | 快速自动化完整闭环（适合 cloud agent）；可选 `direction` + `scale`（S\|M\|L） | Phase 1→5 连续执行，尽量少人工确认 |
 
-在 OpenCode 中，安装或更新 `@mstar-harness/opencode` 后重启 OpenCode；插件会从 `harness-commands/` 打包注册这些 markdown commands。
+**命令加载位置：**
 
-在 Cursor 中，安装或更新 Cursor plugin 链接后 reload window；这些 commands 会与共享 agents、skills、rules 一起从本仓库 `commands/` 目录发现。
+| 宿主 | 发现方式 |
+|------|----------|
+| **Cursor / OpenCode** | 从本仓库 `commands/` 打包（OpenCode：插件内 `harness-commands/`） |
+| **Codex（project 安装）** | 同上三条命令作为项目本地 skill：`.agents/skills/<name>/SKILL.md`（CLI 从 `commands/` 软链接） |
+| **Codex（global 安装）** | **不**安装 iteration skills — 使用 `--scope project` 以免污染其他项目 |
+
+项目知识脚手架的初始化/刷新：通过 `mstar-compound-refresh` skill（`references/project-knowledge-bootstrap.md`）。
+
+安装后请重载宿主（重启 OpenCode / Cursor **Developer: Reload Window** / 重新打开 Codex）。
+
+## Harness Workflow（统一流程）
+
+```mermaid
+flowchart TD
+    A["PM: 入口与意图澄清"] --> B{"PM: 规格与上下文是否就绪"}
+    B -->|否| C["PM: 继续澄清并补齐需求约束"]
+    C --> B
+    B -->|是| D["PM: 初始化或加载 HARNESS_DIR 与 PLAN_DIR"]
+    D --> E{"是否需要 iteration scope"}
+    E -->|深度 / 首次 iteration| F["iteration-start: compass、plans、review chain"]
+    E -->|快速自动化闭环| F2["iteration-loop: Phase 1→5 连续"]
+    F --> G["PM: 锁定 compass 并创建 integration branch"]
+    F2 --> G
+    G --> H["iteration-drive 或 loop 继续: execute → close → PR → merge-ready"]
+    E -->|否| I["PM: 从 status.json 选择 active plan"]
+    H --> I
+    I --> J{"是否仍有 plan 未 Done"}
+    J -->|是| K["PM: 在 feature branch 分派一个 plan"]
+    K --> L["开发角色: 实现并回报"]
+    L --> M["PM: 更新 plan 与 status.json"]
+    M --> N["QC 三审: review gate"]
+    N --> O{"QC 结论"}
+    O -->|Request Changes| K
+    O -->|Approve| P{"QA gate"}
+    P -->|mandatory| P1["qa-engineer: 验收验证"]
+    P -->|pm-acceptance| P2["PM: acceptance 清单"]
+    P1 --> Q{"是否仍有 residual findings"}
+    P2 --> Q
+    Q -->|是| R["PM/QA: 在 status.json 登记或接受 residuals"]
+    R --> S["PM: 标记 plan Done 并合并到 integration branch"]
+    Q -->|否| S
+    S --> T["PM: 同步 compass plan 状态"]
+    T --> J
+    J -->|否| U["iteration-close: close entry checklist"]
+    U --> V["PM: compound round 与 knowledge index"]
+    V --> W["PM: 更新 roadmap 与 compass completed frontmatter"]
+    W --> X["PM: close exit checklist 与 commit"]
+    X --> Y["Phase 4: 开 PR"]
+    Y --> Z["Phase 5: merge-ready loop 直至 CI 全绿且 reviews resolved"]
+```
+
+单 plan 或非 iteration 工作使用同一套 per-plan gate（`Prepare → Execute → QC → QA gate → Done`），但不需要 iteration-start / iteration-close 外层。
 
 ## 角色与技能总览
 
@@ -190,46 +161,6 @@ OpenCode 的详细安装与迁移说明见 `packages/opencode/INSTALL.md`。
 维护者：仓库内维护笔记与计划约定见 [`AGENTS.md`](AGENTS.md)；这些本地产物不属于发布的 skill 树。
 
 项目计划工件默认使用 **`.mstar/`**（`{HARNESS_DIR}`），同时继续识别既有 `.agents/` / `.plans/` / `plans/` 布局。
-
-## Harness Workflow（统一流程）
-
-```mermaid
-flowchart TD
-    A["PM: 入口与意图澄清"] --> B{"PM: 规格与上下文是否就绪"}
-    B -->|否| C["PM: 继续澄清并补齐需求约束"]
-    C --> B
-    B -->|是| D["PM: 初始化或加载 HARNESS_DIR 与 PLAN_DIR"]
-    D --> E{"是否需要 iteration scope"}
-    E -->|是| F["iteration-start: 创建 compass、plans 并执行 review chain"]
-    F --> G["PM: 锁定 compass 并创建 integration branch"]
-    E -->|否| H["PM: 从 status.json 选择 active plan"]
-    G --> H
-    H --> I{"是否仍有 plan 未 Done"}
-    I -->|是| J["PM: 在 feature branch 分派一个 plan"]
-    J --> K["开发角色: 实现并回报"]
-    K --> L["PM: 更新 plan 与 status.json"]
-    L --> M["QC 三审: review gate"]
-    M --> N{"QC 结论"}
-    N -->|Request Changes| J
-    N -->|Approve| O{"QA gate"}
-    O -->|mandatory| O1["qa-engineer: 验收验证"]
-    O -->|pm-acceptance| O2["PM: acceptance 清单"]
-    O1 --> P{"是否仍有 residual findings"}
-    O2 --> P
-    P -->|是| Q["PM/QA: 在 status.json 登记或接受 residuals"]
-    Q --> R["PM: 标记 plan Done 并合并到 integration branch"]
-    P -->|否| R
-    R --> S["PM: 同步 compass plan 状态"]
-    S --> I
-    I -->|否| T["iteration-close: close entry checklist"]
-    T --> U["PM: compound round 与 knowledge index"]
-    U --> V["PM: 更新 roadmap 与 compass completed frontmatter"]
-    V --> W["PM: close exit checklist 与 commit"]
-    W --> X["Phase 4: 开 PR"]
-    X --> Y["Phase 5: merge-ready loop 直至 CI 全绿且 reviews resolved"]
-```
-
-单 plan 或非 iteration 工作使用同一套 per-plan gate（`Prepare → Execute → QC → QA gate → Done`），但不需要 iteration-start / iteration-close 外层。
 
 ## 许可
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,7 +23,7 @@
 - 通过统一的 `mstar-*` skills 执行，而不是散落规则
 - 在 OpenCode / Cursor / Codex 下复用同一套核心流程
 
-当前版本：**1.2.1** — 详见 [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)。
+当前版本：**1.3.0** — 详见 [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)。
 
 ## 快速开始（推荐方式）
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,6 +96,8 @@ Codex install:
 - Runtime host behavior after install:
   - `/pm` enters the shared PM flow.
   - Codex custom agents are linked from `~/.mstar/harness/codex/agents/*.toml`.
+  - **Project scope only:** `iteration-start`, `iteration-drive`, and `iteration-loop` are installed as project-local skills under `.agents/skills/<name>/SKILL.md` (symlinked to `~/.mstar/harness/commands/<name>.md`); the CLI gitignores those paths.
+  - **Global scope:** iteration skills are **not** installed (avoids polluting other projects); `init` prints a warning — re-run with `--scope project` to enable them.
   - Codex-specific clarify, dispatch, sandbox, and tool-discovery rules live in `skills/mstar-host/references/codex.md`.
 
 ### `mstar-harness doctor`
@@ -133,7 +135,7 @@ Codex `init` writes or updates marketplace metadata with a local-source entry:
 - `policy.installation`: `AVAILABLE`
 - `policy.authentication`: `ON_INSTALL`
 
-Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope also links `.codex/plugins/mstar-harness -> ~/.mstar/harness` and adds `.codex/plugins/mstar-harness` plus `.codex/agents/*.toml` to `.gitignore`.
+Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope also links `.codex/plugins/mstar-harness -> ~/.mstar/harness`, adds `.codex/plugins/mstar-harness` plus `.codex/agents/*.toml` to `.gitignore`, and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
 
 ## What `doctor` Checks
 
@@ -141,7 +143,7 @@ Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` 
 - Missing per-role `agent.<role>.model` is a **yellow recommendation** only (OpenCode defaults are OK).
 - If only legacy git is present, or legacy and npm are both listed, `doctor` prints **yellow recommendations** and still exits 0; run `init` to normalize to `@mstar-harness/opencode@latest`.
 - For Cursor, `doctor` checks the maintained `~/.mstar/harness` checkout, that the Cursor plugin path is a **real git directory** (not a symlink), and that `agents/*.md` files use Cursor-first frontmatter.
-- For Codex, `doctor` checks the local marketplace entry, the maintained `~/.mstar/harness` checkout, and custom-agent symlinks.
+- For Codex, `doctor` checks the local marketplace entry, the maintained `~/.mstar/harness` checkout, and custom-agent symlinks. Project scope also validates iteration skill symlinks under `.agents/skills/`.
 
 ## Install path layout
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.3.0
+
+- Codex project install: materialize `iteration-start`, `iteration-drive`, and `iteration-loop` as `.agents/skills/*/SKILL.md` symlinks; `doctor` validates links; global install skips with warning.
+- Version alignment with harness **1.3.0**.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.3.0**.
+
 ## 1.2.1
 
 - Version alignment with harness **1.2.1** (no CLI behavior change in this release).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex).",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -37,6 +37,15 @@ const CODEX_AGENT_NAMES = [
   "prompt-engineer",
 ];
 
+const CODEX_ITERATION_SKILL_NAMES = [
+  "iteration-start",
+  "iteration-drive",
+  "iteration-loop",
+] as const;
+
+const GLOBAL_ITERATION_SKILLS_WARNING =
+  "Codex iteration commands (iteration-start / iteration-drive / iteration-loop) are installed as project-local skills under .agents/skills/ only. Global install skips them to avoid polluting other code agents. Re-run with --scope project to enable.";
+
 type MarketplaceEntry = {
   name: string;
   source: {
@@ -174,6 +183,50 @@ function validateAgentLinks(scope: Scope) {
   return errors;
 }
 
+function iterationCommandSourcePath(skillName: string) {
+  return path.join(HARNESS_REPO_PATH, "commands", `${skillName}.md`);
+}
+
+function projectIterationSkillLinkPath(skillName: string) {
+  return path.join(resolveProjectRoot(), ".agents", "skills", skillName, "SKILL.md");
+}
+
+function iterationSkillGitignoreEntry(skillName: string) {
+  return `.agents/skills/${skillName}`;
+}
+
+function ensureIterationSkillLinks(dryRun: boolean) {
+  const notes: string[] = [];
+  const projectRoot = resolveProjectRoot();
+  for (const skillName of CODEX_ITERATION_SKILL_NAMES) {
+    const source = iterationCommandSourcePath(skillName);
+    const linkPath = projectIterationSkillLinkPath(skillName);
+    notes.push(ensureSymlink(source, linkPath, dryRun));
+  }
+  const gitignoreEntries = CODEX_ITERATION_SKILL_NAMES.map(iterationSkillGitignoreEntry);
+  notes.push(...appendGitignore(projectRoot, gitignoreEntries, dryRun));
+  notes.push(
+    "Installed Codex project-scoped iteration skills under .agents/skills/ (iteration-start, iteration-drive, iteration-loop) — symlinked to harness commands/*.md.",
+  );
+  return notes;
+}
+
+function validateIterationSkillLinks() {
+  const errors: string[] = [];
+  const projectRoot = resolveProjectRoot();
+  const gitignorePath = path.join(projectRoot, ".gitignore");
+  const gitignore = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
+  const lines = gitignore.split(/\r?\n/);
+  for (const skillName of CODEX_ITERATION_SKILL_NAMES) {
+    const source = iterationCommandSourcePath(skillName);
+    const linkPath = projectIterationSkillLinkPath(skillName);
+    errors.push(...validateSymlink(source, linkPath));
+    const entry = iterationSkillGitignoreEntry(skillName);
+    if (!lines.includes(entry)) errors.push(`Missing .gitignore entry: ${entry}`);
+  }
+  return errors;
+}
+
 function runInit(scope: Scope, dryRun: boolean) {
   const pathToMarketplace = marketplacePath(scope);
   const current = readJson(pathToMarketplace);
@@ -185,6 +238,9 @@ function runInit(scope: Scope, dryRun: boolean) {
     notes.push(ensureSymlink(HARNESS_REPO_PATH, path.join(projectRoot, CODEX_PLUGIN_LINK), dryRun));
     notes.push(...appendGitignore(projectRoot, [CODEX_PLUGIN_LINK, ".codex/agents/*.toml"], dryRun));
     notes.push(...appendHarnessProjectGitignore(projectRoot, dryRun));
+    notes.push(...ensureIterationSkillLinks(dryRun));
+  } else {
+    notes.push(GLOBAL_ITERATION_SKILLS_WARNING);
   }
   notes.push(...ensureAgentLinks(scope, dryRun));
   if (!dryRun) writeJson(pathToMarketplace, next);
@@ -219,6 +275,7 @@ function runDoctor(scope: Scope) {
     for (const entry of SDD_SCRATCH_GITIGNORE) {
       if (!lines.includes(entry)) errors.push(`Missing .gitignore entry: ${entry}`);
     }
+    errors.push(...validateIterationSkillLinks());
   }
   errors.push(...validateAgentLinks(scope));
   return { location: pathToMarketplace, errors };

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.3.0
+
+- Bundled commands: retire `/mstar-bootstrap`; bootstrap procedure → `mstar-compound-refresh/references/project-knowledge-bootstrap.md`.
+- Bundled skills: `mstar-compound-refresh` and `mstar-harness-core` short pointers for project knowledge bootstrap.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.3.0**.
+
 ## 1.2.1
 
 - Bundled commands: `/iteration-start` Cursor Plan mode path — blank Phase 1 CreatePlan scaffold, staged grill-me plan updates, Build-gated Review chain.

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -28,7 +28,7 @@ npx @mstar-harness/cli init --target opencode
 |-----------------|----------|
 | `harness-skills/` | `mstar-harness-core`, `mstar-iteration`, `mstar-sdd`, roles, phase/dispatch gates, … |
 | `harness-agents/` | Role shells (`project-manager`, `fullstack-dev`, `qc-specialist`, …) |
-| `harness-commands/` | `/iteration-start`, `/iteration-drive`, `/iteration-loop`, `/mstar-bootstrap` |
+| `harness-commands/` | `/iteration-start`, `/iteration-drive`, `/iteration-loop` |
 
 The plugin resolves **only paths inside this package** — not `process.cwd()/skills`, so your app repo root does not affect harness loading.
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-compound-refresh/SKILL.md
+++ b/skills/mstar-compound-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-compound-refresh
-description: Morning Star 知识维护 —— 审查 `{KNOWLEDGE_DIR}` 中文档是否仍准确、去重叠合并、清理过期知识。触发：`mstar-compound` 发现可合并文档、定期维护、或显式调用。产出：更新/合并/删除/标记为 stale 的文档 + 维护报告。
+description: Morning Star 知识维护与项目知识 bootstrap —— 审查 `{KNOWLEDGE_DIR}` 文档是否仍准确、去重叠合并、清理过期知识；或从代码库提炼 STRATEGY.md、CONCEPTS.md、基线 knowledge 脚手架（无/残旧/空白 knowledge）。触发：`mstar-compound` 发现可合并文档、定期维护、项目缺 STRATEGY.md/CONCEPTS.md/{KNOWLEDGE_DIR}、stale knowledge scaffolding、显式 bootstrap 请求、或显式 refresh。产出：更新/合并/删除知识文档 + 维护报告；或 bootstrap 产物（STRATEGY.md、CONCEPTS.md、基线 knowledge）。
 ---
 
 # mstar-compound-refresh（知识维护）
@@ -25,6 +25,16 @@ Knowledge documents in `{KNOWLEDGE_DIR}` age. Code changes, conventions evolve, 
 | Scheduled maintenance | "It's been a quarter, let's audit knowledge" |
 | Domain refactored | After a major module rewrite |
 | Explicit user request | `/pm compound-refresh performance-issues` |
+| **Project knowledge bootstrap** | No/stale/partial `STRATEGY.md`, `CONCEPTS.md`, or `{KNOWLEDGE_DIR}` — see below |
+
+## Bootstrap vs refresh
+
+| Mode | When | Procedure |
+|------|------|-----------|
+| **Refresh** | `{KNOWLEDGE_DIR}` exists; audit accuracy, merge overlaps, delete stale docs | This skill § Process (Phases 1–6) |
+| **Bootstrap** | No knowledge scaffolding, or artifacts are absent/stale enough to warrant full distillation from codebase | **`references/project-knowledge-bootstrap.md`** (7-phase: survey → STRATEGY.md → CONCEPTS.md → baseline knowledge → indexing → harness init → commit) |
+
+Read the bootstrap reference on demand; do not paste its body into this SKILL.md.
 
 ## Maintenance outcomes
 

--- a/skills/mstar-compound-refresh/references/project-knowledge-bootstrap.md
+++ b/skills/mstar-compound-refresh/references/project-knowledge-bootstrap.md
@@ -1,23 +1,17 @@
----
-name: mstar-bootstrap
-description: Bootstrap or refresh a project's knowledge scaffolding — distill STRATEGY.md, CONCEPTS.md, and baseline knowledge docs from the existing codebase and any docs. Use when a project has no knowledge infrastructure, stale/partial docs, or needs a fresh distillation.
-agent: project-manager
----
-
 # Bootstrap Project Knowledge
 
 Distill a coherent knowledge baseline from the current project — useful when the project has no `STRATEGY.md` / `CONCEPTS.md` / `{KNOWLEDGE_DIR}`, has partial or outdated ones, or has accumulated documentation debt.
 
 **Goal**: produce a minimal, accurate, opinionated knowledge foundation that future iteration-start and plan-work can ground in.
 
-## Boot
+## Load order (bootstrap)
 
 1. `mstar-harness-core`
-2. `mstar-roles` → `references/project-manager.md`
+2. `mstar-compound-refresh` (this skill)
 3. `mstar-plan-conventions`（路径符号）
 4. `mstar-strategy` → **§ STRATEGY.md structure** + **§ Creating STRATEGY.md**
 5. `mstar-compound` → **references/concepts-vocabulary.md**（CONCEPTS.md 规则）
-6. `mstar-compound-refresh` → **§ Core rules**（知识维护基线）
+6. This reference — **§ Core rules** in `mstar-compound-refresh/SKILL.md`（知识维护基线）
 
 ## Phase 1: Survey — understand what exists
 

--- a/skills/mstar-harness-core/SKILL.md
+++ b/skills/mstar-harness-core/SKILL.md
@@ -97,7 +97,7 @@ PM 在 Assignment 写 **`Task category`**（主类 + 可选 `secondary`）：
 | `mstar-review-qc` | PM：QC tri 编排、residual 留档、四层边界；leaf 执行 → `mstar-roles/references/qc-specialist/` |
 | `mstar-coding-behavior` | Think / Simplicity / Surgical / Debugging / Review Feedback / Goal-Driven / Communication |
 | `mstar-compound` | 知识结晶 —— 已解决问题→结构化知识文档，双轨（Bug/Knowledge），「是否值得结晶」自检清单，重叠检测，可发现性检查，CONCEPTS.md 协同 |
-| `mstar-compound-refresh` | 知识维护 —— 审查/更新/合并/删除 `{KNOWLEDGE_DIR}` 文档 |
+| `mstar-compound-refresh` | 知识维护 —— 审查/更新/合并/删除 `{KNOWLEDGE_DIR}` 文档；**项目知识 bootstrap**（无/残旧 STRATEGY.md、CONCEPTS.md、`{KNOWLEDGE_DIR}`）→ `references/project-knowledge-bootstrap.md` |
 | `mstar-strategy` | `STRATEGY.md` 全局战略方向 —— 产品愿景、技术方向、决策原则 |
 | `mstar-skill-authoring` | mstar-native skill authoring: trigger contracts, progressive disclosure, pressure scenarios, behavior-change evidence |
 | `mstar-roles` | 角色正文 hub |

--- a/skills/mstar-host/references/codex.md
+++ b/skills/mstar-host/references/codex.md
@@ -11,7 +11,7 @@ Parallel PM dispatch: read **`parallel-dispatch.md`** only when Codex exposes an
 - Plugin source: `.codex-plugin/plugin.json`.
 - Runtime skills: repo `skills/` mounted by the Codex plugin (`"skills": "./skills/"`).
 - Custom agent source: repo `codex/agents/*.toml`; CLI/manual install links these into `~/.codex/agents/` or project `.codex/agents/`.
-- **`/pm`** or **`pm` skill**: force PM entry → `mstar-roles` → `project-manager.md` (Codex primary; Cursor/OpenCode for general per-plan work). **`commands/`** when running iteration Phase 1–5.
+- **`/pm`** or **`pm` skill**: force PM entry → `mstar-roles` → `project-manager.md` (Codex primary; Cursor/OpenCode for general per-plan work). **`commands/`** when running iteration Phase 1–5; project CLI install (`mstar-harness init --target codex --scope project`) materializes `iteration-start`, `iteration-drive`, and `iteration-loop` as `.agents/skills/<name>/SKILL.md` symlinks.
 - Role files under root `agents/` are for hosts that load OpenCode/Cursor-style agent shells; Codex uses `codex/agents/*.toml` and still loads `mstar-roles` references directly.
 - Tool and plugin availability can be lazy-loaded or session-dependent. Use the tools actually present in the current session; do not infer capability from documentation alone.
 


### PR DESCRIPTION
## Summary
- Retire `/mstar-bootstrap` and absorb the knowledge-bootstrap procedure into `mstar-compound-refresh` (thin core pointer).
- Codex **project** CLI install materializes `iteration-start` / `iteration-drive` / `iteration-loop` as `.agents/skills/*/SKILL.md`; global install skips with a pollution warning.
- Add root `INSTALL.md`, slim bilingual READMEs (CLI-first; clarify start→drive vs loop), and bump all published surfaces to **1.3.0**.

## Test plan
- [ ] `bun run scripts/validate-release-version.ts v1.3.0`
- [ ] `bun run release:check` (typecheck + cli/opencode pack)
- [ ] `bun run opencode:bundle-assets` — `packages/opencode/harness-commands/` has only the three iteration commands (no `mstar-bootstrap`)
- [ ] Dry-run: `bun run --cwd packages/cli src/index.ts init --target codex --scope project --dry-run --yes` shows three skill symlinks + note
- [ ] Dry-run: `--scope global` prints iteration-skills skip warning
- [ ] Spot-check `README.md` / `README_CN.md` parity and `INSTALL.md` links


Made with [Cursor](https://cursor.com)