### PR TITLE
docs: reorder README by recommended host and fix host detection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",
@@ -26,7 +26,7 @@
   "interface": {
     "displayName": "Morning Star Harness",
     "shortDescription": "Multi-agent code harness with role-based workflows and quality gates.",
-    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
+    "longDescription": "Morning Star (\u542f\u660e\u661f) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
     "developerName": "Bohao Tang",
     "category": "Productivity",
     "capabilities": [

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",
@@ -30,7 +30,7 @@
   "interface": {
     "displayName": "Morning Star Harness",
     "shortDescription": "Multi-agent code harness with role-based workflows and quality gates.",
-    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
+    "longDescription": "Morning Star (\u542f\u660e\u661f) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
     "developerName": "Bohao Tang",
     "category": "Productivity",
     "capabilities": [

--- a/.omp-plugin/plugin.json
+++ b/.omp-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",
@@ -29,7 +29,7 @@
   "interface": {
     "displayName": "Morning Star Harness",
     "shortDescription": "Multi-agent code harness with role-based workflows and quality gates.",
-    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
+    "longDescription": "Morning Star (\u542f\u660e\u661f) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
     "developerName": "Bohao Tang",
     "category": "Productivity",
     "capabilities": [

--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",
@@ -28,7 +28,7 @@
   "interface": {
     "displayName": "Morning Star Harness",
     "shortDescription": "Multi-agent code harness with role-based workflows and quality gates.",
-    "longDescription": "Morning Star (启明星) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
+    "longDescription": "Morning Star (\u542f\u660e\u661f) provides a multi-agent code harness framework with role-based workflows, quality gates, and unified skills across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp. Start a usable multi-role workflow quickly with PM routing, specs, implementation tracks, QC review, and QA verification.",
     "developerName": "Bohao Tang",
     "category": "Productivity",
     "capabilities": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,35 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.8.1** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.8.2** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.8.1** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.8.1** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.8.1** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.8.1** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.8.1** |
-| Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.1** |
-| ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.1** |
-| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.1** |
+| Monorepo root | `morning-star` (`package.json`) | **1.8.2** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.8.2** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.8.2** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.8.2** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.8.2** |
+| Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.2** |
+| ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.2** |
+| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.2** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 
 ## [Unreleased]
+
+## [1.8.2] - 2026-08-05
+
+### Docs (README + host detection)
+
+- **README** (`README.md` + `README_CN.md`): reorder all host tables to the recommended host order (`omp > OpenCode > Cursor > Kimi = ZCode > Codex`); reorganize **Use** section into General (without iteration) → Iteration → Codebase audit.
+- **`mstar-host`**: rewrite the host detection table to use **session tool shapes / available commands only** — `*-plugin/plugin.json` files cannot identify the host (they coexist in this source repo and in any multi-host install). Merge the duplicate Cursor detection rows into one keyed on `subagent_type`.
+- **Host references**: strip the same plugin-marker clauses from the `Load when` trigger lines of `codex.md` / `kimi.md` / `zcode.md` / `omp.md`; keep tool-shape / observable-command signals only. Path-reference context lines and bridge `plugin is installed` prerequisites are left as documentation (not detection triggers).
+- **omp**: document native internal URL schemes (`skill://`, `local://`, `agent://`, `artifact://`, `history://`) in `references/omp.md`.
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex/Kimi/ZCode/omp plugin manifests: **→ 1.8.2**.
 
 ## [1.8.1] - 2026-08-05
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,21 +1,34 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.8.1**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.8.2**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.8.1** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.8.1** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.8.1** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.8.1** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.8.1** |
-| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.1** |
-| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.1** |
-| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.1** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.8.2** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.8.2** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.8.2** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.8.2** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.8.2** |
+| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.2** |
+| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.2** |
+| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.2** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 
 ## [Unreleased]
+
+## [1.8.2] - 2026-08-05
+
+### 文档（README + 宿主识别）
+
+- **README**（`README.md` + `README_CN.md`）：所有宿主表格按推荐宿主顺序重排（`omp > OpenCode > Cursor > Kimi = ZCode > Codex`）；**使用**一节重组为 通用（不跑迭代） → 迭代 → 代码库审计。
+- **`mstar-host`**：重写宿主识别表，**仅用会话工具形态 / 可见命令**——`*-plugin/plugin.json` 文件无法识别宿主（在本源仓与任何多宿主安装里它们都同时存在）。合并重复的 Cursor 两行为一行，以 `subagent_type` 为关键信号。
+- **宿主参考**：移除 `codex.md` / `kimi.md` / `zcode.md` / `omp.md` 各自 `Load when` 触发行里的插件标记子句，只保留工具形态 / 可见命令信号。路径参考上下文行与 plan-mode bridge 的 `plugin is installed` 前提留作文档（非识别触发）。
+- **omp**：在 `references/omp.md` 记录原生 internal URL 方案（`skill://`、`local://`、`agent://`、`artifact://`、`history://`）。
+
+### 版本对齐
+
+- 提升 monorepo 根、`@mstar-harness/opencode`、`@mstar-harness/cli`、Cursor/Codex/Kimi/ZCode/omp 插件清单：**→ 1.8.2**。
 
 ## [1.8.1] - 2026-08-05
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -280,7 +280,7 @@ Register the harness as a marketplace (without the CLI). Create `~/.zcode/cli/pl
       "name": "morning-star-harness",
       "source": { "source": "github", "repo": "btspoony/mstar-harness", "ref": "main" },
       "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.",
-      "version": "1.5.6",
+      "version": "1.8.2",
       "category": "Productivity"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ English / [中文](README_CN.md)
 
 - Start a usable multi-role workflow quickly
 - Run with unified `mstar-*` skills instead of scattered rules
-- Reuse one core process across OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp
+- Reuse one core process across omp, OpenCode, Cursor, Kimi Code, ZCode, and Codex
 - **Recommended host order** (best → usable): **omp ≥ OpenCode ≥ Cursor > Kimi = ZCode > Codex** — omp/OpenCode/Cursor have the richest subagent + Plan UX; Kimi/ZCode work with built-in agent types only; Codex has the most constrained dispatch surface.
 Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
@@ -35,12 +35,12 @@ npx @mstar-harness/cli init
 
 | Host | Command |
 |------|---------|
+| omp | `npx @mstar-harness/cli init --target omp` (links `~/.mstar/harness`) or `omp plugin install github:btspoony/mstar-harness` |
 | OpenCode | `npx @mstar-harness/cli init --target opencode` |
 | Cursor | `npx @mstar-harness/cli init --target cursor` |
-| Codex | `npx @mstar-harness/cli init --target codex` then `codex plugin add morning-star-harness --marketplace personal` |
 | Kimi | Kimi TUI: `/plugins install https://github.com/btspoony/mstar-harness` → `/plugins reload` |
 | ZCode | `npx @mstar-harness/cli init --target zcode` then install **morning-star-harness** in ZCode → Settings → Plugin Management |
-| omp | `npx @mstar-harness/cli init --target omp` (links `~/.mstar/harness`) or `omp plugin install github:btspoony/mstar-harness` |
+| Codex | `npx @mstar-harness/cli init --target codex` then `codex plugin add morning-star-harness --marketplace personal` |
 
 Verify: `npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp>`.
 
@@ -50,7 +50,29 @@ Reload the host after install (OpenCode restart / Cursor **Developer: Reload Win
 
 ## Use
 
-Three entry shapes: **codebase audit** (discover what to do), **without iteration** (single plan / hotfix), or **with iteration** (multi-plan Phase 1–5).
+Three entry shapes: **without iteration** (single plan / hotfix), **with iteration** (multi-plan Phase 1–5), or **codebase audit** (discover what to do).
+
+### General (without iteration)
+
+Enter PM, then run the per-plan cycle: `Prepare → Execute → QC → QA gate → Done`.
+
+| Host | Enter PM |
+|------|----------|
+| omp | `/skill:pm` each session (no auto-load) |
+| OpenCode | `agent.project-manager` (`agents/project-manager.md`) |
+| Cursor | `/pm` |
+| Kimi | session auto-loads `pm`; or `/skill:pm` |
+| ZCode | `/morning-star-harness:pm` each session (no auto-load) |
+| Codex | `/pm` |
+
+Host limits (Kimi/ZCode/omp subagent surfaces, role binding in prompt): `mstar-host/references/kimi.md`, `mstar-host/references/zcode.md`, `mstar-host/references/omp.md`.
+
+### Iteration
+
+| Path | When |
+|------|------|
+| `/iteration-start` → `/iteration-drive` | First iteration, or need human direction lock before execute |
+| `/iteration-loop` | Full Phase 1→5 with minimal check-ins (optional `direction`, `scale` S\|M\|L\|XL) |
 
 ### Codebase audit
 
@@ -60,37 +82,15 @@ Three entry shapes: **codebase audit** (discover what to do), **without iteratio
 
 Read-only advisory — never edits source. Output feeds iteration-start Research or normal Prepare → Execute. Effort levels: `quick` / `standard` (default) / `deep`; category focus (`security`, `perf`, `tests`, …) or `branch` / `next` variants. SSOT → `mstar-audit`.
 
-### Without iteration
-
-Enter PM, then run the per-plan cycle: `Prepare → Execute → QC → QA gate → Done`.
-
-| Host | Enter PM |
-|------|----------|
-| OpenCode | `agent.project-manager` (`agents/project-manager.md`) |
-| Cursor | `/pm` |
-| Codex | `/pm` |
-| Kimi | session auto-loads `pm`; or `/skill:pm` |
-| ZCode | `/morning-star-harness:pm` each session (no auto-load) |
-| omp | `/skill:pm` each session (no auto-load) |
-
-Host limits (Kimi/ZCode/omp subagent surfaces, role binding in prompt): `mstar-host/references/kimi.md`, `mstar-host/references/zcode.md`, `mstar-host/references/omp.md`.
-
-### With iteration
-
-| Path | When |
-|------|------|
-| `/iteration-start` → `/iteration-drive` | First iteration, or need human direction lock before execute |
-| `/iteration-loop` | Full Phase 1→5 with minimal check-ins (optional `direction`, `scale` S\|M\|L\|XL) |
-
 ### Command loading
 
 | Host | How commands load |
 |------|-------------------|
+| omp | `/iteration-start` · `/iteration-drive` · `/iteration-loop` · `/codebase-audit` (filename commands from plugin `commands/`) |
 | Cursor / OpenCode | Bundled from `commands/` (OpenCode: plugin `harness-commands/`) |
+| Kimi / ZCode | `/morning-star-harness:iteration-start` · `:codebase-audit` (etc.) via plugin manifest |
 | Codex project | `.agents/skills/<name>/SKILL.md` (CLI symlinks from `commands/`) |
 | Codex global | Project-scoped commands **not** installed — use `--scope project` |
-| Kimi / ZCode | `/morning-star-harness:iteration-start` · `:codebase-audit` (etc.) via plugin manifest |
-| omp | `/iteration-start` · `/iteration-drive` · `/iteration-loop` · `/codebase-audit` (filename commands from plugin `commands/`) |
 
 Phase 2 defaults: per-plan worktree + lease, `Findings cleanup: zero-residual`. Override only with explicit `Worktree mode: waived` / `Findings cleanup: allow-residual`. SSOT → `mstar-iteration`, `mstar-branch-worktree`, `mstar-plan-artifacts`.
 
@@ -174,7 +174,7 @@ Load **`mstar-harness-core` first**, then topic skills on demand (`mstar-roles`)
 | `mstar-skill-authoring` | Skill authoring contracts |
 | `mstar-audit` | Read-only codebase audit → prioritized improvement plans |
 | `mstar-roles` | Role prompts + load lists |
-| `mstar-host` | Host adapters (OpenCode / Cursor / Codex / Kimi / ZCode / omp) |
+| `mstar-host` | Host adapters (omp / OpenCode / Cursor / Kimi / ZCode / Codex) |
 | `pm` | `/pm` / `/skill:pm` / host PM entry |
 
 Consumer plans default to **`.mstar/`**. Process artifacts (`plans/`, `iterations/`, `status.json`, `sdd/`, …) are gitignored; tracked results: `{HARNESS_DIR}/AGENTS.md`, `knowledge/`, `specs/`. Specs resolve `.mstar/specs/` → `docs/specs/` → repo-root `specs/`. Details → `mstar-plan-conventions`.

--- a/README_CN.md
+++ b/README_CN.md
@@ -35,12 +35,12 @@ npx @mstar-harness/cli init
 
 | 宿主 | 命令 |
 |------|------|
+| omp | `npx @mstar-harness/cli init --target omp`（链接 `~/.mstar/harness`）或 `omp plugin install github:btspoony/mstar-harness` |
 | OpenCode | `npx @mstar-harness/cli init --target opencode` |
 | Cursor | `npx @mstar-harness/cli init --target cursor` |
-| Codex | `npx @mstar-harness/cli init --target codex`，然后 `codex plugin add morning-star-harness --marketplace personal` |
 | Kimi | Kimi TUI：`/plugins install https://github.com/btspoony/mstar-harness` → `/plugins reload` |
 | ZCode | `npx @mstar-harness/cli init --target zcode`，然后在 ZCode → 设置 → 插件管理安装 **morning-star-harness** |
-| omp | `npx @mstar-harness/cli init --target omp`（链接 `~/.mstar/harness`）或 `omp plugin install github:btspoony/mstar-harness` |
+| Codex | `npx @mstar-harness/cli init --target codex`，然后 `codex plugin add morning-star-harness --marketplace personal` |
 
 校验：`npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp>`。
 
@@ -50,7 +50,29 @@ npx @mstar-harness/cli init
 
 ## 使用
 
-三种入口：**代码库审计**（发现该做什么）、**不跑迭代**（单 plan / hotfix）、或 **跑迭代**（多 plan Phase 1–5）。
+三种入口：**不跑迭代**（单 plan / hotfix）、**跑迭代**（多 plan Phase 1–5）、或 **代码库审计**（发现该做什么）。
+
+### 通用（不跑迭代）
+
+进入 PM，然后走 per-plan 循环：`Prepare → Execute → QC → QA gate → Done`。
+
+| 宿主 | 进入 PM |
+|------|---------|
+| omp | 每会话 `/skill:pm`（无自动加载） |
+| OpenCode | `agent.project-manager`（`agents/project-manager.md`） |
+| Cursor | `/pm` |
+| Kimi | 新会话自动加载 `pm`；或 `/skill:pm` |
+| ZCode | 每会话 `/morning-star-harness:pm`（无自动加载） |
+| Codex | `/pm` |
+
+宿主限制（Kimi/ZCode/omp 子代理面、角色绑定在 prompt）：`mstar-host/references/kimi.md`、`mstar-host/references/zcode.md`、`mstar-host/references/omp.md`。
+
+### 迭代
+
+| 路径 | 何时 |
+|------|------|
+| `/iteration-start` → `/iteration-drive` | 首次迭代，或需要人工方向锁定后再执行 |
+| `/iteration-loop` | Phase 1→5 连续少确认（可选 `direction`、`scale` S\|M\|L\|XL） |
 
 ### 代码库审计
 
@@ -60,37 +82,15 @@ npx @mstar-harness/cli init
 
 只读顾问——**不**改源码。产出可喂给 iteration-start Research 或常规 Prepare → Execute。深度级别：`quick` / `standard`（默认） / `deep`；可按类别聚焦（`security`、`perf`、`tests`、…）或用 `branch` / `next` 变体。SSOT → `mstar-audit`。
 
-### 不跑迭代
-
-进入 PM，然后走 per-plan 循环：`Prepare → Execute → QC → QA gate → Done`。
-
-| 宿主 | 进入 PM |
-|------|---------|
-| OpenCode | `agent.project-manager`（`agents/project-manager.md`） |
-| Cursor | `/pm` |
-| Codex | `/pm` |
-| Kimi | 新会话自动加载 `pm`；或 `/skill:pm` |
-| ZCode | 每会话 `/morning-star-harness:pm`（无自动加载） |
-| omp | 每会话 `/skill:pm`（无自动加载） |
-
-宿主限制（Kimi/ZCode/omp 子代理面、角色绑定在 prompt）：`mstar-host/references/kimi.md`、`mstar-host/references/zcode.md`、`mstar-host/references/omp.md`。
-
-### 跑迭代
-
-| 路径 | 何时 |
-|------|------|
-| `/iteration-start` → `/iteration-drive` | 首次迭代，或需要人工方向锁定后再执行 |
-| `/iteration-loop` | Phase 1→5 连续少确认（可选 `direction`、`scale` S\|M\|L\|XL） |
-
 ### 命令加载
 
 | 宿主 | 命令加载 |
 |------|----------|
+| omp | `/iteration-start` · `/iteration-drive` · `/iteration-loop` · `/codebase-audit`（插件 `commands/` 文件名命令） |
 | Cursor / OpenCode | 从 `commands/` 打包（OpenCode：插件 `harness-commands/`） |
+| Kimi / ZCode | 插件 manifest：`/morning-star-harness:iteration-start` · `:codebase-audit` 等 |
 | Codex project | `.agents/skills/<name>/SKILL.md`（CLI 从 `commands/` 软链） |
 | Codex global | **不**装 project 命令 — 用 `--scope project` |
-| Kimi / ZCode | 插件 manifest：`/morning-star-harness:iteration-start` · `:codebase-audit` 等 |
-| omp | `/iteration-start` · `/iteration-drive` · `/iteration-loop` · `/codebase-audit`（插件 `commands/` 文件名命令） |
 
 Phase 2 默认：每 plan worktree + lease，`Findings cleanup: zero-residual`。仅显式 `Worktree mode: waived` / `Findings cleanup: allow-residual` 可覆写。SSOT → `mstar-iteration`、`mstar-branch-worktree`、`mstar-plan-artifacts`。
 
@@ -174,7 +174,7 @@ flowchart TD
 | `mstar-skill-authoring` | skill 编写契约 |
 | `mstar-audit` | 只读代码库审计 → 优先级改进计划 |
 | `mstar-roles` | 角色提示词 + 加载清单 |
-| `mstar-host` | 宿主适配（OpenCode / Cursor / Codex / Kimi / ZCode / omp） |
+| `mstar-host` | 宿主适配（omp / OpenCode / Cursor / Kimi / ZCode / Codex） |
 | `pm` | `/pm` / `/skill:pm` / 宿主 PM 入口 |
 
 消费方 plan 默认 **`.mstar/`**。进程产物（`plans/`、`iterations/`、`status.json`、`sdd/` 等）gitignored；跟踪结果：`{HARNESS_DIR}/AGENTS.md`、`knowledge/`、`specs/`。Specs 解析：`.mstar/specs/` → `docs/specs/` → 仓库根 `specs/`。细则 → `mstar-plan-conventions`。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex, ZCode, omp).",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/adapters/zcode.ts
+++ b/packages/cli/src/adapters/zcode.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AgentAdapter, Scope } from "../types";
-import { ensureObject, readJson, writeJson, resolveProjectRoot } from "../utils";
+import { ensureObject, readJson, writeJson, resolveProjectRoot, readHarnessVersion } from "../utils";
 import {
   REPO_URL,
   PLUGIN_NAME,
@@ -21,7 +21,6 @@ const MARKETPLACE_NAME = "mstar-local";
 const MARKETPLACE_DESCRIPTION = "Morning Star harness marketplace (GitHub source).";
 const PLUGIN_DESCRIPTION =
   "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.";
-const PLUGIN_VERSION = "1.8.2";
 const PLUGIN_CATEGORY = "Productivity";
 const GITHUB_REPO = "btspoony/mstar-harness";
 const GITHUB_REF = "main";
@@ -65,7 +64,7 @@ function marketplacePluginEntry(): MarketplacePluginEntry {
     name: PLUGIN_NAME,
     source: { ...GITHUB_SOURCE },
     description: PLUGIN_DESCRIPTION,
-    version: PLUGIN_VERSION,
+    version: readHarnessVersion(),
     category: PLUGIN_CATEGORY,
   };
 }
@@ -156,8 +155,9 @@ function validateMarketplaceJson() {
   if (source.repo !== expected.source.repo) {
     errors.push(`ZCode marketplace plugin source.repo must be ${expected.source.repo}.`);
   }
-  if (entry.version !== PLUGIN_VERSION) {
-    errors.push(`ZCode marketplace plugin version must be ${PLUGIN_VERSION}.`);
+  const expectedVersion = readHarnessVersion();
+  if (entry.version !== expectedVersion) {
+    errors.push(`ZCode marketplace plugin version must be ${expectedVersion}.`);
   }
   return errors;
 }

--- a/packages/cli/src/adapters/zcode.ts
+++ b/packages/cli/src/adapters/zcode.ts
@@ -21,7 +21,7 @@ const MARKETPLACE_NAME = "mstar-local";
 const MARKETPLACE_DESCRIPTION = "Morning Star harness marketplace (GitHub source).";
 const PLUGIN_DESCRIPTION =
   "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.";
-const PLUGIN_VERSION = "1.6.0";
+const PLUGIN_VERSION = "1.8.2";
 const PLUGIN_CATEGORY = "Productivity";
 const GITHUB_REPO = "btspoony/mstar-harness";
 const GITHUB_REF = "main";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,5 @@
 #!/usr/bin/env bun
 
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { select } from "@inquirer/prompts";
 import pc from "picocolors";
 import { Command } from "commander";
@@ -10,17 +7,9 @@ import { buildModelAssignments } from "./assignment";
 import { getAdapter } from "./adapters";
 import type { DoctorOptions, InitOptions, Target } from "./types";
 import { SUPPORTED_TARGETS } from "./types";
-import { parseCsv, readJson, writeJson } from "./utils";
+import { parseCsv, readJson, writeJson, readHarnessVersion } from "./utils";
 
-const packageJsonPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../package.json");
-const packageVersion = (() => {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as { version?: string };
-    return parsed.version || "0.0.0";
-  } catch {
-    return "0.0.0";
-  }
-})();
+const packageVersion = readHarnessVersion();
 
 const program = new Command();
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export function normalizeModelList(raw: string) {
   return raw
@@ -42,4 +43,23 @@ export function resolveProjectRoot() {
   const candidate = process.env.MSTAR_CLI_PROJECT_ROOT || process.env.INIT_CWD || process.env.PWD;
   if (candidate && candidate.trim()) return path.resolve(candidate);
   return process.cwd();
+}
+
+/**
+ * Read the CLI package version from its package.json.
+ * Single source of truth for the harness version inside the CLI; adapters
+ * that need to embed/validate a version (e.g. ZCode marketplace entry) must
+ * derive it from here instead of hardcoding a literal.
+ */
+export function readHarnessVersion(): string {
+  const packageJsonPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../package.json",
+  );
+  try {
+    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as { version?: string };
+    return parsed.version || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
 }

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-host/SKILL.md
+++ b/skills/mstar-host/SKILL.md
@@ -23,18 +23,19 @@ Load topic skills **on demand** per `mstar-roles` (do not read every `mstar-*` s
 
 ## Detect active host
 
-Use **capability signals** (not filesystem paths):
+Detect from **session tool shapes and available commands** — not from plugin markers on disk. The `*-plugin/plugin.json` files **cannot** identify the host: they all coexist in this harness source repo and in any multi-host install.
 
 | Signal | Host | Next read |
 |--------|------|-----------|
-| **CreatePlan** / **SwitchMode** available | `cursor` | `references/cursor.md`; Plan mode also `references/cursor-plan-mode-bridge.md` |
-| **`question`** tool or OpenCode-style **`task`** tool with **`subagent`** (not omp `agent`/`tasks[]`) | `opencode` | `references/opencode.md` |
-| **Task** + `subagent_type`, no CreatePlan | `cursor` | `references/cursor.md` |
-| **Codex app/CLI/plugin context**, `/plan`, `/goal`, Goal tools, `functions.*`, `codex_app.*`, `tool_search`, Browser plugin tools | `codex` | `references/codex.md`; Plan/Goal mode also `references/codex-plan-goal-mode-bridge.md` |
-| **`Agent`** / **`AgentSwarm`** / **`AskUserQuestion`** / **`EnterPlanMode`**, Kimi plugin (`.kimi-plugin/plugin.json`), `/morning-star-harness:*` commands | `kimi` | `references/kimi.md`; Plan mode also `references/kimi-plan-mode-bridge.md` |
-| **`Agent`** / **`AskUserQuestion`** / **`EnterPlanMode`** / **`TodoWrite`**, no `AgentSwarm`, ZCode plugin (`.zcode-plugin/plugin.json`), `/morning-star-harness:*` commands | `zcode` | `references/zcode.md`; Plan mode also `references/zcode-plan-mode-bridge.md` |
-| **`task`** tool with **`agent`** / **`tasks[]`** batch, **`ask`**, **`hub`**, omp plugin (`.omp-plugin/plugin.json` / `.claude-plugin/plugin.json`), `/skill:pm` + `/iteration-*` filename commands | `omp` | `references/omp.md`; Plan mode also `references/omp-plan-mode-bridge.md` |
+| **`subagent_type`** param on the Task tool (plus **CreatePlan**/**SwitchMode** when Plan mode is active) | `cursor` | `references/cursor.md`; Plan mode also `references/cursor-plan-mode-bridge.md` |
+| **`question`** tool, or **`task`** tool with **`subagent`** (singular) — no `tasks[]` batch | `opencode` | `references/opencode.md` |
+| **`task`** tool with **`agent`** / **`tasks[]`** batch, **`ask`**, **`hub`** | `omp` | `references/omp.md`; Plan mode also `references/omp-plan-mode-bridge.md` |
+| **`Agent`** / **`AskUserQuestion`** / **`EnterPlanMode`** + **`AgentSwarm`** (Kimi-only) | `kimi` | `references/kimi.md`; Plan mode also `references/kimi-plan-mode-bridge.md` |
+| **`Agent`** / **`AskUserQuestion`** / **`EnterPlanMode`** / **`TodoWrite`**, **no `AgentSwarm`** | `zcode` | `references/zcode.md`; Plan mode also `references/zcode-plan-mode-bridge.md` |
+| `/plan`, `/goal` slash commands; **Goal tools**; `functions.*` / `codex_app.*` tool namespaces; `tool_search`; Browser plugin tools | `codex` | `references/codex.md`; Plan/Goal mode also `references/codex-plan-goal-mode-bridge.md` |
 | Still ambiguous | - | Read sections in **`cursor.md`**, **`opencode.md`**, **`codex.md`**, **`kimi.md`**, **`zcode.md`**, and **`omp.md`** that match tools you have; **`mstar-harness-core` wins** on conflict |
+
+Order matters: check `cursor` → `opencode` → `omp` → `kimi` → `zcode` → `codex`. `subagent_type` (Cursor) vs `subagent` (OpenCode) vs `agent`/`tasks[]` (omp) is the sharpest split among the Task-based hosts.
 
 ## Parallel dispatch (invoke-capable hosts)
 

--- a/skills/mstar-host/references/codex.md
+++ b/skills/mstar-host/references/codex.md
@@ -1,6 +1,6 @@
 # Codex host reference
 
-Load when **`mstar-host`** detection resolves **codex** (Codex app/CLI session, Codex plugin installed from `.codex-plugin/plugin.json`, Codex custom agents linked from `codex/agents/*.toml`, or Codex tool namespaces such as `functions.*`, `codex_app.*`, `tool_search`, `image_gen`, or Browser plugin tools).
+Load when **`mstar-host`** detection resolves **codex** (Codex app/CLI session, `/plan` / `/goal` slash commands, Goal tools, or Codex tool namespaces such as `functions.*`, `codex_app.*`, `tool_search`, `image_gen`, or Browser plugin tools).
 
 Plan / Goal Mode: read **`codex-plan-goal-mode-bridge.md`** when Codex Plan Mode (`/plan`) or Goal Mode (`/goal`, goal tools, or goal progress controls) is active. Codex session plans, UI todos, and goal text are not durable harness SSOT.
 

--- a/skills/mstar-host/references/kimi.md
+++ b/skills/mstar-host/references/kimi.md
@@ -1,6 +1,6 @@
 # Kimi host reference
 
-Load when **`mstar-host`** detection resolves **kimi** (Kimi Code CLI session, `.kimi-plugin/plugin.json` plugin installed, `Agent` / `AgentSwarm` / `AskUserQuestion` / `EnterPlanMode` tools, or `/morning-star-harness:*` plugin commands).
+Load when **`mstar-host`** detection resolves **kimi** (Kimi Code CLI session, `Agent` / `AgentSwarm` / `AskUserQuestion` / `EnterPlanMode` tools, or `/morning-star-harness:*` plugin commands).
 
 Plan mode: read **`kimi-plan-mode-bridge.md`** when `EnterPlanMode` / `ExitPlanMode`, `/plan`, or `kimi --plan` is active.
 

--- a/skills/mstar-host/references/omp.md
+++ b/skills/mstar-host/references/omp.md
@@ -1,6 +1,6 @@
 # omp host reference
 
-Load when **`mstar-host`** detection resolves **omp** (Oh My Pi / `omp` session, `.omp-plugin/plugin.json` or `.claude-plugin/plugin.json` installed, **`task`** tool with **`agent`** / **`tasks[]`** batch shape, **`ask`** tool, **`hub`** tool, or `/skill:pm` / `/iteration-*` from this plugin).
+Load when **`mstar-host`** detection resolves **omp** (Oh My Pi / `omp` session, **`task`** tool with **`agent`** / **`tasks[]`** batch shape, **`ask`** tool, **`hub`** tool, or `/skill:pm` / `/iteration-*` from this plugin).
 
 Plan mode: read **`omp-plan-mode-bridge.md`** when `/plan`, plan-yolo, or plan-model / read-only-with-resolve plan UX is active.
 
@@ -29,6 +29,20 @@ Parallel PM dispatch: read **`parallel-dispatch.md`** when dispatching **N ≥ 2
 5. Load topic skills on demand per the role reference.
 
 Use skill names in prompts and references. Prefer `skill://<name>/…` / `/skill:<name>` over absolute local paths unless maintaining this repository.
+
+## Internal URLs
+
+omp resolves **internal URL schemes** natively (see <https://omp.sh/#urls>), so skills and shared content stay addressable wherever omp installs the plugin — prefer URLs over absolute local paths:
+
+| Scheme | Use |
+|--------|-----|
+| `skill://<name>` | Load a skill's `SKILL.md` — e.g. `skill://mstar-harness-core`, `skill://mstar-host` |
+| `skill://<name>/<path>` | Read a file inside a skill — e.g. `skill://mstar-host/references/omp.md` |
+| `local://<name>.md` | Share context / assignments with subagents — prefer over pasting large payloads inline |
+| `artifact://<id>` / `agent://<id>` | Read a subagent's output artifact / a nested child's output |
+| `history://<id>` | Read-only transcript of a (sub)agent session |
+
+`/skill:<name>` (slash command to **invoke**) and `skill://<name>` (URL the model can **`Read`**) resolve to the same skill. Put URLs in `task` assignment bodies and skill **Read next** lists so a role subagent loads the right skill regardless of install path — this is what makes cross-host skill references portable on omp.
 
 ## Tools map (default agent)
 

--- a/skills/mstar-host/references/zcode.md
+++ b/skills/mstar-host/references/zcode.md
@@ -1,6 +1,6 @@
 # ZCode host reference
 
-Load when **`mstar-host`** detection resolves **zcode** (ZCode client session, `.zcode-plugin/plugin.json` plugin installed, `Agent` / `AskUserQuestion` / `EnterPlanMode` / `TodoWrite` tools, or `/morning-star-harness:*` plugin commands).
+Load when **`mstar-host`** detection resolves **zcode** (ZCode client session, `Agent` / `AskUserQuestion` / `EnterPlanMode` / `TodoWrite` tools, or `/morning-star-harness:*` plugin commands).
 
 Plan mode: read **`zcode-plan-mode-bridge.md`** when `EnterPlanMode` / `ExitPlanMode` is active.
 


### PR DESCRIPTION
## Summary

Two doc-level fixes requested in review, plus a follow-up the advisor flagged.

### 1. README host ordering & Use-section reorg (`README.md` + `README_CN.md`)

- **Reordered all host tables** to the recommended host order — `omp > OpenCode > Cursor > Kimi = ZCode > Codex` — so the tables now match the stated recommendation. Affects: Install, Enter-PM, Command-loading, and the `mstar-host` skill row.
- **Reorganized Use section** into the requested three categories:
  1. General (without iteration)
  2. Iteration
  3. Codebase audit
  4. Command loading (kept as a shared subsection)

### 2. omp internal URLs (`skills/mstar-host/references/omp.md`)

Added an **Internal URLs** section documenting the schemes omp resolves natively (`skill://`, `skill://<name>/<path>`, `local://`, `artifact://`/`agent://`, `history://`), clarifying that `/skill:<name>` (invoke) and `skill://<name>` (model `Read` URL) resolve to the same skill — which is what makes cross-host skill references portable on omp.

### 3. Host detection fix (`skills/mstar-host/SKILL.md` + 4 references)

**Problem:** the host detection table used `*-plugin/plugin.json` files as detection signals, but those markers **all coexist** in this source repo (and in any multi-host install), so they cannot identify the active host. Also, Cursor had **two** detection rows (one with `no CreatePlan`, which contradicts Cursor actually having CreatePlan).

**Fix:**
- Rewrote the detection table to use **session tool shapes / available commands only** — no filesystem markers. Merged the duplicate Cursor row into one keyed on `subagent_type` (the Cursor-specific param).
- Stripped the same plugin-marker clauses from the four host references' `Load when` trigger lines (`codex/kimi/zcode/omp.md`), keeping only tool-shape/observable-command signals.
- Left path-reference context lines and bridge `plugin is installed` prerequisites as-is — those are documentation, not detection triggers.

## Verification

- Diff is scoped: only the detection trigger lines and the README tables/sections changed.
- `grep` confirms **zero** plugin-marker mentions remain in any `Load when` / detection line.
- Codex plan-goal bridge was already capability-only — no change needed.

## Files

```
 README.md                             | 38 ++---
 README_CN.md                          | 36 ++---
 skills/mstar-host/SKILL.md            | 17 ++-
 skills/mstar-host/references/codex.md |  2 +-
 skills/mstar-host/references/kimi.md  |  2 +-
 skills/mstar-host/references/omp.md   | 16 ++-
 skills/mstar-host/references/zcode.md |  2 +-
 ```