### PR TITLE
fix(cli): parse omp plugin list JSON for doctor (1.7.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.omp-plugin/plugin.json
+++ b/.omp-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,32 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.7.0** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.7.1** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.7.0** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.7.0** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.7.0** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.7.0** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.7.0** |
-| Kimi plugin | `.kimi-plugin/plugin.json` | **1.7.0** |
-| ZCode plugin | `.zcode-plugin/plugin.json` | **1.7.0** |
+| Monorepo root | `morning-star` (`package.json`) | **1.7.1** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.7.1** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.7.1** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.7.1** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.7.1** |
+| Kimi plugin | `.kimi-plugin/plugin.json` | **1.7.1** |
+| ZCode plugin | `.zcode-plugin/plugin.json` | **1.7.1** |
+| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.7.1** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-08-05
+
 ### CLI (`@mstar-harness/cli`)
 
 - **omp doctor**: parse `omp plugin list --json` shape `{ npm, marketplace }` (omp 17.x) instead of only array/`plugins`, and match `manifest.name`.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex/Kimi/ZCode/omp plugin manifests: **→ 1.7.1**.
 
 ## [1.7.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG
 
 ## [Unreleased]
 
+### CLI (`@mstar-harness/cli`)
+
+- **omp doctor**: parse `omp plugin list --json` shape `{ npm, marketplace }` (omp 17.x) instead of only array/`plugins`, and match `manifest.name`.
+
 ## [1.7.0] - 2026-08-05
 
 ### Harness (omp host surface)

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,24 +1,31 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.7.0**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.7.1**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.7.0** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.7.0** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.7.0** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.7.0** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.7.0** |
-| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.7.0** |
-| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.7.0** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.7.1** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.7.1** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.7.1** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.7.1** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.7.1** |
+| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.7.1** |
+| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.7.1** |
+| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.7.1** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-08-05
+
 ### CLI（`@mstar-harness/cli`）
 
 - **omp doctor**：解析 omp 17.x 的 `omp plugin list --json` 形状 `{ npm, marketplace }`（不再只认数组/`plugins`），并匹配 `manifest.name`。
+
+### 版本对齐
+
+- 提升 monorepo 根、`@mstar-harness/opencode`、`@mstar-harness/cli`、Cursor/Codex/Kimi/ZCode/omp 插件清单：**→ 1.7.1**。
 
 ## [1.7.0] - 2026-08-05
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -16,6 +16,10 @@
 
 ## [Unreleased]
 
+### CLI（`@mstar-harness/cli`）
+
+- **omp doctor**：解析 omp 17.x 的 `omp plugin list --json` 形状 `{ npm, marketplace }`（不再只认数组/`plugins`），并匹配 `manifest.name`。
+
 ## [1.7.0] - 2026-08-05
 
 ### Harness（omp 宿主面）

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `@mstar-harness/cli` package are documented in this f
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## [Unreleased]
+
+- Fix omp doctor plugin detection for `omp plugin list --json` `{ npm, marketplace }` shape.
+
 ## [1.7.0] - 2026-08-05
 
 - Add **`omp`** install target (`packages/cli/src/adapters/omp.ts`): link/install Morning Star into omp plugins; doctor validates markers + `omp plugin list`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,7 +6,12 @@ The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface re
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-08-05
+
 - Fix omp doctor plugin detection for `omp plugin list --json` `{ npm, marketplace }` shape.
+- Version alignment with harness **1.7.1**.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.7.1**.
 
 ## [1.7.0] - 2026-08-05
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex, ZCode, omp).",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/adapters/omp.ts
+++ b/packages/cli/src/adapters/omp.ts
@@ -42,8 +42,26 @@ function listInstalledPlugins(): Array<Record<string, unknown>> {
     });
     const parsed = JSON.parse(raw) as unknown;
     if (Array.isArray(parsed)) return parsed as Array<Record<string, unknown>>;
-    if (parsed && typeof parsed === "object" && Array.isArray((parsed as { plugins?: unknown }).plugins)) {
-      return (parsed as { plugins: Array<Record<string, unknown>> }).plugins;
+    if (parsed && typeof parsed === "object") {
+      const record = parsed as {
+        plugins?: unknown;
+        npm?: unknown;
+        marketplace?: unknown;
+      };
+      if (Array.isArray(record.plugins)) {
+        return record.plugins as Array<Record<string, unknown>>;
+      }
+      // omp 17.x: { npm: [...], marketplace: [...] }
+      const entries: Array<Record<string, unknown>> = [];
+      for (const key of ["npm", "marketplace"] as const) {
+        const group = record[key];
+        if (Array.isArray(group)) {
+          for (const item of group) {
+            if (item && typeof item === "object") entries.push(item as Record<string, unknown>);
+          }
+        }
+      }
+      if (entries.length > 0) return entries;
     }
     return [];
   } catch {
@@ -55,8 +73,13 @@ function findInstalledPlugin(plugins: Array<Record<string, unknown>>) {
   return plugins.find((entry) => {
     const name = typeof entry.name === "string" ? entry.name : "";
     const pathValue = typeof entry.path === "string" ? entry.path : "";
-    if (PACKAGE_NAMES.has(name)) return true;
-    if (name.includes("morning-star")) return true;
+    const manifest =
+      entry.manifest && typeof entry.manifest === "object"
+        ? (entry.manifest as Record<string, unknown>)
+        : null;
+    const manifestName = typeof manifest?.name === "string" ? manifest.name : "";
+    if (PACKAGE_NAMES.has(name) || PACKAGE_NAMES.has(manifestName)) return true;
+    if (name.includes("morning-star") || manifestName.includes("morning-star")) return true;
     if (pathValue.includes("mstar-harness") || pathValue.includes(`${path.sep}morning-star`)) return true;
     return false;
   });

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## [1.7.1] - 2026-08-05
+
+- Version alignment with harness **1.7.1** (no OpenCode package API change; CLI omp doctor fix).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.7.1**.
+
 ## [1.7.0] - 2026-08-05
 
 - Version alignment with harness **1.7.0** (omp host surface is added at the harness/CLI layer; OpenCode package unchanged beyond version bump / bundled skills sync).

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Post-merge local verification of #49 found that `omp plugin link` succeeded and `omp plugin list` showed `morning-star@1.7.0`, but `mstar-harness doctor --target omp` still reported the plugin missing.

This PR ships the fix as release **1.7.1**.

## Cause

omp 17.x `omp plugin list --json` returns:

```json
{ "npm": [{ "name": "morning-star", "manifest": { "name": "morning-star-harness", ... }, ... }], "marketplace": [] }
```

The doctor parser only accepted a top-level array or `{ plugins: [...] }`.

## Fix

- Flatten `npm` + `marketplace` entries
- Also match `manifest.name` (`morning-star-harness`)
- Bump all harness surfaces to **1.7.1**

## Verification

- [x] `bun run typecheck`
- [x] `init --target omp --scope global` links `~/.mstar/harness`
- [x] `doctor --target omp` → **healthy** (after this parse fix)
- [x] `omp plugin doctor` → `plugin:morning-star` ok
- [x] Version table / manifests aligned to **1.7.1**