### PR TITLE
feat(harness): process-vs-results git policy + SPECS_DIR resolve (1.5.2)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, and Kimi Code.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor/LOCAL-VALIDATION.md
+++ b/.cursor/LOCAL-VALIDATION.md
@@ -43,9 +43,9 @@ git rev-parse HEAD | xargs -I{} skills/mstar-sdd/scripts/review-package {} {}
 ```
 
 - Confirm outputs land under `{SDD_DIR}` printed by `sdd-workspace` (default `.mstar/sdd/<plan-id>/`) and plan-level review artifacts use `{SDD_DIR}/review/`.
-- `git status` must **not** list `{HARNESS_DIR}/sdd/` scratch files (directory should be gitignored).
+- `git status` must **not** list `{HARNESS_DIR}/sdd/` scratch files or other process artifacts (`plans/`, `iterations/`, `status.json`, … — see `mstar-plan-conventions` git policy).
 - PM-style routing: **`Execution mode: sdd`** → plan QC **N=3** tri + branch review-package in `{SDD_DIR}/review/`; **`inline`/hotfix** → **N=1** `qc.md` in the same bundle. SDD implement/reviewer dispatches are **serial**. Optional **`SDD implementer session: sticky`** (Cursor Task `resume`) — reviewers stay **fresh** per task (`mstar-sdd/references/sticky-implementer-session.md`).
-- Stale path check: raw QC/QA report defaults should not point at `{PLAN_DIR}/reports/` or `plans/reports/`; tracked artifacts should be durable plan summaries and `status.json` residuals.
+- Stale path check: raw QC/QA report defaults should not point at `{PLAN_DIR}/reports/` or `plans/reports/`; cross-clone tracked results are `{HARNESS_DIR}/AGENTS.md`, `{KNOWLEDGE_DIR}/`, `{SPECS_DIR}/` — durable gate summaries live in local plan files (gitignored by default).
 
 ## 4) Packaging guardrails
 

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, and Kimi Code.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG
 
 ## [Unreleased]
 
+### Harness (git policy + SPECS_DIR)
+
+- **Process vs results git policy**: default tracked under `{HARNESS_DIR}` — `AGENTS.md`, `knowledge/`, `specs/`; default gitignored — `plans/`, `iterations/`, `status.json`, `sdd/`, `archived/`, `notes.json`. Cross-clone handoff = tracked results + root `CONCEPTS.md` / `STRATEGY.md`; promote residuals via compound instead of default `git add` for `status.json` / `plans/`.
+- **`{SPECS_DIR}` resolve order**: `{HARNESS_DIR}/specs/` → `docs/specs/` → repo-root `specs/` (skip empty dirs; greenfield creates `{HARNESS_DIR}/specs/`). Legacy read-compat: non-empty `designs/` paths.
+- Aligned: `mstar-plan-conventions`, `mstar-plan-artifacts`, `mstar-sdd` file-handoffs, host Plan-mode bridges, bilingual README, `.cursor/LOCAL-VALIDATION.md`.
+
 ## [1.5.1] - 2026-07-22
 
 ### Harness (Phase 5 push cadence)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,33 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.5.1** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.5.2** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.5.1** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.5.1** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.5.1** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.5.1** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.5.1** |
-| Kimi plugin | `.kimi-plugin/plugin.json` | **1.5.1** |
+| Monorepo root | `morning-star` (`package.json`) | **1.5.2** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.5.2** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.5.2** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.5.2** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.5.2** |
+| Kimi plugin | `.kimi-plugin/plugin.json` | **1.5.2** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 
 ## [Unreleased]
+
+## [1.5.2] - 2026-07-23
 
 ### Harness (git policy + SPECS_DIR)
 
 - **Process vs results git policy**: default tracked under `{HARNESS_DIR}` — `AGENTS.md`, `knowledge/`, `specs/`; default gitignored — `plans/`, `iterations/`, `status.json`, `sdd/`, `archived/`, `notes.json`. Cross-clone handoff = tracked results + root `CONCEPTS.md` / `STRATEGY.md`; promote residuals via compound instead of default `git add` for `status.json` / `plans/`.
 - **`{SPECS_DIR}` resolve order**: `{HARNESS_DIR}/specs/` → `docs/specs/` → repo-root `specs/` (skip empty dirs; greenfield creates `{HARNESS_DIR}/specs/`). Legacy read-compat: non-empty `designs/` paths.
 - Aligned: `mstar-plan-conventions`, `mstar-plan-artifacts`, `mstar-sdd` file-handoffs, host Plan-mode bridges, bilingual README, `.cursor/LOCAL-VALIDATION.md`.
+- **CLI**: `init`/`doctor` append/check the full process gitignore set (see `packages/cli/CHANGELOG.md`).
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex/Kimi plugin manifests: **→ 1.5.2**.
 
 ## [1.5.1] - 2026-07-22
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,25 +1,32 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.5.1**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.5.2**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.5.1** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.5.1** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.5.1** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.5.1** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.5.1** |
-| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.5.1** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.5.2** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.5.2** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.5.2** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.5.2** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.5.2** |
+| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.5.2** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 
 ## [Unreleased]
+
+## [1.5.2] - 2026-07-23
 
 ### Harness（git 策略 + SPECS_DIR）
 
 - **进程 vs 结果 Git 策略**：`{HARNESS_DIR}` 下默认 tracked — `AGENTS.md`、`knowledge/`、`specs/`；默认 gitignored — `plans/`、`iterations/`、`status.json`、`sdd/`、`archived/`、`notes.json`。跨 clone handoff = tracked 结果 + 根目录 `CONCEPTS.md` / `STRATEGY.md`；residual 经 compound 提升，**勿**默认 `git add` `status.json` / `plans/`。
 - **`{SPECS_DIR}` 解析顺序**：`{HARNESS_DIR}/specs/` → `docs/specs/` → 仓库根 `specs/`（空目录跳过；greenfield 创建 `{HARNESS_DIR}/specs/`）。Legacy 只读：非空 `designs/` 路径。
 - 已对齐：`mstar-plan-conventions`、`mstar-plan-artifacts`、`mstar-sdd` file-handoffs、宿主 Plan 模式桥接、双语 README、`.cursor/LOCAL-VALIDATION.md`。
+- **CLI**：`init`/`doctor` 追加/检查完整 process gitignore 集（见 `packages/cli/CHANGELOG.md`）。
+
+### 版本对齐
+
+- monorepo、OpenCode、CLI、Cursor/Codex/Kimi 插件：**→ 1.5.2**。
 
 ## [1.5.1] - 2026-07-22
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -15,6 +15,12 @@
 
 ## [Unreleased]
 
+### Harness（git 策略 + SPECS_DIR）
+
+- **进程 vs 结果 Git 策略**：`{HARNESS_DIR}` 下默认 tracked — `AGENTS.md`、`knowledge/`、`specs/`；默认 gitignored — `plans/`、`iterations/`、`status.json`、`sdd/`、`archived/`、`notes.json`。跨 clone handoff = tracked 结果 + 根目录 `CONCEPTS.md` / `STRATEGY.md`；residual 经 compound 提升，**勿**默认 `git add` `status.json` / `plans/`。
+- **`{SPECS_DIR}` 解析顺序**：`{HARNESS_DIR}/specs/` → `docs/specs/` → 仓库根 `specs/`（空目录跳过；greenfield 创建 `{HARNESS_DIR}/specs/`）。Legacy 只读：非空 `designs/` 路径。
+- 已对齐：`mstar-plan-conventions`、`mstar-plan-artifacts`、`mstar-sdd` file-handoffs、宿主 Plan 模式桥接、双语 README、`.cursor/LOCAL-VALIDATION.md`。
+
 ## [1.5.1] - 2026-07-22
 
 ### Harness（Phase 5 push cadence）

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Maintainers: follow [`AGENTS.md`](AGENTS.md) for in-repo maintenance notes and p
 
 Project plan artifacts default to **`.mstar/`** (`{HARNESS_DIR}`), with existing `.agents/` / `.plans/` / `plans/` layouts still recognized for compatibility.
 
+**Git tracking (default):** process stays local (`plans/`, `iterations/`, `status.json`, `sdd/`, … are gitignored); results are shared (`AGENTS.md`, `knowledge/`, `specs/` under `{HARNESS_DIR}` are tracked). `{SPECS_DIR}` resolves `.mstar/specs/` → `docs/specs/` → repo-root `specs/` (empty dirs skipped; greenfield creates `.mstar/specs/`). Details → `mstar-plan-conventions`.
+
 ## License
 
 This project is licensed under MIT. See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Core value:
 - Run with unified `mstar-*` skills instead of scattered rules
 - Reuse one core process across OpenCode, Cursor, Codex, and Kimi Code
 
-Latest release: **1.5.1** — see [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md).
+Latest release: **1.5.2** — see [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
 ## Quick Start
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -174,6 +174,8 @@ flowchart TD
 
 项目计划工件默认使用 **`.mstar/`**（`{HARNESS_DIR}`），同时继续识别既有 `.agents/` / `.plans/` / `plans/` 布局。
 
+**Git 跟踪（默认）**：进程本地（`plans/`、`iterations/`、`status.json`、`sdd/` 等 gitignored）；结果共享（`{HARNESS_DIR}` 下 `AGENTS.md`、`knowledge/`、`specs/` 默认 tracked）。`{SPECS_DIR}` 解析顺序：`.mstar/specs/` → `docs/specs/` → 仓库根 `specs/`（空目录跳过；greenfield 创建 `.mstar/specs/`）。细则 → `mstar-plan-conventions`。
+
 ## 许可
 
 本项目采用 MIT License，详见 [LICENSE](./LICENSE)。

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,7 +23,7 @@
 - 通过统一的 `mstar-*` skills 执行，而不是散落规则
 - 在 OpenCode / Cursor / Codex / Kimi Code 下复用同一套核心流程
 
-当前版本：**1.5.1** — 详见 [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)。
+当前版本：**1.5.2** — 详见 [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)。
 
 ## 快速开始（推荐方式）
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,7 +138,7 @@ Cursor and Codex `init` ensure a maintained local checkout exists at `~/.mstar/h
 Cursor `init`:
 
 - global: `git clone` / `git pull` at `~/.cursor/plugins/local/morning-star-harness`
-- project: `git clone` / `git pull` at `.cursor/plugins/morning-star-harness` and `.gitignore` entry for the plugin directory
+- project: `git clone` / `git pull` at `.cursor/plugins/morning-star-harness`, `.gitignore` entry for the plugin directory, and harness **process** gitignore entries for `.mstar/` and legacy `.agents/` (`archived/`, `iterations/`, `plans/`, `sdd/`, `notes.json`, `status.json`). Harness **results** (`knowledge/`, `specs/`, `AGENTS.md`) are not added automatically.
 
 Codex `init` writes or updates marketplace metadata with a local-source entry:
 
@@ -148,15 +148,15 @@ Codex `init` writes or updates marketplace metadata with a local-source entry:
 - `policy.installation`: `AVAILABLE`
 - `policy.authentication`: `ON_INSTALL`
 
-Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope also links `.codex/plugins/mstar-harness -> ~/.mstar/harness`, adds `.codex/plugins/mstar-harness` plus `.codex/agents/*.toml` to `.gitignore`, and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
+Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope also links `.codex/plugins/mstar-harness -> ~/.mstar/harness`, adds `.codex/plugins/mstar-harness` plus `.codex/agents/*.toml` to `.gitignore`, appends the same harness **process** gitignore set as Cursor project `init` (see above), and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
 
 ## What `doctor` Checks
 
 - Same schema and presence of **either** `@mstar-harness/opencode…` **or** a recognized legacy `morning-star@git+…` line (so existing git-based configs still pass).
 - Missing per-role `agent.<role>.model` is a **yellow recommendation** only (OpenCode defaults are OK).
 - If only legacy git is present, or legacy and npm are both listed, `doctor` prints **yellow recommendations** and still exits 0; run `init` to normalize to `@mstar-harness/opencode@latest`.
-- For Cursor, `doctor` checks the maintained `~/.mstar/harness` checkout, that the Cursor plugin path is a **real git directory** (not a symlink), and that `agents/*.md` files use Cursor-first frontmatter.
-- For Codex, `doctor` checks the local marketplace entry, the maintained `~/.mstar/harness` checkout, and custom-agent symlinks. Project scope also validates iteration skill symlinks under `.agents/skills/`.
+- For Cursor, `doctor` checks the maintained `~/.mstar/harness` checkout, that the Cursor plugin path is a **real git directory** (not a symlink), that `agents/*.md` files use Cursor-first frontmatter, and (project scope) all harness **process** `.gitignore` entries listed under Cursor `init`.
+- For Codex, `doctor` checks the local marketplace entry, the maintained `~/.mstar/harness` checkout, and custom-agent symlinks. Project scope also validates iteration skill symlinks under `.agents/skills/` and harness **process** `.gitignore` entries.
 
 ## Install path layout
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface re
 ## 1.5.2
 
 - Project `init`/`doctor` (Cursor/Codex project scope): append/check full harness **process** gitignore set under `.mstar/` and legacy `.agents/` (`archived/`, `iterations/`, `plans/`, `sdd/`, `notes.json`, `status.json`). Results paths (`knowledge/`, `specs/`, `AGENTS.md`) are not forced gitignored.
+- Version alignment with harness **1.5.2**.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.5.2**.
 
 ## 1.5.1
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.5.2
+
+- Project `init`/`doctor` (Cursor/Codex project scope): append/check full harness **process** gitignore set under `.mstar/` and legacy `.agents/` (`archived/`, `iterations/`, `plans/`, `sdd/`, `notes.json`, `status.json`). Results paths (`knowledge/`, `specs/`, `AGENTS.md`) are not forced gitignored.
+
 ## 1.5.1
 
 - Version alignment with harness **1.5.1** (Phase 5 push cadence; no CLI API change).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex).",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -13,7 +13,7 @@ import {
   validateSymlink,
   appendGitignore,
   appendHarnessProjectGitignore,
-  SDD_SCRATCH_GITIGNORE,
+  missingHarnessProcessGitignoreEntries,
   homeRelativeSourcePath,
 } from "./shared-install";
 
@@ -272,8 +272,8 @@ function runDoctor(scope: Scope) {
     const lines = gitignore.split(/\r?\n/);
     if (!lines.includes(CODEX_PLUGIN_LINK)) errors.push(`Missing .gitignore entry: ${CODEX_PLUGIN_LINK}`);
     if (!lines.includes(".codex/agents/*.toml")) errors.push("Missing .gitignore entry: .codex/agents/*.toml");
-    for (const entry of SDD_SCRATCH_GITIGNORE) {
-      if (!lines.includes(entry)) errors.push(`Missing .gitignore entry: ${entry}`);
+    for (const entry of missingHarnessProcessGitignoreEntries(gitignore)) {
+      errors.push(`Missing .gitignore entry: ${entry}`);
     }
     errors.push(...validateIterationSkillLinks());
   }

--- a/packages/cli/src/adapters/cursor.ts
+++ b/packages/cli/src/adapters/cursor.ts
@@ -11,7 +11,7 @@ import {
   validateGitCheckout,
   appendGitignore,
   appendHarnessProjectGitignore,
-  SDD_SCRATCH_GITIGNORE,
+  missingHarnessProcessGitignoreEntries,
 } from "./shared-install";
 
 const CURSOR_PLUGIN_NAME = "morning-star-harness";
@@ -89,10 +89,8 @@ function projectDoctor() {
   if (!gitignore.split(/\r?\n/).includes(CURSOR_PLUGIN_LINK)) {
     errors.push(`Missing .gitignore entry: ${CURSOR_PLUGIN_LINK}`);
   }
-  for (const entry of SDD_SCRATCH_GITIGNORE) {
-    if (!gitignore.split(/\r?\n/).includes(entry)) {
-      errors.push(`Missing .gitignore entry: ${entry}`);
-    }
+  for (const entry of missingHarnessProcessGitignoreEntries(gitignore)) {
+    errors.push(`Missing .gitignore entry: ${entry}`);
   }
   errors.push(...validatePluginAgents(location));
   return { location, errors };

--- a/packages/cli/src/adapters/shared-install.ts
+++ b/packages/cli/src/adapters/shared-install.ts
@@ -170,7 +170,26 @@ export function validateSymlink(target: string, linkPath: string) {
   return errors;
 }
 
-export const SDD_SCRATCH_GITIGNORE = [".mstar/sdd/", ".agents/sdd/"];
+/** Harness process artifacts (not results: knowledge/, specs/, AGENTS.md). */
+export const HARNESS_PROCESS_GITIGNORE = [
+  ".mstar/archived/",
+  ".mstar/iterations/",
+  ".mstar/plans/",
+  ".mstar/sdd/",
+  ".mstar/notes.json",
+  ".mstar/status.json",
+  ".agents/archived/",
+  ".agents/iterations/",
+  ".agents/plans/",
+  ".agents/sdd/",
+  ".agents/notes.json",
+  ".agents/status.json",
+];
+
+export function missingHarnessProcessGitignoreEntries(gitignoreContent: string): string[] {
+  const lines = gitignoreContent.split(/\r?\n/);
+  return HARNESS_PROCESS_GITIGNORE.filter((entry) => !lines.includes(entry));
+}
 
 export function appendGitignore(projectRoot: string, entries: string[], dryRun: boolean) {
   const gitignorePath = path.join(projectRoot, ".gitignore");
@@ -186,7 +205,7 @@ export function appendGitignore(projectRoot: string, entries: string[], dryRun: 
 }
 
 export function appendHarnessProjectGitignore(projectRoot: string, dryRun: boolean) {
-  return appendGitignore(projectRoot, SDD_SCRATCH_GITIGNORE, dryRun);
+  return appendGitignore(projectRoot, HARNESS_PROCESS_GITIGNORE, dryRun);
 }
 
 export function homeRelativeSourcePath(targetPath: string) {

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## 1.5.2
+
+- Version alignment with harness **1.5.2** (bundled skills/commands: process-vs-results git policy + `{SPECS_DIR}` resolve order).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.5.2**.
+
 ## 1.5.1
 
 - Version alignment with harness **1.5.1** (bundled skills/commands: Phase 5 push cadence — local early fix, push only when CI/review wave idle).

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-host/references/cursor-plan-mode-bridge.md
+++ b/skills/mstar-host/references/cursor-plan-mode-bridge.md
@@ -31,7 +31,7 @@ Cursor **Plan mode** uses **CreatePlan** and built-in plan todos for session UX.
 When plan management is required and directories are missing:
 
 1. Create `{HARNESS_DIR}` and `{PLAN_DIR}`.
-2. Ensure `{HARNESS_DIR}/sdd/` is gitignored; per-plan review bundles are created under `{SDD_DIR}/review/` when needed.
+2. Ensure Morning Star **process-artifact** gitignore set is present (canonical snippet → `mstar-plan-conventions` SKILL.md「Git 跟踪策略」): `{HARNESS_DIR}/archived/`, `iterations/`, `plans/`, `sdd/`, `notes.json`, `status.json` (legacy `.agents/` equivalents when applicable). Per-plan review bundles are created under `{SDD_DIR}/review/` when needed.
 3. Create `{HARNESS_DIR}/archived/residuals/`.
 4. Initialize `{HARNESS_DIR}/status.json` from `mstar-plan-artifacts/templates/status.empty.json` if missing.
 5. Optional: `{HARNESS_DIR}/notes.json` from `templates/notes.empty.json`, `{HARNESS_DIR}/knowledge/README.md`.
@@ -46,7 +46,7 @@ Full PM checklist: `mstar-roles/references/project-manager/plan-management.md`.
 
 | Todo ID (use in title) | Goal | On-disk outcome |
 |------------------------|------|-----------------|
-| **`harness-init`** | Bootstrap harness tree | `{HARNESS_DIR}/`, `{PLAN_DIR}/`, `sdd/` gitignore, `archived/residuals/`, `status.json` initialized |
+| **`harness-init`** | Bootstrap harness tree | `{HARNESS_DIR}/`, `{PLAN_DIR}/`, process-artifact gitignore set, `archived/residuals/`, `status.json` initialized |
 | **`spec-register`** | Register plan in SSOT | New `plans[]` row in `status.json` (`id`, `status`, `file`, `metadata`); spec stub in `{SPECS_DIR}` or plan frontmatter |
 | **`mirror-plan`** | SSOT main plan file | `{PLAN_DIR}/<plan-id>-<name>.md` with task checkboxes aligned to CreatePlan body |
 
@@ -66,7 +66,7 @@ Add one object to `status.json` → `plans[]`:
 }
 ```
 
-Set `updated_at` on `status.json` to today (`YYYY-MM-DD`). Commit harness files in the **business repo** when the project tracks `{HARNESS_DIR}` (default).
+Set `updated_at` on `status.json` to today (`YYYY-MM-DD`). Commit **tracked results** in the business repo when applicable: `{HARNESS_DIR}/AGENTS.md`, `{KNOWLEDGE_DIR}/`, `{SPECS_DIR}/` (default git policy — see `mstar-plan-conventions`). Do **not** default `git add` for `status.json`, `plans/`, or `iterations/`.
 
 ### `mirror-plan` minimum content
 
@@ -107,7 +107,7 @@ Use this structure in CreatePlan `plan` markdown; mirror the same sections into 
 
 ### Bootstrap (fixed prefix — complete before implement)
 
-1. harness-init — init .mstar/, status.json, sdd/ gitignore, archived/residuals/
+1. harness-init — init .mstar/, status.json, process-artifact gitignore set, archived/residuals/
 2. spec-register — register plan_id in status.json; spec stub if applicable
 3. mirror-plan — write .mstar/plans/<plan-id>-<short-name>.md
 

--- a/skills/mstar-host/references/cursor.md
+++ b/skills/mstar-host/references/cursor.md
@@ -19,7 +19,7 @@ Before first **CreatePlan**: Read `mstar-plan-conventions`, `mstar-plan-artifact
 
 | Todo ID | Purpose |
 |---------|---------|
-| `harness-init` | Init `{HARNESS_DIR}`, `{PLAN_DIR}`, `sdd/` gitignore, `archived/residuals/`, `status.json` |
+| `harness-init` | Init `{HARNESS_DIR}`, `{PLAN_DIR}`, process-artifact gitignore set (`plans/`, `iterations/`, `sdd/`, `status.json`, …), `archived/residuals/`, `status.json` |
 | `spec-register` | Register `plan_id` in `status.json.plans[]` + spec stub if applicable |
 | `mirror-plan` | Write SSOT main plan under `{PLAN_DIR}/` |
 

--- a/skills/mstar-host/references/kimi-plan-mode-bridge.md
+++ b/skills/mstar-host/references/kimi-plan-mode-bridge.md
@@ -24,7 +24,7 @@ Kimi **Plan mode** (`EnterPlanMode` / `ExitPlanMode`, `/plan`, or `Shift-Tab`) u
 
 1. **Read** (minimum): `mstar-plan-conventions`, `mstar-plan-artifacts` (SKILL.md); Prepare gates from `mstar-phase-gates` if not hotfix.
 2. **Discover** `{HARNESS_DIR}` / `{PLAN_DIR}` per `mstar-plan-conventions`.
-3. **Initialize** if absent: `{HARNESS_DIR}/`, `{PLAN_DIR}/`, `status.json` from `mstar-plan-artifacts/templates/status.empty.json`, `archived/residuals/`, gitignored `sdd/`.
+3. **Initialize** if absent: `{HARNESS_DIR}/`, `{PLAN_DIR}/`, `status.json` from `mstar-plan-artifacts/templates/status.empty.json`, `archived/residuals/`, Morning Star process-artifact gitignore set (see `mstar-plan-conventions` SKILL.md「Git 跟踪策略」).
 
 ## Plan mode workflow (dual-write)
 

--- a/skills/mstar-plan-artifacts/references/knowledge-and-designs.md
+++ b/skills/mstar-plan-artifacts/references/knowledge-and-designs.md
@@ -31,7 +31,7 @@
 
 ## `{SPECS_DIR}`（可选·长期规格）
 
-- `{SPECS_DIR}` 解析：优先 `{HARNESS_DIR}/specs/`，否则 `{HARNESS_DIR}/designs/`；皆无则建议新建 `specs/`。
+- `{SPECS_DIR}` 解析（非空即停）：`{HARNESS_DIR}/specs/` → `docs/specs/` → 仓库根 `specs/`；皆无或皆空则 init 创建 `{HARNESS_DIR}/specs/`。Legacy 只读：`{HARNESS_DIR}/designs/` 或根 `designs/` 非空时可用。细则 → `mstar-plan-conventions` SKILL.md「`{SPECS_DIR}` 解析」。
 - **放什么**：跨迭代有效、已锁定或待锁定的产品/API 规范、ADR、契约 — **iteration-start 主产出**（product/architect）。
 - **不放什么**：本迭代-only 探索（→ `<iteration-id>/guides/`）；迭代级 spec 草案（→ `<iteration-id>/specs/`）；实施踩坑原文（→ package 或 plan 素材，**close 时 compound 提升**）。
 - **索引**：非 trivial 树建议 `{SPECS_DIR}/README.md`；plan **`primary_spec` / `spec_refs`** 主要指向此处。

--- a/skills/mstar-plan-artifacts/references/plan-files-and-reports.md
+++ b/skills/mstar-plan-artifacts/references/plan-files-and-reports.md
@@ -54,7 +54,7 @@ The durable summary is not a paste of raw reports. It is a small gate record suf
 
 ## Residual findings（R#）：权威在哪、和主 plan 谁先谁后？
 
-- **Open 条目的单一事实来源（SSOT）**是 **`{HARNESS_DIR}/status.json`** 根级 **`residual_findings[<plan-id>]`**（与 `plans` 平级；canonical 见 `mstar-plan-artifacts` **SKILL.md** 开篇；字段见 `mstar-plan-artifacts/references/status-and-residuals.md`）。跨会话 handoff、关闭与归档流程**以该数组为准**。
+- **Open 条目的单一事实来源（SSOT）**是 **`{HARNESS_DIR}/status.json`** 根级 **`residual_findings[<plan-id>]`**（与 `plans` 平级；canonical 见 `mstar-plan-artifacts` **SKILL.md** 开篇；字段见 `mstar-plan-artifacts/references/status-and-residuals.md`）。**同一工作副本内**的会话 handoff、关闭与归档流程**以该数组为准**（本地 SSOT，默认 gitignored）；**跨 clone** 须持久的 residual 须提升入 tracked `{KNOWLEDGE_DIR}/` / `{SPECS_DIR}/` 等（见 `mstar-plan-conventions`「Git 跟踪策略」）。
 - **推荐操作顺序**（避免 plan 与 JSON 两套 ID 漂移）：
   1. `project-manager` 读完 review bundle 并完成「QC 三审轻量汇总」：对 finding **去重合并**，为每条待跟踪项分配**稳定 `id`**（如 `R1`、`R2`，全 plan 内唯一）。
   2. **立即**将上述条目写入根级 **`residual_findings[<plan-id>]`**（含 `source` 指向 reviewer seat + bundle basename + finding id + review range，便于回溯）；**勿**与 legacy 侧双写（见 `mstar-plan-conventions` **SKILL.md** 开篇）。
@@ -79,7 +79,7 @@ The durable summary is not a paste of raw reports. It is a small gate record suf
 
 **QC 落盘与宿主权限**：`qc-specialist` / `qc-specialist-2` / `qc-specialist-3` 在支持路径白名单的宿主上（如 OpenCode 的 **`permission.edit`**），默认 **仅可** Write/Edit Assignment 指定的 **`{SDD_DIR}/review/`** 下 **`.md`**。全局 agent 提示词应允许 `.mstar/sdd/**`、`.agents/sdd/**` 及 worktree 下对应路径。报告文件**必须**以 YAML **frontmatter** 开头（键见各 QC agent 提示词）。
 
-**QC 报告与 Git**：默认 raw QC/QA bundle **不**执行 `git add` / `git commit`。PM must commit durable artifacts instead: main plan gate summaries, `{HARNESS_DIR}/status.json` residual changes, and any tracked specs/knowledge/iteration updates. If a project explicitly opts into tracked audit reports, state `Review archive mode: tracked reports` in Assignment and use project-specific allow rules.
+**QC 报告与 Git**：默认 raw QC/QA bundle **不**执行 `git add` / `git commit`。PM 将 durable gate summary 写入主 plan（本地会话 SSOT；默认 gitignored）并在当轮更新 `{HARNESS_DIR}/status.json` 的 open residuals（本地 SSOT，默认 gitignored）。**跨 clone 须持久的** residual 或决策须提升入 tracked `{KNOWLEDGE_DIR}/` / `{SPECS_DIR}/` 或 `{HARNESS_DIR}/AGENTS.md`（见 `mstar-plan-conventions`「Git 跟踪策略」）— **勿**默认 `git add` `status.json` / `plans/`。若项目显式 opt-in 跟踪审计报告，在 Assignment 写 `Review archive mode: tracked reports` 并使用项目 allow rules。
 
 ## 主 plan 内任务清单（Markdown checkbox）
 

--- a/skills/mstar-plan-artifacts/references/status-and-residuals.md
+++ b/skills/mstar-plan-artifacts/references/status-and-residuals.md
@@ -6,7 +6,9 @@
 Canonical vs legacy residual definitions → **`mstar-plan-artifacts` SKILL.md** (“`status.json` and open residual (summary)”); this file covers **fields, severity, lifecycle, archive, and `jq` examples**.  
 **Closed** residuals should not accumulate here long-term; authoritative archive → **`{HARNESS_DIR}/archived/residuals/<plan-id>.json`** (see “Residual findings lifecycle”).
 
-**Why this matters:** The open list and `archived/residuals/` are the **cross-session handoff surface** for risk and decisions. Non-blocking conclusions that stay only in chat or a gitignored review bundle **without SSOT** cannot be inherited reliably; `Done` drifts from visible known debt. **`@project-manager`** should register trackable open items soon after review closure; close/archive after verification per **`QA gate`** (`qa-engineer` when `mandatory`, else PM acceptance checklist).
+**Why this matters:** Within a working copy, the open list in `status.json` and `archived/residuals/` are the **local session SSOT** for risk and decisions. Non-blocking conclusions that stay only in chat or a gitignored review bundle **without local SSOT update** cannot be inherited reliably in that session; `Done` drifts from visible known debt. **`@project-manager`** should register trackable open items soon after review closure; close/archive after verification per **`QA gate`** (`qa-engineer` when `mandatory`, else PM acceptance checklist).
+
+**Cross-clone handoff** (default git policy): tracked `{HARNESS_DIR}/AGENTS.md`, `{KNOWLEDGE_DIR}/**`, `{SPECS_DIR}/**`, and root `CONCEPTS.md` / `STRATEGY.md` when used. Residuals that must survive clone must be **promoted** (compound) or written into those tracked results — do not treat `status.json` / `plans/` as the default clone handoff surface.
 
 ## Basic structure
 

--- a/skills/mstar-plan-conventions/SKILL.md
+++ b/skills/mstar-plan-conventions/SKILL.md
@@ -23,9 +23,9 @@ description: Morning Star (启明星) harness 计划目录约定 —— `{HARNES
 | `{SDD_DIR}` | `{HARNESS_DIR}/sdd/<plan-id>/`（SDD 运行时 scratch + review bundle；gitignored） |
 | `{ITERATION_DIR}` | `{HARNESS_DIR}/iterations/` |
 | `{KNOWLEDGE_DIR}` | `{HARNESS_DIR}/knowledge/` |
-| `{SPECS_DIR}` | `specs/` 优先，否则 `designs/` |
+| `{SPECS_DIR}` | `{HARNESS_DIR}/specs/`（默认）；解析见下文「`{SPECS_DIR}` 解析」 |
 
-### 解析顺序（找到即停）
+### `{HARNESS_DIR}` 解析顺序（找到即停）
 
 1. `.mstar/` → `{HARNESS_DIR}=.mstar/`, `{PLAN_DIR}=.mstar/plans/`
 2. 否则 `.agents/` → legacy `{HARNESS_DIR}=.agents/`, `{PLAN_DIR}=.agents/plans/`
@@ -34,7 +34,19 @@ description: Morning Star (启明星) harness 计划目录约定 —— `{HARNES
 
 并存时 **`.mstar/` 优先**；仅当项目已有 `.agents/` 且无 `.mstar/` 时继续沿用 `.agents/`。
 
-`{SPECS_DIR}`：有 `specs/` 用之；否则 `designs/`；皆无则建议新建 `specs/`。
+### `{SPECS_DIR}` 解析（找到非空目录即停）
+
+1. `{HARNESS_DIR}/specs/`（默认 `.mstar/specs/`）
+2. `docs/specs/`
+3. `specs/`（仓库根）
+
+**空目录规则**：候选路径存在但无任何文件 → 视为不存在，继续下一候选。
+
+**创建默认**：全部缺失或皆空 → 创建并使用 `{HARNESS_DIR}/specs/`（统一落在 `.mstar/` 下）。**禁止**在 greenfield init 时优先创建裸仓库根 `specs/`。
+
+**Legacy（仅兼容读）**：若以上皆无内容，但 `{HARNESS_DIR}/designs/` 或仓库根 `designs/` **非空**，可作 `{SPECS_DIR}` 使用；init 时**不**新建 `designs/`。
+
+可选项目选择：部分 spoke 仓库另跟踪 `{HARNESS_DIR}/roadmap.md` — **非**默认 tracked；仅在项目 opt-in 时提及。
 
 ## 内容边界（摘要）
 
@@ -53,11 +65,60 @@ description: Morning Star (启明星) harness 计划目录约定 —— `{HARNES
 PM 在需要持久化追踪时：
 
 1. 建 `.mstar/`、`plans/`、`status.json`（空模板见 **`mstar-plan-artifacts/templates/status.empty.json`**）
-2. 可选 `notes.json`（模板 **`mstar-plan-artifacts/templates/notes.empty.json`**）、`knowledge/`、`iterations/`、`specs/`、`sdd/`（空目录占位；运行时 per-plan 子目录由 `mstar-sdd/scripts/sdd-workspace` 创建）
-3. 项目根 `.gitignore` 追加 `.mstar/sdd/`（或 `.agents/sdd/` legacy）— CLI `init` 可自动添加
-4. Git：团队交付 **勿** ignore 整个 `{HARNESS_DIR}`（handoff 需 clone 可达）
+2. 可选 `notes.json`（模板 **`mstar-plan-artifacts/templates/notes.empty.json`**）、`knowledge/`、`iterations/`、`{HARNESS_DIR}/specs/`、`sdd/`（空目录占位；运行时 per-plan 子目录由 `mstar-sdd/scripts/sdd-workspace` 创建）
+3. 项目根 `.gitignore` 追加 Morning Star **进程产物**忽略集（见下文「Git 跟踪策略」）— CLI `init` 可自动添加
+4. Git：**进程本地、结果共享** — 默认跟踪 `{HARNESS_DIR}/AGENTS.md`、`{KNOWLEDGE_DIR}/**`、`{SPECS_DIR}/**`；`plans/`、`iterations/`、`status.json` 等为**本地会话 SSOT**，默认 gitignored。跨 clone 持久 handoff = knowledge + specs + `{HARNESS_DIR}/AGENTS.md`（及根 `CONCEPTS.md` / `STRATEGY.md` 若使用）；须跨 clone 的 residual 须提升（compound）或写入 tracked results — **勿**默认 `git add` `status.json` / `plans/`。
 
 步骤与 `{HARNESS_DIR}/AGENTS.md` 分层 → **`references/harness-bootstrap-and-agents-layering.md`**。
+
+## Git 跟踪策略（进程 vs 结果）
+
+**原则**：进程留在本地；结果与团队共享。
+
+**默认 tracked（`{HARNESS_DIR}` 下）**：
+
+- `{HARNESS_DIR}/AGENTS.md`
+- `{KNOWLEDGE_DIR}/**`
+- `{HARNESS_DIR}/specs/`（即解析后的 `{SPECS_DIR}` 在 harness 下的默认落点）
+
+**默认 gitignored（`{HARNESS_DIR}` 下）**：
+
+- `archived/`
+- `iterations/`
+- `plans/`
+- `sdd/`
+- `notes.json`
+- `status.json`
+
+Legacy `.agents/` 项目：将上表路径前缀 `.mstar/` 换为 `.agents/`。
+
+**Canonical `.gitignore` snippet**（skills 与 CLI `init` 对齐）：
+
+```gitignore
+# Morning Star harness (.mstar/)
+# Principle: process stays local; results are shared with the team.
+# Ignored (process / coordination):
+.mstar/archived/
+.mstar/iterations/
+.mstar/plans/
+.mstar/sdd/
+.mstar/notes.json
+.mstar/status.json
+# Tracked (results): .mstar/AGENTS.md, .mstar/knowledge/, .mstar/specs/
+```
+
+Legacy `.agents/` 等价：
+
+```gitignore
+# Morning Star harness (.agents/) — legacy
+.agents/archived/
+.agents/iterations/
+.agents/plans/
+.agents/sdd/
+.agents/notes.json
+.agents/status.json
+# Tracked (results): .agents/AGENTS.md, .agents/knowledge/, .agents/specs/
+```
 
 ## Spec 驱动的分支模型（多 Plan · 同一 Spec）
 

--- a/skills/mstar-plan-conventions/references/artifact-storage-paths.md
+++ b/skills/mstar-plan-conventions/references/artifact-storage-paths.md
@@ -6,20 +6,21 @@
 
 ## Harness 子树内（`{HARNESS_DIR}/` 下）
 
-这些是 agent handoff 用的结构化产物；除明确标注 gitignored 的 scratch 外，默认随 `.git` 追踪，不面向人类直接阅读。
+这些是 agent handoff 用的结构化产物。**Git 跟踪**遵循 `mstar-plan-conventions` SKILL.md「Git 跟踪策略」：**进程本地、结果共享** — `plans/`、`iterations/`、`status.json`、`sdd/` 等默认 gitignored；`AGENTS.md`、`knowledge/`、`specs/` 默认 tracked。
 
 | 产物 | 解析后路径（默认 `.mstar/`） | 读写的技能 |
 |------|---------------------------|-----------|
 | **知识文档** | `.mstar/knowledge/<category>/<slug>.md` | `mstar-compound`（写）、`mstar-compound-refresh`（读写） |
 | **知识索引** | `.mstar/knowledge/README.md` | `mstar-compound`（写）、`mstar-compound-refresh`（读写） |
-| **主 plan** | `.mstar/plans/<plan-id>-<name>.md` | PM / `mstar-plan-artifacts` |
+| **主 plan** | `.mstar/plans/<plan-id>-<name>.md`（gitignored；本地会话 SSOT） | PM / `mstar-plan-artifacts` |
 | **Review bundle（QC/QA 原始过程报告）** | `{HARNESS_DIR}/sdd/<plan-id>/review/`（gitignored；默认 `.mstar/sdd/<plan-id>/review/`） | `mstar-sdd`、`mstar-review-qc`、`qa-engineer` |
 | **SDD scratch** | `{HARNESS_DIR}/sdd/<plan-id>/`（gitignored；含 per-task handoff 与 `review/` bundle） | `mstar-sdd` |
-| **status.json** | `.mstar/status.json` | `mstar-plan-artifacts` |
-| **迭代 package** | `.mstar/iterations/<iteration-id>/`（`delivery-compass.md`、`guides/`、`specs/`、可选 `README.md`） | `mstar-iteration`（读写）；close 时 `mstar-compound`（提升读；默认排除 compass） |
-| **迭代索引** | `.mstar/iterations/README.md`（一行 = 一次迭代） | `mstar-iteration`（读写） |
-| **规格** | `specs/`（优先），否则 `designs/` | `mstar-plan-artifacts` |
-| **archived residuals** | `.mstar/archived/residuals/<plan-id>.json` | `mstar-plan-artifacts` |
+| **status.json** | `.mstar/status.json`（gitignored；本地会话 SSOT） | `mstar-plan-artifacts` |
+| **迭代 package** | `.mstar/iterations/<iteration-id>/`（gitignored；`delivery-compass.md`、`guides/`、`specs/`、可选 `README.md`） | `mstar-iteration`（读写）；close 时 `mstar-compound`（提升读；默认排除 compass） |
+| **迭代索引** | `.mstar/iterations/README.md`（gitignored；一行 = 一次迭代） | `mstar-iteration`（读写） |
+| **规格** | `{HARNESS_DIR}/specs/`（默认 tracked；解析见 `mstar-plan-conventions`） | `mstar-plan-artifacts` |
+| **harness AGENTS** | `.mstar/AGENTS.md`（tracked） | PM / init |
+| **archived residuals** | `.mstar/archived/residuals/<plan-id>.json`（gitignored） | `mstar-plan-artifacts` |
 | **archived knowledge** | `.mstar/archived/knowledge/`（保留原 `{KNOWLEDGE_DIR}` 相对路径） | `mstar-iteration` §1.6 corpus hygiene、`mstar-plan-artifacts` |
 | **archived specs** | `.mstar/archived/specs/`（保留原 `{SPECS_DIR}` 相对路径） | `mstar-iteration` §1.6 corpus hygiene、`mstar-plan-artifacts` |
 

--- a/skills/mstar-plan-conventions/references/harness-bootstrap-and-agents-layering.md
+++ b/skills/mstar-plan-conventions/references/harness-bootstrap-and-agents-layering.md
@@ -14,12 +14,24 @@
 
 1. 创建 `{HARNESS_DIR}`（推荐 `.mstar/`）与 `{PLAN_DIR}`（推荐 `.mstar/plans/`）。
 2. 初始化 `status.json`：从 **`mstar-plan-artifacts/templates/status.empty.json`** 复制；residual canonical 见 **`mstar-plan-artifacts` SKILL.md**；字段与生命周期见 **`mstar-plan-artifacts/references/status-and-residuals.md`**。
-3. 初始化可选 `notes.json`（**`mstar-plan-artifacts/templates/notes.empty.json`**）；`sdd/` 空目录占位（per-plan 子目录由 `mstar-sdd/scripts/sdd-workspace` 创建；项目根 `.gitignore` 须含 `.mstar/sdd/`，legacy `.agents/` 项目对应 `.agents/sdd/`）。
-4. **Profile B**（统一 Done 压缩）时另建 `{HARNESS_DIR}/archived/plans/` 与 `archived/plans-done.json`（自 **`mstar-plan-artifacts/templates/plans-done.empty.json`** 复制；schema 仅 `{ "plans": [] }`，见 **`mstar-plan-artifacts/references/done-compaction.md`**）。
-5. 可选：创建 `{ITERATION_DIR}`（`iterations/` + `README.md`）与 `{KNOWLEDGE_DIR}`（`knowledge/` + `README.md`）；内容边界见 `mstar-plan-conventions` SKILL.md 与 `references/knowledge-and-designs.md`。
-6. 创建 `{HARNESS_DIR}/AGENTS.md`（harness 子树规则）：符号表可复述 `{HARNESS_DIR}`、`{PLAN_DIR}`、`{ITERATION_DIR}`、`{KNOWLEDGE_DIR}`、`{SPECS_DIR}` 与 `docs/` 分工；新项目推荐 `.mstar/AGENTS.md`，已有项目可继续使用 `.agents/AGENTS.md`。
-7. 校准根 `AGENTS.md`：只保留仓库级长期约束，显式引用 `{HARNESS_DIR}/AGENTS.md` 作为 harness SSOT。
-8. 仅在确有稳定边界时新增目录级 `AGENTS.md`（如 `contracts/`、`gateway/`、`sdk/`）。
+3. 初始化可选 `notes.json`（**`mstar-plan-artifacts/templates/notes.empty.json`**）；`sdd/` 空目录占位（per-plan 子目录由 `mstar-sdd/scripts/sdd-workspace` 创建）。
+4. 项目根 `.gitignore` 追加 Morning Star **进程产物**忽略集（canonical snippet → `mstar-plan-conventions` SKILL.md「Git 跟踪策略」；legacy `.agents/` 有等价表）。
+5. **Profile B**（统一 Done 压缩）时另建 `{HARNESS_DIR}/archived/plans/` 与 `archived/plans-done.json`（自 **`mstar-plan-artifacts/templates/plans-done.empty.json`** 复制；schema 仅 `{ "plans": [] }`，见 **`mstar-plan-artifacts/references/done-compaction.md`**）。
+6. 可选：创建 `{ITERATION_DIR}`（`iterations/` + `README.md`）与 `{KNOWLEDGE_DIR}`（`knowledge/` + `README.md`）；`{HARNESS_DIR}/specs/`（解析后的 `{SPECS_DIR}` 默认落点）；内容边界见 `mstar-plan-conventions` SKILL.md 与 `references/knowledge-and-designs.md`。
+7. 创建 `{HARNESS_DIR}/AGENTS.md`（harness 子树规则；**tracked**）：符号表可复述 `{HARNESS_DIR}`、`{PLAN_DIR}`、`{ITERATION_DIR}`、`{KNOWLEDGE_DIR}`、`{SPECS_DIR}` 与 `docs/` 分工；新项目推荐 `.mstar/AGENTS.md`，已有项目可继续使用 `.agents/AGENTS.md`。
+8. 校准根 `AGENTS.md`：只保留仓库级长期约束，显式引用 `{HARNESS_DIR}/AGENTS.md` 作为 harness SSOT。
+9. 仅在确有稳定边界时新增目录级 `AGENTS.md`（如 `contracts/`、`gateway/`、`sdk/`）。
+
+## Git 跟踪策略（进程 vs 结果）
+
+**原则**：进程留在本地；结果与团队共享。完整规则与 canonical `.gitignore` snippet → **`mstar-plan-conventions` SKILL.md「Git 跟踪策略」**。
+
+| 类别 | 默认 tracked | 默认 gitignored |
+|------|--------------|-----------------|
+| 结果（跨 clone handoff） | `{HARNESS_DIR}/AGENTS.md`、`{KNOWLEDGE_DIR}/**`、`{SPECS_DIR}/**` | — |
+| 进程（本地会话 SSOT） | — | `plans/`、`iterations/`、`status.json`、`notes.json`、`sdd/`、`archived/` |
+
+跨 clone 须持久的 residual 或决策：经 **`mstar-compound`** 提升入 `{KNOWLEDGE_DIR}/`、写入 `{SPECS_DIR}/`，或记入 tracked `{HARNESS_DIR}/AGENTS.md` — **勿**默认 `git add` `status.json` / `plans/`。
 
 ## 三层 `AGENTS.md` 职责切分
 

--- a/skills/mstar-roles/references/project-manager/plan-management.md
+++ b/skills/mstar-roles/references/project-manager/plan-management.md
@@ -19,7 +19,7 @@ Legacy fallbacks:
 
 1. Create `{HARNESS_DIR}` and `{PLAN_DIR}` when absent.
 2. Initialize `{HARNESS_DIR}/status.json` from template if available.
-3. Ensure `{HARNESS_DIR}/sdd/` is gitignored; per-plan `{SDD_DIR}/review/` is created by the SDD/review flow when needed.
+3. Ensure Morning Star **process-artifact** gitignore set is present (canonical snippet → `mstar-plan-conventions` SKILL.md「Git 跟踪策略」): `{HARNESS_DIR}/archived/`, `iterations/`, `plans/`, `sdd/`, `notes.json`, `status.json` (legacy `.agents/` equivalents when applicable). Per-plan `{SDD_DIR}/review/` is created by the SDD/review flow when needed.
 4. Initialize residual archive path: `{HARNESS_DIR}/archived/residuals/`.
 5. **Profile B** only: `{HARNESS_DIR}/archived/plans/` and `archived/plans-done.json` from `mstar-plan-artifacts/templates/plans-done.empty.json` (`{ "plans": [] }` only; see `done-compaction.md`).
 6. Optional: `{HARNESS_DIR}/notes.json`, `{HARNESS_DIR}/knowledge/README.md`.
@@ -28,8 +28,12 @@ If legacy plan directories already exist, reuse them; avoid dual-structure dupli
 
 ## Git Tracking Policy
 
-- Default: track `{HARNESS_DIR}` files in repo for reproducible handoff.
-- If project policy requires local-only, explicitly record it and ensure no required artifact depends on ignored files.
+**Principle:** process stays local; results are shared with the team. Full rules → `mstar-plan-conventions` SKILL.md「Git 跟踪策略」.
+
+- **Default tracked** under `{HARNESS_DIR}`: `AGENTS.md`, `{KNOWLEDGE_DIR}/**`, `{SPECS_DIR}/**` (resolved specs path; default `{HARNESS_DIR}/specs/`).
+- **Default gitignored** (local session SSOT / coordination): `archived/`, `iterations/`, `plans/`, `sdd/`, `notes.json`, `status.json`.
+- `status.json` and main plan files remain **local session SSOT** — PM must keep them current on disk, but **do not** default `git add` / `git commit` for cross-clone handoff. Promote durable residuals and decisions into tracked `knowledge/` / `specs/` / `AGENTS.md` (compound) when they must survive clone.
+- If a project explicitly opts into tracking process artifacts, record that policy in `{HARNESS_DIR}/AGENTS.md` and ensure team alignment.
 
 ## PM Responsibilities
 

--- a/skills/mstar-sdd/references/file-handoffs.md
+++ b/skills/mstar-sdd/references/file-handoffs.md
@@ -62,7 +62,7 @@ mkdir -p "$SDD_DIR/review"
 skills/mstar-sdd/scripts/review-package "$MERGE_BASE" HEAD "$SDD_DIR/review/branch-review-....diff"
 ```
 
-Pass **branch** diff path and bundle report paths (`$SDD_DIR/review/qc1.md` …) to QC dispatch — not task-level diffs. Raw QC/QA files stay in the gitignored review bundle; PM records durable summary and residuals in tracked plan/status artifacts.
+Pass **branch** diff path and bundle report paths (`$SDD_DIR/review/qc1.md` …) to QC dispatch — not task-level diffs. Raw QC/QA files stay in the gitignored review bundle; PM records durable summary and open residuals in **local** plan/`status.json` (session SSOT) and promotes cross-clone decisions into tracked knowledge/specs/`AGENTS.md` per `mstar-plan-conventions` git policy.
 
 ## PM context hygiene
 


### PR DESCRIPTION
## Summary
- Adopt spoke-style **process vs results** git policy: track `{HARNESS_DIR}/AGENTS.md`, `knowledge/`, `specs/`; gitignore `plans/`, `iterations/`, `status.json`, `sdd/`, `archived/`, `notes.json` (CLI `init`/`doctor` append/check the full set).
- Fix `{SPECS_DIR}` discovery to `{HARNESS_DIR}/specs/` → `docs/specs/` → repo-root `specs/` (skip empty dirs; greenfield creates `.mstar/specs/`).
- Bump all harness surfaces to **1.5.2**.

## Test plan
- [ ] `bun run scripts/validate-release-version.ts v1.5.2`
- [ ] Grep skills for leftover “track entire HARNESS_DIR” / default `git add status.json` handoff language
- [ ] CLI: `init --target cursor --scope project --dry-run` lists full process gitignore set
- [ ] CLI doctor warns when process ignore entries are missing
- [ ] Confirm `{SPECS_DIR}` wording in `mstar-plan-conventions/SKILL.md` matches README / CHANGELOG


Made with [Cursor](https://cursor.com)