### PR TITLE
chore(release): bump to 1.8.1 + changelogs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.omp-plugin/plugin.json
+++ b/.omp-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,39 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.8.0** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.8.1** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.8.0** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.8.0** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.8.0** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.8.0** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.8.0** |
-| Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.0** |
-| ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.0** |
-| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.0** |
+| Monorepo root | `morning-star` (`package.json`) | **1.8.1** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.8.1** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.8.1** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.8.1** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.8.1** |
+| Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.1** |
+| ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.1** |
+| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.1** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-05
+
+### Harness (skills + commands optimization)
+
+- **Lossless optimization** of `skills/` and `commands/` per SkillsBench principles (compact bodies, progressive disclosure, dedup to SSOT). No rule, gate, field name, or NEVER bullet altered or dropped — rules move or compress, never disappear.
+- **Extract to `references/`**: `mstar-iteration` Phase 3 → `phase-3-iteration-close.md`, Phase 4/5 → `phase-4-5-pr-delivery.md` (body 574 → 384 lines); `mstar-compound` Q1–Q8 + Phase 1–7 → `compound-workflow.md` (275 → 103).
+- **Compress**: `mstar-coding-behavior` 216 → 142 (kept The Ladder, `simplify:` marker, minimal-check); `qc-specialist/deep-review-lenses.md` 11 lens checklists → one-liners (155 → 94).
+- **Dedup**: anti-pattern lists → `mstar-harness-core` index; new `_shared/leaf-executor-core.md` (Completion Report + Git NEVER across 9 leaf roles); new `_shared/host-role-binding-core.md` + `_shared/plan-mode-bridge-core.md` (de-clone kimi/zcode/omp host files + 5 plan-mode bridges).
+- **Commands → thin orchestrators**: 4 commands 943 → 388 lines (−59%); new `mstar-iteration/references/phase5-helper-discovery.md`.
+- **Descriptions**: tightened `coding-behavior`, `branch-worktree`, `phase-gates` frontmatter to trigger contracts.
+- **Docs**: recommended host order added to `README.md` + `README_CN.md` (`omp ≥ OpenCode ≥ Cursor > Kimi = ZCode > Codex`).
+- **Naming**: `Completion Report v2` → `Completion Report` (template unified; version suffix dropped).
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex/Kimi/ZCode/omp plugin manifests: **→ 1.8.1**.
 ## [1.8.0] - 2026-08-05
 
 ### Harness (codebase audit skill)

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,22 +1,38 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.8.0**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.8.1**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.8.0** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.8.0** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.8.0** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.8.0** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.8.0** |
-| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.0** |
-| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.0** |
-| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.0** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.8.1** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.8.1** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.8.1** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.8.1** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.8.1** |
+| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.1** |
+| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.1** |
+| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.1** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-05
+
+### Harness（skills + commands 优化）
+
+- **无损优化** `skills/` 与 `commands/`，按 SkillsBench 原则（紧凑 body、progressive disclosure、dedup 到 SSOT）。无任何规则、门禁、字段名或 NEVER 条目被改动或删除——规则只移动或压缩，绝不消失。
+- **提取到 `references/`**：`mstar-iteration` Phase 3 → `phase-3-iteration-close.md`、Phase 4/5 → `phase-4-5-pr-delivery.md`（body 574 → 384 行）；`mstar-compound` Q1–Q8 + Phase 1–7 → `compound-workflow.md`（275 → 103）。
+- **压缩**：`mstar-coding-behavior` 216 → 142（保留 The Ladder、`simplify:` 标记、minimal-check）；`qc-specialist/deep-review-lenses.md` 11 个透镜清单 → 每透镜一行（155 → 94）。
+- **去重**：反模式清单 → `mstar-harness-core` 索引；新增 `_shared/leaf-executor-core.md`（9 个 leaf 角色的 Completion Report + Git NEVER 去重）；新增 `_shared/host-role-binding-core.md` + `_shared/plan-mode-bridge-core.md`（kimi/zcode/omp 宿主文件 + 5 个 plan-mode bridge 去重）。
+- **命令 → 薄编排器**：4 个命令 943 → 388 行（−59%）；新增 `mstar-iteration/references/phase5-helper-discovery.md`。
+- **描述**：收紧 `coding-behavior`、`branch-worktree`、`phase-gates` 的 frontmatter 为触发契约。
+- **文档**：`README.md` + `README_CN.md` 增加推荐宿主顺序（`omp ≥ OpenCode ≥ Cursor > Kimi = ZCode > Codex`）。
+- **命名**：`Completion Report v2` → `Completion Report`（模板已统一，去掉版本后缀）。
+
+### 版本对齐
+
+- 提升 monorepo 根、`@mstar-harness/opencode`、`@mstar-harness/cli`、Cursor/Codex/Kimi/ZCode/omp 插件清单：**→ 1.8.1**。
 ## [1.8.0] - 2026-08-05
 
 ### Harness（代码库审计 skill）

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,12 @@ The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface re
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-05
+
+- Version alignment with harness **1.8.1** (no CLI API change; bundled skills/commands optimization landed at the harness layer).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.8.1**.
+
 ## [1.8.0] - 2026-08-05
 
 - **Codex adapter**: `CODEX_PROJECT_COMMAND_NAMES` (renamed from `CODEX_ITERATION_SKILL_NAMES`) now includes `codebase-audit`; project-scoped install materializes it alongside iteration commands. Global-scoped install warning updated.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex, ZCode, omp).",
   "license": "MIT",
   "repository": {

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the `@mstar-harness/opencode` package are documented in t
 
 The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface releases.
 
+## [Unreleased]
+
+## [1.8.1] - 2026-08-05
+
+- **Bundled skills/commands lossless optimization** (SkillsBench principles): compact `SKILL.md` bodies + progressive disclosure — extracted Phase 3/4/5 and compound workflow to `references/`; compressed `mstar-coding-behavior` and QC review lenses; deduped anti-pattern lists, leaf-role Completion Report/Git NEVER (new `_shared/leaf-executor-core.md`), host role-binding (new `_shared/host-role-binding-core.md`) and plan-mode bridges (new `_shared/plan-mode-bridge-core.md`); slimmed 4 commands to thin boot+route+delegate orchestrators (943 → 388 lines); tightened frontmatter descriptions; `Completion Report v2` → `Completion Report`. No rule, gate, or field name altered or dropped.
+- Version alignment with harness **1.8.1** (no OpenCode package API change).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.8.1**.
+
+## [1.8.0] - 2026-08-05
+
+- **Bundled skills**: new `mstar-audit` skill + `plan-quality-bar` reference + `/codebase-audit` command (read-only advisory workflow adapted from improve).
+- Version alignment with harness **1.8.0** (no OpenCode package API change).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.8.0**.
+
 ## [1.7.1] - 2026-08-05
 
 - Version alignment with harness **1.7.1** (no OpenCode package API change; CLI omp doctor fix).

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Version bump + changelog entries for the lossless skills/commands optimization (PR #52).

## Changes

- **Version → 1.8.1** across 9 surfaces: `package.json`, `packages/{opencode,cli}/package.json`, 6 plugin manifests (`.cursor-plugin` / `.codex-plugin` / `.kimi-plugin` / `.zcode-plugin` / `.omp-plugin` / `.claude-plugin`).
- **CHANGELOG.md + CHANGELOG_CN.md**: header version tables → 1.8.1; new `[1.8.1]` section documenting the optimization (extract to references/, compress, dedup to SSOT, commands → thin orchestrators, descriptions, README host order, `Completion Report v2` → `Completion Report`).

Patch bump (no CLI/API behavior change — structural/content optimization only).