### PR TITLE
feat: add omp as sixth host surface

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "morning-star-harness",
+  "version": "1.7.0",
+  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
+  "author": {
+    "name": "Bohao Tang",
+    "email": "tech@btang.cn"
+  },
+  "homepage": "https://github.com/btspoony/mstar-harness",
+  "repository": "https://github.com/btspoony/mstar-harness.git",
+  "license": "MIT",
+  "keywords": [
+    "morning-star",
+    "mstar",
+    "harness",
+    "omp",
+    "oh-my-pi",
+    "claude-plugin"
+  ],
+  "skills": "./skills/",
+  "commands": "./commands/",
+  "agents": "./agents/"
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
-  "version": "1.6.1",
-  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.",
+  "version": "1.7.0",
+  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",
     "email": "tech@btang.cn"
@@ -26,7 +26,7 @@
   "interface": {
     "displayName": "Morning Star Harness",
     "shortDescription": "Multi-agent code harness with role-based workflows and quality gates.",
-    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, and ZCode. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
+    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
     "developerName": "Bohao Tang",
     "category": "Productivity",
     "capabilities": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
-  "version": "1.6.1",
-  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.",
+  "version": "1.7.0",
+  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",
     "email": "tech@btang.cn"
@@ -30,7 +30,7 @@
   "interface": {
     "displayName": "Morning Star Harness",
     "shortDescription": "Multi-agent code harness with role-based workflows and quality gates.",
-    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, and ZCode. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
+    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
     "developerName": "Bohao Tang",
     "category": "Productivity",
     "capabilities": [

--- a/.omp-plugin/plugin.json
+++ b/.omp-plugin/plugin.json
@@ -1,0 +1,49 @@
+{
+  "name": "morning-star-harness",
+  "version": "1.7.0",
+  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
+  "author": {
+    "name": "Bohao Tang",
+    "email": "tech@btang.cn"
+  },
+  "homepage": "https://github.com/btspoony/mstar-harness",
+  "repository": "https://github.com/btspoony/mstar-harness.git",
+  "license": "MIT",
+  "keywords": [
+    "morning-star",
+    "mstar",
+    "harness",
+    "agent",
+    "multi-agent",
+    "omp-plugin",
+    "oh-my-pi",
+    "specification-engineering",
+    "harness-engineering",
+    "quality-gates",
+    "workflow",
+    "role-based-workflow"
+  ],
+  "skills": "./skills/",
+  "commands": "./commands/",
+  "agents": "./agents/",
+  "interface": {
+    "displayName": "Morning Star Harness",
+    "shortDescription": "Multi-agent code harness with role-based workflows and quality gates.",
+    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
+    "developerName": "Bohao Tang",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "brandColor": "#E6B450",
+    "composerIcon": "./assets/logo.svg",
+    "logo": "./assets/logo.svg",
+    "logoDark": "./assets/logo-dark.svg",
+    "defaultPrompt": [
+      "Start a new project with PM routing and role assignment.",
+      "Run a QC review on recent changes.",
+      "Create a product spec and implementation plan."
+    ]
+  }
+}

--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
-  "version": "1.6.1",
-  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.",
+  "version": "1.7.0",
+  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",
     "email": "tech@btang.cn"
@@ -28,7 +28,7 @@
   "interface": {
     "displayName": "Morning Star Harness",
     "shortDescription": "Multi-agent code harness with role-based workflows and quality gates.",
-    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, and ZCode. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
+    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
     "developerName": "Bohao Tang",
     "category": "Productivity",
     "capabilities": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ Use this document as the primary maintenance contract for contributors and agent
   - Put narrative, deep install, and host quirks in `INSTALL.md`, `docs/`, or `mstar-*` skills — not in the README body.
   - Edit both language files together when README content changes.
 
-## Cursor + OpenCode + Codex + Kimi + ZCode Sync Policy
+## Cursor + OpenCode + Codex + Kimi + ZCode + omp Sync Policy
 
-When a change affects shared harness behavior, treat OpenCode, Cursor, Codex, Kimi, and ZCode as host surfaces of one system.
+When a change affects shared harness behavior, treat OpenCode, Cursor, Codex, Kimi, ZCode, and omp as host surfaces of one system.
 
 - Update shared semantics first (core harness contract), then host-specific adapters.
 - Keep host wording consistent on:
@@ -151,14 +151,16 @@ Use **`.harness/`** only for **in-progress maint work** on this repo (not publis
 - Skill authoring / trigger contracts -> `skills/mstar-skill-authoring/*`
 - Role behavior text -> `skills/mstar-roles/references/*`
 - Host adapters:
-  - Host adapter -> `mstar-host` (in-repo: `skills/mstar-host/*`; OpenCode via `bundle-assets` → `harness-skills/mstar-host/`; Cursor/Codex/Kimi/ZCode via `.cursor-plugin/` / `.codex-plugin` / `.kimi-plugin` / `.zcode-plugin/` `skills/`)
+  - Host adapter -> `mstar-host` (in-repo: `skills/mstar-host/*`; OpenCode via `bundle-assets` → `harness-skills/mstar-host/`; Cursor/Codex/Kimi/ZCode/omp via `.cursor-plugin/` / `.codex-plugin` / `.kimi-plugin` / `.zcode-plugin/` / `.omp-plugin/` `skills/`)
   - OpenCode package: `harness-skills/` + `harness-agents/` from `bundle-assets` (npm publish prepublish + root `postinstall`); plugin reads only package paths, not `process.cwd()` (npm: `@mstar-harness/opencode`)
 - CLI package -> `packages/cli/*` (package name `@mstar-harness/cli`; local `AGENTS.md`)
 - Codex plugin manifest -> `.codex-plugin/plugin.json`
 - Kimi plugin manifest -> `.kimi-plugin/plugin.json` (plugin root is repo root; paths `./skills/`, `./commands/`)
 - ZCode plugin manifest -> `.zcode-plugin/plugin.json` (plugin root is repo root; paths `./skills/`, `./commands/`, `./agents/`)
+- omp plugin markers -> `.omp-plugin/plugin.json` + `.claude-plugin/plugin.json` (plugin root is repo root; paths `./skills/`, `./commands/`, `./agents/`)
 - Codex install metadata generation -> `packages/cli/src/adapters/codex.ts`
 - ZCode install metadata generation -> `packages/cli/src/adapters/zcode.ts`
+- omp install/link flow -> `packages/cli/src/adapters/omp.ts`
 - Maintenance policy (this file) -> `AGENTS.md`
 
 ## Skill Sync Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,36 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.6.1** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.7.0** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.6.1** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.6.1** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.6.1** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.6.1** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.6.1** |
-| Kimi plugin | `.kimi-plugin/plugin.json` | **1.6.1** |
-| ZCode plugin | `.zcode-plugin/plugin.json` | **1.6.1** |
+| Monorepo root | `morning-star` (`package.json`) | **1.7.0** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.7.0** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.7.0** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.7.0** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.7.0** |
+| Kimi plugin | `.kimi-plugin/plugin.json` | **1.7.0** |
+| ZCode plugin | `.zcode-plugin/plugin.json` | **1.7.0** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 
 ## [Unreleased]
+
+## [1.7.0] - 2026-08-05
+
+### Harness (omp host surface)
+
+- **omp as sixth host surface**: markers `.omp-plugin/plugin.json` + `.claude-plugin/plugin.json` (plugin root = repo root; mounts `./skills/`, `./commands/`, `./agents/`). New `skills/mstar-host/references/omp.md` covering `task`/`ask`/`hub`, filename slash commands (`/iteration-*`), and C5/C5b built-in `task.agent` + role-in-prompt binding. `omp-plan-mode-bridge.md` for `/plan` dual-write. `mstar-host` detect table + `pm` entry + `parallel-dispatch` updated.
+- Install: `omp plugin install github:btspoony/mstar-harness` or `omp plugin link` of the local harness checkout; package list name is root `morning-star`.
+
+### CLI (`@mstar-harness/cli`)
+
+- **`omp` install target**: `npx @mstar-harness/cli init --target omp` ensures `~/.mstar/harness` and runs `omp plugin link` (falls back to `omp plugin install github:btspoony/mstar-harness`). `doctor --target omp` checks markers, smoke skills/commands, and `omp plugin list`. `shared-install` `HARNESS_MARKERS` accepts `.omp-plugin/plugin.json`.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex/Kimi/ZCode/omp plugin manifests: **→ 1.7.0**.
 
 ## [1.6.1] - 2026-08-04
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,20 +1,35 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.6.1**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.7.0**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.6.1** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.6.1** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.6.1** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.6.1** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.6.1** |
-| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.6.1** |
-| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.6.1** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.7.0** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.7.0** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.7.0** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.7.0** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.7.0** |
+| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.7.0** |
+| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.7.0** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 
 ## [Unreleased]
+
+## [1.7.0] - 2026-08-05
+
+### Harness（omp 宿主面）
+
+- **omp 作为第六宿主面**：标记 `.omp-plugin/plugin.json` + `.claude-plugin/plugin.json`（插件根 = 仓库根；挂载 `./skills/`、`./commands/`、`./agents/`）。新增 `skills/mstar-host/references/omp.md`，覆盖 `task`/`ask`/`hub`、文件名 slash 命令（`/iteration-*`）、以及 C5/C5b 内置 `task.agent` + prompt 角色绑定。`omp-plan-mode-bridge.md` 用于 `/plan` 双写。`mstar-host` detect 表、`pm` 入口、`parallel-dispatch` 已同步。
+- 安装：`omp plugin install github:btspoony/mstar-harness` 或对本地 harness checkout 执行 `omp plugin link`；`omp plugin list` 中的包名为根 `morning-star`。
+
+### CLI（`@mstar-harness/cli`）
+
+- **`omp` 安装目标**：`npx @mstar-harness/cli init --target omp` 确保 `~/.mstar/harness` 并执行 `omp plugin link`（失败则回退 `omp plugin install github:btspoony/mstar-harness`）。`doctor --target omp` 校验标记、skills/commands 冒烟与 `omp plugin list`。`shared-install` 的 `HARNESS_MARKERS` 接受 `.omp-plugin/plugin.json`。
+
+### 版本对齐
+
+- 提升 monorepo 根、`@mstar-harness/opencode`、`@mstar-harness/cli`、Cursor/Codex/Kimi/ZCode/omp 插件清单：**→ 1.7.0**。
 
 ## [1.6.1] - 2026-08-04
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,7 @@
   - [Codex](https://github.com/openai/codex) (with `codex` CLI for marketplace install)
   - [Kimi Code CLI](https://www.kimi.com/code/docs/kimi-code-cli/) (for `/plugins install`)
   - [ZCode](https://zcode.z.ai) (for Plugin Management install)
+  - [omp (Oh My Pi)](https://omp.sh) (for `omp plugin install` / `omp plugin link`)
 
 ## Recommended: CLI install
 
@@ -125,11 +126,36 @@ Install the plugin in Kimi TUI (user-scoped — all projects):
 - New sessions auto-load **`pm`** via `sessionStart.skill`; use `/skill:pm` anytime.
 - Project `.agents/skills/` symlinks are **not** required — skills and commands come from the plugin.
 
+### omp
+
+User scope (recommended):
+
+```bash
+npx @mstar-harness/cli init --target omp --scope global
+npx @mstar-harness/cli doctor --target omp
+```
+
+Or install/link directly:
+
+```bash
+omp plugin install github:btspoony/mstar-harness
+# maintainer / local checkout:
+# omp plugin link ~/.mstar/harness
+```
+
+Project scope: `npx @mstar-harness/cli init --target omp --scope project`.
+
+**Notes:**
+
+- `omp plugin list` package name is root **`morning-star`**; display name remains **morning-star-harness**.
+- Enter PM with `/skill:pm`. Iteration commands: `/iteration-start`, `/iteration-drive`, `/iteration-loop`.
+- Host adapter: `skills/mstar-host/references/omp.md`.
+
 ## Manual install
 
 Use when you cannot run the CLI or need to mirror the same layout by hand.
 
-Supported targets: `opencode`, `cursor`, `codex`, `zcode`. Kimi uses Kimi TUI `/plugins install` (see [Kimi](#kimi) above).
+Supported targets: `opencode`, `cursor`, `codex`, `zcode`, `omp`. Kimi uses Kimi TUI `/plugins install` (see [Kimi](#kimi) above).
 
 ### OpenCode
 
@@ -285,6 +311,46 @@ ZCode plugin source in this repository:
 - Plugin agents: `agents/`
 - Host adapter: `skills/mstar-host/references/zcode.md`
 
+
+### omp
+
+User scope (recommended):
+
+```bash
+npx @mstar-harness/cli init --target omp --scope global
+npx @mstar-harness/cli doctor --target omp
+```
+
+Or install/link directly with the omp CLI:
+
+```bash
+omp plugin install github:btspoony/mstar-harness
+# local checkout / maintainer link:
+# omp plugin link ~/.mstar/harness
+omp plugin list
+```
+
+Project scope:
+
+```bash
+npx @mstar-harness/cli init --target omp --scope project
+npx @mstar-harness/cli doctor --target omp --scope project
+```
+
+**Notes:**
+
+- Plugin package name in `omp plugin list` is root **`morning-star`** (`package.json` name); display name remains **morning-star-harness**.
+- Skills/commands are discovered from the linked/installed package root (`skills/`, `commands/`).
+- Enter PM with `/skill:pm`. Iteration commands are filename-based: `/iteration-start`, `/iteration-drive`, `/iteration-loop`.
+- Host adapter: `skills/mstar-host/references/omp.md`.
+
+omp plugin source in this repository:
+
+- Markers: `.omp-plugin/plugin.json`, `.claude-plugin/plugin.json` (Claude-compatible discovery)
+- Runtime skills: `skills/`
+- Plugin commands: `commands/`
+- Plugin agents: `agents/` (optional discovery; Morning Star roles still bind via prompt — see C5/C5b)
+
 ## Post-install
 
 1. **Enter PM orchestration**
@@ -292,6 +358,7 @@ ZCode plugin source in this repository:
    - Cursor / Codex: use `/pm`.
    - Kimi: use `/skill:pm`.
    - ZCode: use `/morning-star-harness:pm` or `/skill:pm` (no session auto-load).
+   - omp: use `/skill:pm` (no session auto-load).
 
 2. **Run an iteration** (see [README — Harness Commands](README.md#harness-commands))
    - **Deep / first iteration:** `/iteration-start` (Phase 1) → `/iteration-drive` (Phase 2–5).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ English / [中文](README_CN.md)
 
 - Start a usable multi-role workflow quickly
 - Run with unified `mstar-*` skills instead of scattered rules
-- Reuse one core process across OpenCode, Cursor, Codex, Kimi Code, and ZCode
+- Reuse one core process across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp
 
 Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
@@ -40,12 +40,13 @@ npx @mstar-harness/cli init
 | Codex | `npx @mstar-harness/cli init --target codex` then `codex plugin add morning-star-harness --marketplace personal` |
 | Kimi | Kimi TUI: `/plugins install https://github.com/btspoony/mstar-harness` → `/plugins reload` |
 | ZCode | `npx @mstar-harness/cli init --target zcode` then install **morning-star-harness** in ZCode → Settings → Plugin Management |
+| omp | `npx @mstar-harness/cli init --target omp` (links `~/.mstar/harness`) or `omp plugin install github:btspoony/mstar-harness` |
 
-Verify: `npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode>`.
+Verify: `npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp>`.
 
 Manual install / path layout: [`INSTALL.md`](INSTALL.md). CLI flags: [`docs/cli.md`](docs/cli.md).
 
-Reload the host after install (OpenCode restart / Cursor **Developer: Reload Window** / reopen Codex / Kimi `/plugins reload` or `/new` / ZCode reload plugin).
+Reload the host after install (OpenCode restart / Cursor **Developer: Reload Window** / reopen Codex / Kimi `/plugins reload` or `/new` / ZCode reload plugin / omp new session or `/reload-plugins` if available).
 
 ## Use
 
@@ -62,8 +63,9 @@ Enter PM, then run the per-plan cycle: `Prepare → Execute → QC → QA gate �
 | Codex | `/pm` |
 | Kimi | session auto-loads `pm`; or `/skill:pm` |
 | ZCode | `/morning-star-harness:pm` each session (no auto-load) |
+| omp | `/skill:pm` each session (no auto-load) |
 
-Host limits (Kimi/ZCode subagent surfaces, role binding in prompt): `mstar-host/references/kimi.md`, `mstar-host/references/zcode.md`.
+Host limits (Kimi/ZCode/omp subagent surfaces, role binding in prompt): `mstar-host/references/kimi.md`, `mstar-host/references/zcode.md`, `mstar-host/references/omp.md`.
 
 ### With iteration
 
@@ -78,6 +80,7 @@ Host limits (Kimi/ZCode subagent surfaces, role binding in prompt): `mstar-host/
 | Codex project | `.agents/skills/<name>/SKILL.md` (CLI symlinks from `commands/`) |
 | Codex global | Iteration skills **not** installed — use `--scope project` |
 | Kimi / ZCode | `/morning-star-harness:iteration-start` (etc.) via plugin manifest |
+| omp | `/iteration-start` · `/iteration-drive` · `/iteration-loop` (filename commands from plugin `commands/`) |
 
 Phase 2 defaults: per-plan worktree + lease, `Findings cleanup: zero-residual`. Override only with explicit `Worktree mode: waived` / `Findings cleanup: allow-residual`. SSOT → `mstar-iteration`, `mstar-branch-worktree`, `mstar-plan-artifacts`.
 
@@ -160,7 +163,7 @@ Load **`mstar-harness-core` first**, then topic skills on demand (`mstar-roles`)
 | `mstar-strategy` | `STRATEGY.md` alignment |
 | `mstar-skill-authoring` | Skill authoring contracts |
 | `mstar-roles` | Role prompts + load lists |
-| `mstar-host` | Host adapters (OpenCode / Cursor / Codex / Kimi / ZCode) |
+| `mstar-host` | Host adapters (OpenCode / Cursor / Codex / Kimi / ZCode / omp) |
 | `pm` | `/pm` / `/skill:pm` / host PM entry |
 
 Consumer plans default to **`.mstar/`**. Process artifacts (`plans/`, `iterations/`, `status.json`, `sdd/`, …) are gitignored; tracked results: `{HARNESS_DIR}/AGENTS.md`, `knowledge/`, `specs/`. Specs resolve `.mstar/specs/` → `docs/specs/` → repo-root `specs/`. Details → `mstar-plan-conventions`.

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,7 +22,7 @@
 
 - 快速启动一套可用的多角色协作流
 - 通过统一的 `mstar-*` skills 执行，而不是散落规则
-- 在 OpenCode / Cursor / Codex / Kimi Code / ZCode 下复用同一套核心流程
+- 在 OpenCode / Cursor / Codex / Kimi Code / ZCode / omp 下复用同一套核心流程
 
 更新说明：[CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)。
 
@@ -40,12 +40,13 @@ npx @mstar-harness/cli init
 | Codex | `npx @mstar-harness/cli init --target codex`，然后 `codex plugin add morning-star-harness --marketplace personal` |
 | Kimi | Kimi TUI：`/plugins install https://github.com/btspoony/mstar-harness` → `/plugins reload` |
 | ZCode | `npx @mstar-harness/cli init --target zcode`，然后在 ZCode → 设置 → 插件管理安装 **morning-star-harness** |
+| omp | `npx @mstar-harness/cli init --target omp`（链接 `~/.mstar/harness`）或 `omp plugin install github:btspoony/mstar-harness` |
 
-校验：`npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode>`。
+校验：`npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp>`。
 
 手动安装 / 路径布局：[`INSTALL.md`](INSTALL.md)。CLI 参数：[`docs/cli.md`](docs/cli.md)。
 
-安装后重载宿主（重启 OpenCode / Cursor **Developer: Reload Window** / 重开 Codex / Kimi `/plugins reload` 或 `/new` / ZCode 重载插件）。
+安装后重载宿主（重启 OpenCode / Cursor **Developer: Reload Window** / 重开 Codex / Kimi `/plugins reload` 或 `/new` / ZCode 重载插件 / omp 新会话或 `/reload-plugins`）。
 
 ## 使用
 
@@ -62,8 +63,9 @@ npx @mstar-harness/cli init
 | Codex | `/pm` |
 | Kimi | 新会话自动加载 `pm`；或 `/skill:pm` |
 | ZCode | 每会话 `/morning-star-harness:pm`（无自动加载） |
+| omp | 每会话 `/skill:pm`（无自动加载） |
 
-宿主限制（Kimi/ZCode 子代理面、角色绑定在 prompt）：`mstar-host/references/kimi.md`、`mstar-host/references/zcode.md`。
+宿主限制（Kimi/ZCode/omp 子代理面、角色绑定在 prompt）：`mstar-host/references/kimi.md`、`mstar-host/references/zcode.md`、`mstar-host/references/omp.md`。
 
 ### 跑迭代
 
@@ -78,6 +80,7 @@ npx @mstar-harness/cli init
 | Codex project | `.agents/skills/<name>/SKILL.md`（CLI 从 `commands/` 软链） |
 | Codex global | **不**装 iteration skills — 用 `--scope project` |
 | Kimi / ZCode | 插件 manifest：`/morning-star-harness:iteration-start` 等 |
+| omp | `/iteration-start` · `/iteration-drive` · `/iteration-loop`（插件 `commands/` 文件名命令） |
 
 Phase 2 默认：每 plan worktree + lease，`Findings cleanup: zero-residual`。仅显式 `Worktree mode: waived` / `Findings cleanup: allow-residual` 可覆写。SSOT → `mstar-iteration`、`mstar-branch-worktree`、`mstar-plan-artifacts`。
 
@@ -160,7 +163,7 @@ flowchart TD
 | `mstar-strategy` | `STRATEGY.md` 对齐 |
 | `mstar-skill-authoring` | skill 编写契约 |
 | `mstar-roles` | 角色提示词 + 加载清单 |
-| `mstar-host` | 宿主适配（OpenCode / Cursor / Codex / Kimi / ZCode） |
+| `mstar-host` | 宿主适配（OpenCode / Cursor / Codex / Kimi / ZCode / omp） |
 | `pm` | `/pm` / `/skill:pm` / 宿主 PM 入口 |
 
 消费方 plan 默认 **`.mstar/`**。进程产物（`plans/`、`iterations/`、`status.json`、`sdd/` 等）gitignored；跟踪结果：`{HARNESS_DIR}/AGENTS.md`、`knowledge/`、`specs/`。Specs 解析：`.mstar/specs/` → `docs/specs/` → 仓库根 `specs/`。细则 → `mstar-plan-conventions`。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # mstar-harness CLI Guide
 
-This guide documents the standalone `@mstar-harness/cli` package (command: `mstar-harness`) for OpenCode, Cursor, and Codex bootstrap. Kimi Code uses Kimi TUI `/plugins install` — see [INSTALL.md](../INSTALL.md#kimi).
+This guide documents the standalone `@mstar-harness/cli` package (command: `mstar-harness`) for OpenCode, Cursor, Codex, ZCode, and omp bootstrap. Kimi Code uses Kimi TUI `/plugins install` — see [INSTALL.md](../INSTALL.md#kimi).
 
 ## Fast Path
 
@@ -56,6 +56,25 @@ Kimi is **not** a CLI `--target`. Install via Kimi TUI:
 ```
 
 See [INSTALL.md](../INSTALL.md#kimi) and `skills/mstar-host/references/kimi.md` for host behavior (`sessionStart.skill: pm`, `/morning-star-harness:iteration-*`, C5/C5b role-in-prompt).
+
+
+### omp
+
+1) Link the local harness checkout into omp plugins (user scope):
+
+- `npx @mstar-harness/cli init --target omp --scope global`
+
+2) Verify:
+
+- `npx @mstar-harness/cli doctor --target omp`
+
+Alternate without the CLI:
+
+- `omp plugin install github:btspoony/mstar-harness`
+- or `omp plugin link ~/.mstar/harness`
+
+See [INSTALL.md](../INSTALL.md#omp) and `skills/mstar-host/references/omp.md` for host behavior (`/skill:pm`, filename `/iteration-*` commands, C5/C5b role-in-prompt).
+
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",
@@ -26,5 +26,9 @@
   "packageManager": "bun@1.2.17",
   "devDependencies": {
     "@types/node": "^25.6.0"
+  },
+  "omp": {
+    "name": "morning-star-harness",
+    "description": "Morning Star multi-agent harness skills and iteration commands for omp."
   }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## [1.7.0] - 2026-08-05
+
+- Add **`omp`** install target (`packages/cli/src/adapters/omp.ts`): link/install Morning Star into omp plugins; doctor validates markers + `omp plugin list`.
+- Version alignment with harness **1.7.0**.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.7.0**.
+
+
 ## 1.6.1
 
 - Version alignment with harness **1.6.1** (no CLI API change in this release).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.6.1",
-  "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex).",
+  "version": "1.7.0",
+  "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex, ZCode, omp).",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cli/src/adapters/index.ts
+++ b/packages/cli/src/adapters/index.ts
@@ -1,6 +1,7 @@
 import type { AgentAdapter, Target } from "../types";
 import { codexAdapter } from "./codex";
 import { cursorAdapter } from "./cursor";
+import { ompAdapter } from "./omp";
 import { opencodeAdapter } from "./opencode";
 import { zcodeAdapter } from "./zcode";
 
@@ -9,6 +10,7 @@ const adapters: Record<Target, AgentAdapter> = {
   cursor: cursorAdapter,
   codex: codexAdapter,
   zcode: zcodeAdapter,
+  omp: ompAdapter,
 };
 
 export function getAdapter(target: Target) {

--- a/packages/cli/src/adapters/omp.ts
+++ b/packages/cli/src/adapters/omp.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import type { AgentAdapter, Scope } from "../types";
+import { resolveProjectRoot } from "../utils";
+import {
+  REPO_URL,
+  PLUGIN_NAME,
+  HARNESS_REPO_PATH,
+  ensureLocalHarnessRepo,
+  appendGitignore,
+  appendHarnessProjectGitignore,
+  missingHarnessProcessGitignoreEntries,
+  validateLocalHarnessRepo,
+} from "./shared-install";
+
+const OMP_PLUGIN_MARKER = ".omp-plugin/plugin.json";
+const CLAUDE_PLUGIN_MARKER = ".claude-plugin/plugin.json";
+const PACKAGE_NAMES = new Set(["morning-star", PLUGIN_NAME, "github:btspoony/mstar-harness"]);
+const SKILL_SMOKE = ["mstar-host", "mstar-harness-core", "pm"];
+const COMMAND_SMOKE = ["iteration-start", "iteration-drive", "iteration-loop"];
+
+function ompAvailable() {
+  try {
+    execFileSync("omp", ["--version"], { stdio: "pipe", encoding: "utf8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runOmp(args: string[], dryRun: boolean) {
+  if (dryRun) return;
+  execFileSync("omp", args, { stdio: "pipe", encoding: "utf8" });
+}
+
+function listInstalledPlugins(): Array<Record<string, unknown>> {
+  try {
+    const raw = execFileSync("omp", ["plugin", "list", "--json"], {
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) return parsed as Array<Record<string, unknown>>;
+    if (parsed && typeof parsed === "object" && Array.isArray((parsed as { plugins?: unknown }).plugins)) {
+      return (parsed as { plugins: Array<Record<string, unknown>> }).plugins;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function findInstalledPlugin(plugins: Array<Record<string, unknown>>) {
+  return plugins.find((entry) => {
+    const name = typeof entry.name === "string" ? entry.name : "";
+    const pathValue = typeof entry.path === "string" ? entry.path : "";
+    if (PACKAGE_NAMES.has(name)) return true;
+    if (name.includes("morning-star")) return true;
+    if (pathValue.includes("mstar-harness") || pathValue.includes(`${path.sep}morning-star`)) return true;
+    return false;
+  });
+}
+
+function validatePluginTree(pluginRoot: string) {
+  const errors: string[] = [];
+  for (const marker of [OMP_PLUGIN_MARKER, CLAUDE_PLUGIN_MARKER]) {
+    const markerPath = path.join(pluginRoot, marker);
+    if (!fs.existsSync(markerPath)) {
+      errors.push(`Missing omp plugin marker: ${markerPath}`);
+    }
+  }
+  for (const skill of SKILL_SMOKE) {
+    const skillPath = path.join(pluginRoot, "skills", skill, "SKILL.md");
+    if (!fs.existsSync(skillPath)) errors.push(`Missing skill: ${skillPath}`);
+  }
+  for (const command of COMMAND_SMOKE) {
+    const commandPath = path.join(pluginRoot, "commands", `${command}.md`);
+    if (!fs.existsSync(commandPath)) errors.push(`Missing command: ${commandPath}`);
+  }
+  const hostRef = path.join(pluginRoot, "skills", "mstar-host", "references", "omp.md");
+  if (!fs.existsSync(hostRef)) errors.push(`Missing omp host reference: ${hostRef}`);
+  return errors;
+}
+
+function runInit(scope: Scope, dryRun: boolean) {
+  const notes = ensureLocalHarnessRepo(dryRun);
+  const projectRoot = resolveProjectRoot();
+
+  // Keep the shared checkout current so new host markers (`.omp-plugin/`) exist before link/doctor.
+  if (fs.existsSync(path.join(HARNESS_REPO_PATH, ".git"))) {
+    if (dryRun) {
+      notes.push(`Would update local harness repo: git -C ${HARNESS_REPO_PATH} pull --ff-only`);
+    } else {
+      try {
+        execFileSync("git", ["-C", HARNESS_REPO_PATH, "pull", "--ff-only"], {
+          stdio: "pipe",
+          encoding: "utf8",
+        });
+        notes.push(`Updated local harness repo at ${HARNESS_REPO_PATH}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        notes.push(`Warning: could not ff-only pull ${HARNESS_REPO_PATH} (${message})`);
+      }
+    }
+  }
+
+  if (!ompAvailable()) {
+    notes.push(
+      "omp CLI not found on PATH. Install Oh My Pi (`omp`), then re-run init or manually: omp plugin install github:btspoony/mstar-harness",
+    );
+  } else {
+    const linkArgs = ["plugin", "link", HARNESS_REPO_PATH];
+    if (scope === "project") linkArgs.push("--scope", "project");
+    if (dryRun) {
+      notes.push(`Would run: omp ${linkArgs.join(" ")}`);
+    } else {
+      try {
+        runOmp(linkArgs, dryRun);
+        notes.push(
+          `Linked local harness into omp plugins (${scope}): omp plugin link ${HARNESS_REPO_PATH}${scope === "project" ? " --scope project" : ""}`,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        notes.push(`omp plugin link failed (${message}). Falling back guidance: omp plugin install github:btspoony/mstar-harness`);
+        try {
+          const installArgs = ["plugin", "install", "github:btspoony/mstar-harness"];
+          if (scope === "project") installArgs.push("--scope", "project");
+          runOmp(installArgs, dryRun);
+          notes.push(`Installed github:btspoony/mstar-harness via omp plugin install (${scope}).`);
+        } catch (installError) {
+          const installMessage = installError instanceof Error ? installError.message : String(installError);
+          notes.push(`omp plugin install also failed: ${installMessage}`);
+        }
+      }
+    }
+  }
+
+  if (scope === "project") {
+    notes.push(...appendHarnessProjectGitignore(projectRoot, dryRun));
+    notes.push(
+      ...appendGitignore(
+        projectRoot,
+        [".omp/plugins/", ".omp/plugin-overrides.json", ".omp/plugins/installed_plugins.json"],
+        dryRun,
+      ),
+    );
+  }
+
+  notes.push("Verify with: omp plugin list");
+  notes.push("Enter PM with /skill:pm ; iteration commands: /iteration-start /iteration-drive /iteration-loop");
+  notes.push(`Host adapter: skills/mstar-host/references/omp.md`);
+  notes.push(`Alternate install without CLI link: omp plugin install ${REPO_URL.replace("https://github.com/", "github:").replace(/\.git$/, "")}`);
+
+  return {
+    location: HARNESS_REPO_PATH,
+    notes,
+  };
+}
+
+function runDoctor(scope: Scope) {
+  const errors: string[] = [];
+  errors.push(...validateLocalHarnessRepo());
+  errors.push(...validatePluginTree(HARNESS_REPO_PATH));
+
+  if (!ompAvailable()) {
+    errors.push("omp CLI not found on PATH (required for omp target doctor checks).");
+  } else {
+    const plugins = listInstalledPlugins();
+    const installed = findInstalledPlugin(plugins);
+    if (!installed) {
+      errors.push(
+        `Morning Star plugin not found in \`omp plugin list\` (expected one of: ${[...PACKAGE_NAMES].join(", ")}). Run: mstar-harness init --target omp --scope ${scope}`,
+      );
+    } else if (installed.enabled === false) {
+      errors.push(`Morning Star omp plugin is installed but disabled (${String(installed.name)}).`);
+    }
+  }
+
+  if (scope === "project") {
+    const projectRoot = resolveProjectRoot();
+    const gitignorePath = path.join(projectRoot, ".gitignore");
+    const gitignore = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
+    for (const entry of missingHarnessProcessGitignoreEntries(gitignore)) {
+      errors.push(`Missing .gitignore entry: ${entry}`);
+    }
+  }
+
+  return { location: HARNESS_REPO_PATH, errors };
+}
+
+export const ompAdapter: AgentAdapter = {
+  target: "omp",
+  mode: "install",
+  runInstallInit: (scope, dryRun) => runInit(scope, dryRun),
+  runInstallDoctor: (scope) => runDoctor(scope),
+};

--- a/packages/cli/src/adapters/shared-install.ts
+++ b/packages/cli/src/adapters/shared-install.ts
@@ -7,7 +7,11 @@ export const REPO_URL = "https://github.com/btspoony/mstar-harness.git";
 export const PLUGIN_NAME = "morning-star-harness";
 export const HARNESS_REPO_PATH = path.join(os.homedir(), ".mstar", "harness");
 
-const HARNESS_MARKERS = [".codex-plugin/plugin.json", ".zcode-plugin/plugin.json"];
+const HARNESS_MARKERS = [
+  ".codex-plugin/plugin.json",
+  ".zcode-plugin/plugin.json",
+  ".omp-plugin/plugin.json",
+];
 
 function harnessMarkerPath() {
   for (const marker of HARNESS_MARKERS) {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_TARGETS = ["opencode", "cursor", "codex", "zcode"] as const;
+export const SUPPORTED_TARGETS = ["opencode", "cursor", "codex", "zcode", "omp"] as const;
 export type Target = (typeof SUPPORTED_TARGETS)[number];
 export type Scope = "global" | "project";
 

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## [1.7.0] - 2026-08-05
+
+- Version alignment with harness **1.7.0** (omp host surface is added at the harness/CLI layer; OpenCode package unchanged beyond version bump / bundled skills sync).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.7.0**.
+
+
 ## 1.6.1
 
 - Bundled skills/agents: **QC = code reviewer** — L3 must not run test/build/lint on shared tri-review cwd; L1/L4 own runtime evidence; `qc-specialist*` bash allowlist git-only (+ lightweight analysis).

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-host/SKILL.md
+++ b/skills/mstar-host/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-host
-description: Morning Star host adapter (OpenCode, Cursor, Codex, Kimi, ZCode). Use after mstar-harness-core whenever host entry, clarify, dispatch, or plan UX differs by platform - OpenCode question/task-tool subagent invoke, Cursor /pm and CreatePlan/SwitchMode dual-write and Task parallel QC, Codex plugin skills plus Plan/Goal Mode, Kimi Agent/AgentSwarm with built-in subagent types only (coder/explore/plan) and role-in-prompt binding, ZCode Agent/AskUserQuestion/EnterPlanMode with built-in subagent types and role-in-prompt binding, sandboxed tools, and tool discovery. Auto-detect host from session tools; then Read references/<host>.md. Always load after mstar-harness-core.
+description: Morning Star host adapter (OpenCode, Cursor, Codex, Kimi, ZCode, omp). Use after mstar-harness-core whenever host entry, clarify, dispatch, or plan UX differs by platform - OpenCode question/task-tool subagent invoke, Cursor /pm and CreatePlan/SwitchMode dual-write and Task parallel QC, Codex plugin skills plus Plan/Goal Mode, Kimi Agent/AgentSwarm with built-in subagent types only (coder/explore/plan) and role-in-prompt binding, ZCode Agent/AskUserQuestion/EnterPlanMode with built-in subagent types and role-in-prompt binding, omp task/ask/hub with built-in task.agent types and role-in-prompt binding, sandboxed tools, and tool discovery. Auto-detect host from session tools; then Read references/<host>.md. Always load after mstar-harness-core.
 ---
 
 # Morning Star Host Adapter
@@ -28,12 +28,13 @@ Use **capability signals** (not filesystem paths):
 | Signal | Host | Next read |
 |--------|------|-----------|
 | **CreatePlan** / **SwitchMode** available | `cursor` | `references/cursor.md`; Plan mode also `references/cursor-plan-mode-bridge.md` |
-| **`question`** tool or **`task`** tool (**subagent** invoke) | `opencode` | `references/opencode.md` |
+| **`question`** tool or OpenCode-style **`task`** tool with **`subagent`** (not omp `agent`/`tasks[]`) | `opencode` | `references/opencode.md` |
 | **Task** + `subagent_type`, no CreatePlan | `cursor` | `references/cursor.md` |
 | **Codex app/CLI/plugin context**, `/plan`, `/goal`, Goal tools, `functions.*`, `codex_app.*`, `tool_search`, Browser plugin tools | `codex` | `references/codex.md`; Plan/Goal mode also `references/codex-plan-goal-mode-bridge.md` |
 | **`Agent`** / **`AgentSwarm`** / **`AskUserQuestion`** / **`EnterPlanMode`**, Kimi plugin (`.kimi-plugin/plugin.json`), `/morning-star-harness:*` commands | `kimi` | `references/kimi.md`; Plan mode also `references/kimi-plan-mode-bridge.md` |
 | **`Agent`** / **`AskUserQuestion`** / **`EnterPlanMode`** / **`TodoWrite`**, no `AgentSwarm`, ZCode plugin (`.zcode-plugin/plugin.json`), `/morning-star-harness:*` commands | `zcode` | `references/zcode.md`; Plan mode also `references/zcode-plan-mode-bridge.md` |
-| Still ambiguous | - | Read sections in **`cursor.md`**, **`opencode.md`**, **`codex.md`**, **`kimi.md`**, and **`zcode.md`** that match tools you have; **`mstar-harness-core` wins** on conflict |
+| **`task`** tool with **`agent`** / **`tasks[]`** batch, **`ask`**, **`hub`**, omp plugin (`.omp-plugin/plugin.json` / `.claude-plugin/plugin.json`), `/skill:pm` + `/iteration-*` filename commands | `omp` | `references/omp.md`; Plan mode also `references/omp-plan-mode-bridge.md` |
+| Still ambiguous | - | Read sections in **`cursor.md`**, **`opencode.md`**, **`codex.md`**, **`kimi.md`**, **`zcode.md`**, and **`omp.md`** that match tools you have; **`mstar-harness-core` wins** on conflict |
 
 ## Parallel dispatch (invoke-capable hosts)
 

--- a/skills/mstar-host/references/omp-plan-mode-bridge.md
+++ b/skills/mstar-host/references/omp-plan-mode-bridge.md
@@ -1,0 +1,42 @@
+# omp Plan mode bridge
+
+Load with **`omp.md`** when omp Plan mode is active (`/plan`, plan-yolo / plan-model flows, or read-only-with-resolve plan UX).
+
+## Dual-write contract
+
+omp session plans, composer todos, and plan-mode UI text are **session UX only**. Durable SSOT remains **`{HARNESS_DIR}`** (default `.mstar/`, legacy `.agents/`):
+
+| Artifact | SSOT |
+|----------|------|
+| Main plan | `{PLAN_DIR}/<plan-id>-<name>.md` |
+| Plan registry | `{HARNESS_DIR}/status.json` |
+| Iteration compass | `{ITERATION_DIR}/…` when in formal iteration |
+
+Before treating a plan as ready for Execute:
+
+1. Read `mstar-plan-conventions` + `mstar-plan-artifacts`.
+2. Ensure `{HARNESS_DIR}` / `{PLAN_DIR}` exist and process-artifact gitignore entries are present.
+3. Mirror the active omp plan content into the SSOT main plan path.
+4. Register `plan_id` in `status.json.plans[]` when required by Prepare gates.
+
+**Never** use only the omp session plan / UI todo list as **Plan Path**.
+
+## `mstar-iteration` Phase 1 in Plan mode
+
+When formal iteration Phase 1 runs under omp Plan UX:
+
+1. Keep a **single** SSOT draft plan path (no silent second plan file).
+2. Converge by **feedback-driven in-place edits** on that SSOT plan (and mirror into omp plan UI if helpful).
+3. **Do not** run Review & Edit chain, commit, or create integration branch until the user leaves Plan mode / approves implementation (Build-equivalent).
+4. Recommended branch policy still applies — no silent work on `main`/`master` (`mstar-iteration` §1.2).
+
+## Clarify vs plan approval
+
+- Use **`ask`** for high-impact product/tech choices while drafting.
+- Plan sign-off is the host Plan resolve / approval path, not a casual chat question.
+- After approval, resume as **`project-manager`**: reload `mstar-harness-core` + `omp.md`, then dispatch implementation through **`task`** (C5/C5b). Parent plan session must **not** implement product code unless the user explicitly overrides harness dispatch.
+
+## Gotchas
+
+- Plan-yolo / prewalk model switches are host UX — they do not waive Morning Star gates, Assignment, or evidence rules.
+- Isolated task worktrees from omp are orthogonal to Morning Star L1 lease/worktree fields; when L1 is active, still record harness **Worktree path** / leases.

--- a/skills/mstar-host/references/omp.md
+++ b/skills/mstar-host/references/omp.md
@@ -1,0 +1,192 @@
+# omp host reference
+
+Load when **`mstar-host`** detection resolves **omp** (Oh My Pi / `omp` session, `.omp-plugin/plugin.json` or `.claude-plugin/plugin.json` installed, **`task`** tool with **`agent`** / **`tasks[]`** batch shape, **`ask`** tool, **`hub`** tool, or `/skill:pm` / `/iteration-*` from this plugin).
+
+Plan mode: read **`omp-plan-mode-bridge.md`** when `/plan`, plan-yolo, or plan-model / read-only-with-resolve plan UX is active.
+
+Parallel PM dispatch: read **`parallel-dispatch.md`** when dispatching **N ≥ 2** concurrent `task` invocations.
+
+## omp-only context
+
+- Plugin markers: **`.omp-plugin/plugin.json`** (Morning Star host marker) and **`.claude-plugin/plugin.json`** (Claude-compatible marketplace discovery). Plugin root is the **repo root**; paths stay `./skills/`, `./commands/`, `./agents/`.
+- Runtime skills: repo `skills/` discovered after `omp plugin install` / `omp plugin link` (OMP extension-package sub-discovery) or Claude marketplace install.
+- Plugin commands: repo `commands/<name>.md` → slash **`/<name>`** (e.g. `/iteration-start`). omp uses the **filename** as the command name (no `morning-star-harness:` prefix).
+- Plugin agents: repo `agents/*.md` may be discovered, but Morning Star role ids are **not** assumed to be valid `task.agent` values — see C5/C5b.
+- **No Kimi-style `sessionStart.skill`** — enter PM manually via **`/skill:pm`** (or the `pm` skill), then **Read next** → `mstar-harness-core` → `project-manager.md`.
+- Install (user-scoped, recommended):
+  - `omp plugin install github:btspoony/mstar-harness`
+  - or CLI: `npx @mstar-harness/cli init --target omp --scope global` (links `~/.mstar/harness`)
+- Project scope: `omp plugin install github:btspoony/mstar-harness --scope project` or `npx @mstar-harness/cli init --target omp --scope project`.
+- Local maintainers: `omp plugin link /path/to/mstar-harness` (or the CLI-managed `~/.mstar/harness` checkout).
+- After install/link: `omp plugin list` should show package **`morning-star`** (root `package.json` name). Reload / new session to pick up skills and commands.
+
+## Skill loading
+
+1. On entry: invoke **`pm`** via `/skill:pm` → **Read next** loads `mstar-harness-core`, then `mstar-roles` → `project-manager.md` when PM is active.
+2. Read `mstar-host` and this omp reference.
+3. If Plan mode is active, read `omp-plan-mode-bridge.md`.
+4. Load `mstar-roles` and the active role reference.
+5. Load topic skills on demand per the role reference.
+
+Use skill names in prompts and references. Prefer `skill://<name>/…` / `/skill:<name>` over absolute local paths unless maintaining this repository.
+
+## Tools map (default agent)
+
+| omp tool | Harness use |
+|----------|-------------|
+| **`task`** | Primary dispatch — fan out one or more subagents (`agent` ∈ built-ins; batch via `tasks[]` + shared `context`) |
+| **`ask`** | Structured clarify (options + recommended); prefer over free-form when choices are known |
+| **`hub`** | Optional peer messaging / long-running process control among subagents — not a substitute for Assignment + `task` |
+| **bash** | Commands, git, tests — evidence per `mstar-coding-behavior` |
+| **read** / **write** / **edit** | File I/O (and host AST/edit variants when present) |
+| **grep** / **glob** | Search (prefer over shell find/grep) |
+| **web_search** / URL fetch tools | External docs / facts when present |
+
+OpenCode **`question`** / **`task`+`subagent`**, Cursor **Task**+`subagent_type`, and Kimi/ZCode **Agent** / **AskUserQuestion** are **not** omp tools — do not assume them.
+
+### `task` shape (operational SSOT)
+
+Prefer the live tool schema every session. Typical batch shape:
+
+```text
+task(
+  context: "<shared batch context>",
+  tasks: [
+    {
+      name: "CamelCaseId",
+      agent: "task",          # built-in only — see C5
+      task: "<full Assignment body including Act as + skill load>"
+    }
+  ]
+)
+```
+
+Single-task shorthand may exist depending on host version — always match the live schema. Parallel **N** Morning Star assignees ⇒ **one** `task` call with **N** `tasks[]` entries **or** **N** `task` calls in one assistant message when the host requires that shape. Count emitted dispatches = **N**.
+
+## Role agents (C5 — hard constraint)
+
+omp ships **built-in `task.agent` types**. Exact names vary by omp version — **read the live `task` tool schema**. Common set (docs + current releases):
+
+| `agent` | Typical use | Harness mapping |
+|---------|-------------|-----------------|
+| `scout` / `explore` | Fast read-only investigation | Orientation, codebase survey, Prepare explore passes |
+| `plan` | Architectural planning | Prepare plan-only work when appropriate |
+| `reviewer` / `security-reviewer` | Structured review | Optional QC assist — still bind Morning Star QC role in prompt (C5b) |
+| `designer` | UI/UX | Optional when Assignment is UI-heavy `frontend-dev` |
+| `librarian` | External library/API research | Optional research assist |
+| `sonic` / `quick_task` | Mechanical / low-reasoning | Mechanical transcription only |
+| `task` | General-purpose worker | **Default for Morning Star roles** (`product-manager`, `fullstack-dev`, `qc-specialist`, …) |
+
+Morning Star role ids (`project-manager`, `fullstack-dev`, `qc-specialist`, …) are **not** valid `task.agent` values unless the live schema explicitly lists them after a custom-agent unpack. Do not invent agent names.
+
+### Role binding in prompt (C5b — required)
+
+Because omp cannot bind Morning Star roles via `task.agent` alone, every dispatch **must** carry the played role in the **Assignment** and in the **task assignment text**:
+
+1. **`Execute as: <role-id>`** in Assignment (harness routing SSOT).
+2. **`Act as <role-id>`** (or equivalent) at the top of the task body.
+3. **Skill load list** — instruct the subagent to read `mstar-roles` → `references/<role-id>.md` (or shared reference + parameters) and topic skills per that reference.
+4. **`agent`** — pick from the live built-in list only (default **`task`**; explore → `scout`/`explore`).
+
+Paste-only Assignment without a **`task`** call is **not** dispatch.
+
+### Assignment / task-body template
+
+```markdown
+## Assignment
+
+**Execute as**: fullstack-dev
+**Delegation**: forbidden
+**Working branch**: feat/example
+**Plan Path**: .mstar/plans/20260717-example.md
+
+**IDENTITY:** You ARE `fullstack-dev`. Act as `fullstack-dev` for this task.
+Load: `mstar-harness-core` → `mstar-host` → `omp.md` → `mstar-roles` → `references/fullstack-dev-shared.md` → topic skills per that reference.
+
+<task body>
+```
+
+PM dispatch invocation (same turn):
+
+```text
+task(
+  context: "Morning Star dispatch for plan 20260717-example",
+  tasks: [{
+    name: "ImplementAuth",
+    agent: "task",
+    task: "<full Assignment body including Act as + skill load>"
+  }]
+)
+```
+
+For explore-only orientation:
+
+```text
+task(
+  tasks: [{
+    name: "ExploreAuth",
+    agent: "scout",   # or explore if that is what the live schema lists
+    task: "... Act as explore-only orientation; Execute as: n/a ..."
+  }]
+)
+```
+
+## PM dispatch (`task`)
+
+Harness **dispatch** on omp = **one or more `task` tool calls** with correct **`agent`** values and role-bound assignment text.
+
+| Harness | omp |
+|---------|-----|
+| `Execute as: <role-id>` | Role id in Assignment + **Act as** + skill load in **task** body |
+| `agent` for invoke | built-ins only (default `task`; explore → `scout`/`explore`) |
+| 1 Assignment ⇒ 1 invoke | **1** `tasks[]` entry (or 1 `task` call) with full Assignment body |
+| Parallel batch **N** | **N** `tasks[]` entries in **one** `task` call, or **N** `task` calls in **one** assistant message |
+| No `task` call | **Not dispatched** — paste-only / `dispatch incomplete` |
+
+### QC default
+
+- **`Execution mode: sdd`**: **N=3** task entries (`qc-specialist`, `qc-specialist-2`, `qc-specialist-3`) — each body **Act as** the respective QC role; prefer `agent: "task"` (or `reviewer` only when it does not drop Morning Star QC skill load).
+- **`inline`**: **N=1** per `parallel-dispatch.md`.
+
+Cannot emit required **N** → **`Blocked`**.
+
+### SDD implement (serial)
+
+- **`Execution mode: sdd`**: one implementer `task` entry per task id; task reviewer = new entry (no sticky resume unless host resume/id is available and recorded).
+- **Never** multiple implementer entries in one message for the same plan.
+
+## Clarify
+
+- Prefer **`ask`** for 1–3 high-impact choices with known options (`recommended` when there is a default).
+- Fallback: one concise Markdown question after codebase exploration cannot answer it.
+- Plan approval in Plan mode follows **`omp-plan-mode-bridge.md`** — do not treat a casual `ask` as plan lock.
+- “Question asked” ≠ clarify done; blocking ambiguity → **`Blocked`** or escalation.
+
+## Commands and skills paths
+
+| Surface | Path / invocation |
+|---------|-------------------|
+| Plugin skills | `/skill:<skill-name>` or auto-load from `skills/` via plugin discovery |
+| Plugin commands | `/iteration-start`, `/iteration-drive`, `/iteration-loop` (filename-based) |
+| Session entry | `/skill:pm` → `mstar-harness-core` via pm **Read next** |
+
+## Files, shell, and approvals
+
+- Prefer host search/edit tools over shell find/sed when available.
+- Respect omp approval prompts (`approval-mode`, write/yolo) for destructive operations.
+- Do not edit `~/.omp/` credentials, plugin lockfiles, or user secrets without explicit consent.
+
+## Git and final evidence
+
+- Git work follows `mstar-branch-worktree` and Assignment **Working branch** / **Branch policy**.
+- omp may offer task isolation / worktrees (`task.isolation`, `~/.omp/wt`) — still record Morning Star **Worktree path** / leases when L1 gates apply.
+- Completion reports cite concrete commands, artifacts, and commit lines when required.
+
+## Gotchas
+
+- Installed npm/git plugin package name is root **`morning-star`** (`package.json`); Morning Star display name remains **morning-star-harness**.
+- Marketplace (Claude) installs and `omp plugin install` are different discovery providers — prefer one install path per machine to avoid duplicate skill listings.
+- Session plan UI / todos are not durable SSOT unless mirrored to `{HARNESS_DIR}`.
+- No custom guaranteed Morning Star `task.agent` profiles — role binding is **always** prompt + skill load (C5b).
+- omp has no `sessionStart.skill`; new sessions do **not** auto-load PM — invoke `/skill:pm` manually.
+- Do not confuse omp **`task.agent`** with OpenCode **`subagent`** or Cursor **`subagent_type`**.

--- a/skills/mstar-host/references/parallel-dispatch.md
+++ b/skills/mstar-host/references/parallel-dispatch.md
@@ -1,6 +1,6 @@
 # Parallel dispatch (invoke-capable hosts)
 
-Shared PM dispatch contract for **any** host that uses subagent / Task / Agent invoke (OpenCode task tool, Cursor Task, Kimi **Agent** / **AgentSwarm**, Codex only when a callable multi-agent / Task tool is actually available). Process SSOT also in `mstar-dispatch-gates`.
+Shared PM dispatch contract for **any** host that uses subagent / Task / Agent invoke (OpenCode task tool, Cursor Task, Kimi **Agent** / **AgentSwarm**, omp **`task`** with **`agent`** / **`tasks[]`**, Codex only when a callable multi-agent / Task tool is actually available). Process SSOT also in `mstar-dispatch-gates`.
 
 If the active host has no callable invoke tool, this reference does not create delegation capability — mark dispatch **`Blocked`** and report to the user. Do not substitute PM-thread or single-session role execution unless the user explicitly overrides harness dispatch for this turn.
 
@@ -17,7 +17,7 @@ Printing `## Assignment` in the main thread **without** matching host invocation
 
 1. Finalize all `N` Assignment payloads (after any prerequisite turn).
 2. Count distinct `Execute as` sessions (`N`).
-3. Issue **`N` host invocations first** — OpenCode: **N `task` tool** calls with **subagent**; Cursor: **N `Task`** with `subagent_type` (JSON field shape → `cursor.md` § Task invoke schema); Kimi: **N `Agent`** calls (each prompt carries **Act as** + skill load; `subagent_type` ∈ {`coder`,`explore`,`plan`} only — see `kimi.md` C5/C5b); each with one Assignment body. For parallel work, **all `N` tool calls in one assistant message** when the host allows.
+3. Issue **`N` host invocations first** — OpenCode: **N `task` tool** calls with **subagent**; Cursor: **N `Task`** with `subagent_type` (JSON field shape → `cursor.md` § Task invoke schema); Kimi: **N `Agent`** calls (each prompt carries **Act as** + skill load; `subagent_type` ∈ {`coder`,`explore`,`plan`} only — see `kimi.md` C5/C5b); omp: **one `task` call with N `tasks[]`** (or N `task` calls) with built-in `agent` + **Act as** / skill load (see `omp.md` C5/C5b); each with one Assignment body. For parallel work, **all `N` tool calls in one assistant message** when the host allows.
 4. Optionally post a short **Status Update** after invocations (audit trail only — does not replace step 3).
 
 ## Hard rules

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm
-description: "PM entry shim — force project-manager orchestration when user invokes /pm or this skill (Codex, Cursor, OpenCode, and Kimi). General per-plan PM work: this skill + project-manager.md. Formal iteration lifecycle: mstar-iteration (host commands/ may orchestrate Phase 1–5). Boot, routing, dispatch SSOT → mstar-roles/references/project-manager.md and topic mstar-* skills — not here."
+description: "PM entry shim — force project-manager orchestration when user invokes /pm or this skill (Codex, Cursor, OpenCode, Kimi, ZCode, and omp). General per-plan PM work: this skill + project-manager.md. Formal iteration lifecycle: mstar-iteration (host commands/ may orchestrate Phase 1–5). Boot, routing, dispatch SSOT → mstar-roles/references/project-manager.md and topic mstar-* skills — not here."
 ---
 
 # PM (entry shim)
@@ -15,10 +15,12 @@ description: "PM entry shim — force project-manager orchestration when user in
 | **Cursor** | **`/pm`** or this skill → general PM orchestration (single-plan, hotfix, QC waves, dispatch) **without** starting an iteration. Formal iteration → host **`commands/`** + **`mstar-iteration`** |
 | **OpenCode** | Same as Cursor when no command: **`project-manager`** via `mstar-roles` → `references/project-manager.md` |
 | **Kimi** | **`/skill:pm`** or this skill → **`project-manager`**; iteration → plugin **`commands/`** (`/morning-star-harness:iteration-*`) |
+| **ZCode** | **`/morning-star-harness:pm`** or **`/skill:pm`** → **`project-manager`** (no session auto-load) |
+| **omp** | **`/skill:pm`** or this skill → **`project-manager`**; iteration → **`/iteration-start`** · **`/iteration-drive`** · **`/iteration-loop`** (filename commands) |
 
 **Iteration lifecycle** (optional): host `commands/` may sequence Phase 1–5; semantics SSOT → **`mstar-iteration`**. Not required for ordinary PM work.
 
-Detect host → **`mstar-host`** → `references/codex.md` | `cursor.md` | `opencode.md` | `kimi.md`.
+Detect host → **`mstar-host`** → `references/codex.md` | `cursor.md` | `opencode.md` | `kimi.md` | `zcode.md` | `omp.md`.
 
 ## Read next (in order)
 


### PR DESCRIPTION
## Summary

Adds **omp (Oh My Pi)** as the sixth host surface of the Morning Star harness, alongside OpenCode / Cursor / Codex / Kimi / ZCode. Follows the existing host SSOT pattern: plugin root = repo root, markers `.omp-plugin/plugin.json` + `.claude-plugin/plugin.json`, runtime `skills/` `commands/` `agents/` mount at the repo root.

## Why

This session runs under omp. omp discovers installed plugins via `omp plugin install` / `omp plugin link` (and Claude-compatible `.claude-plugin` marketplace layout). Adding it as a first-class host lets Morning Star skills/commands load correctly and documents the real dispatch surface (`task` / `ask` / `hub`) with C5/C5b role-in-prompt binding.

## What changed

**Core SSOT (host adapter)**
- `.omp-plugin/plugin.json` — Morning Star omp host marker (mounts `./skills/`, `./commands/`, `./agents/`)
- `.claude-plugin/plugin.json` — Claude-compatible discovery marker for omp extension-package roots
- `skills/mstar-host/references/omp.md` — host reference for `task`/`ask`/`hub`, filename slash commands (`/iteration-*`), and **C5/C5b** built-in `task.agent` + role-in-prompt binding
- `skills/mstar-host/references/omp-plan-mode-bridge.md` — `/plan` dual-write bridge to `{HARNESS_DIR}` SSOT
- `skills/mstar-host/SKILL.md` — detect-host table includes omp (`task` + `agent`/`tasks[]`, `ask`, `hub`)
- `skills/pm/SKILL.md` + `parallel-dispatch.md` — omp entry / batch `task` notes

**CLI adapter (`packages/cli`)**
- `adapters/omp.ts` — install-mode adapter:
  - ensures `~/.mstar/harness`
  - `git pull --ff-only` when checkout exists
  - `omp plugin link ~/.mstar/harness` (fallback: `omp plugin install github:btspoony/mstar-harness`)
  - `doctor` checks markers, smoke skills/commands, and `omp plugin list`
- `types.ts` — `omp` added to `SUPPORTED_TARGETS`
- `adapters/index.ts` — registered `ompAdapter`
- `shared-install.ts` — `HARNESS_MARKERS` accepts `.omp-plugin/plugin.json`

**Docs + version**
- `INSTALL.md` / `README.md` / `README_CN.md` / `docs/cli.md` / `AGENTS.md` — omp install & entry paths
- Version bump across root / CLI / OpenCode / plugin manifests: **1.7.0**
- `CHANGELOG.md` / `CHANGELOG_CN.md` / package changelogs

## How to use

```bash
npx @mstar-harness/cli init --target omp --scope global
npx @mstar-harness/cli doctor --target omp

# or
omp plugin install github:btspoony/mstar-harness
# maintainer link:
# omp plugin link ~/.mstar/harness
```

Enter PM: `/skill:pm`  
Iteration: `/iteration-start` · `/iteration-drive` · `/iteration-loop`

## Verification

- [x] `bun run typecheck` passes
- [x] `init --target omp --scope global --dry-run --yes` — correct notes (ensure repo / pull / link / entry paths)
- [x] New markers + `omp.md` / plan bridge / CLI adapter present
- [ ] Real `omp plugin link` / `doctor --target omp` on a machine with omp (not run in this PR to avoid changing local plugin state)
- [ ] Manual: new omp session loads `/skill:pm` and `/iteration-*` after install/link

## Risk notes

- omp `task.agent` values are **built-ins only** (`task`, `scout`/`explore`, `reviewer`, …). Morning Star role ids bind via Assignment **Act as** + skill load (C5b), same pattern as Kimi/ZCode.
- Installed package name in `omp plugin list` is root **`morning-star`** (`package.json` name); display name remains **morning-star-harness**.
- Marketplace (Claude) installs and `omp plugin install` are different discovery providers — prefer one install path per machine.

## Commits

1. `feat(mstar-host): add omp host surface (markers + adapter refs)`
2. `feat(cli): add omp install adapter (plugin link/install + doctor)`
3. `docs: sync bilingual install/readme + bump surfaces to 1.7.0`