### PR TITLE
docs(runtime): skill-root resolve cues + bump 1.8.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.omp-plugin/plugin.json
+++ b/.omp-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG
 
 ## [Unreleased]
 
+## [1.8.5] - 2026-08-06
+
+### Harness (skill path discovery — runtime surfaces)
+
+- Closed remaining cwd-looking `skills/mstar-*` traps on **shipped runtime surfaces**: Cursor `rules/mstar-entry.mdc` and `rules/mstar-cursor-plan-mode.mdc`, plus omp CLI post-install note in `packages/cli/src/adapters/omp.ts` (now `mstar-host → references/omp.md` / `skill://…`).
+- **`mstar-host`**: new § Resolve loaded skill root (per-host prefer + filesystem fallback: omp `skill://`, Cursor plugin checkouts, OpenCode `harness-skills/`, Codex/Kimi/ZCode plugin mounts). Host references point at the table; `mstar-skill-authoring` documents the same anti-pattern for rules/CLI notes.
+- INSTALL / `docs/cli.md` Host adapter bullets use the same skill-relative form (not consumer-cwd `skills/mstar-host/references/…`).
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex/Kimi/ZCode/omp plugin manifests: **→ 1.8.5**.
+
 ## [1.8.4] - 2026-08-06
 
 ### Harness (skill script path discovery)

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -17,6 +17,18 @@
 
 ## [Unreleased]
 
+## [1.8.5] - 2026-08-06
+
+### Harness（技能路径发现 — 运行时表面）
+
+- 关闭仍留在**已发布运行时表面**上的 cwd 型 `skills/mstar-*` 陷阱：Cursor `rules/mstar-entry.mdc`、`rules/mstar-cursor-plan-mode.mdc`，以及 omp CLI 安装后提示 `packages/cli/src/adapters/omp.ts`（改为 `mstar-host → references/omp.md` / `skill://…`）。
+- **`mstar-host`**：新增 § Resolve loaded skill root（按宿主 prefer + 文件系统回退：omp `skill://`、Cursor 插件 checkout、OpenCode `harness-skills/`、Codex/Kimi/ZCode 插件挂载）。各宿主 reference 指向该表；`mstar-skill-authoring` 同步 rules/CLI note 反模式。
+- INSTALL / `docs/cli.md` 的 Host adapter 条目改为同一套技能相对写法（不再用 consumer cwd 的 `skills/mstar-host/references/…`）。
+
+### 版本对齐
+
+- 提升 monorepo 根、`@mstar-harness/opencode`、`@mstar-harness/cli`、Cursor/Codex/Kimi/ZCode/omp 插件清单：**→ 1.8.5**。
+
 ## [1.8.4] - 2026-08-06
 
 ### Harness（技能脚本路径发现）

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -149,7 +149,7 @@ Project scope: `npx @mstar-harness/cli init --target omp --scope project`.
 
 - `omp plugin list` package name is root **`morning-star`**; display name remains **morning-star-harness**.
 - Enter PM with `/skill:pm`. Iteration commands: `/iteration-start`, `/iteration-drive`, `/iteration-loop`.
-- Host adapter: `skills/mstar-host/references/omp.md`.
+- Host adapter: **`mstar-host`** → `references/omp.md` (`skill://mstar-host/references/omp.md`).
 
 ## Manual install
 
@@ -248,7 +248,7 @@ Codex plugin source in this repository:
 - Manifest: `.codex-plugin/plugin.json`
 - Runtime skills: `skills/`
 - Custom agents: `codex/agents/`
-- Host adapter: `skills/mstar-host/references/codex.md`
+- Host adapter: **`mstar-host`** → `references/codex.md`
 
 For project-local iteration skills, prefer `npx @mstar-harness/cli init --target codex --scope project` (see [Codex: project vs global scope](#codex-project-vs-global-scope)).
 
@@ -266,7 +266,7 @@ Kimi plugin source in this repository:
 - Manifest: `.kimi-plugin/plugin.json` (plugin root is repo root; paths `./skills/`, `./commands/`)
 - Runtime skills: `skills/`
 - Plugin commands: `commands/`
-- Host adapter: `skills/mstar-host/references/kimi.md`
+- Host adapter: **`mstar-host`** → `references/kimi.md`
 
 ### ZCode
 
@@ -280,7 +280,7 @@ Register the harness as a marketplace (without the CLI). Create `~/.zcode/cli/pl
       "name": "morning-star-harness",
       "source": { "source": "github", "repo": "btspoony/mstar-harness", "ref": "main" },
       "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "category": "Productivity"
     }
   ]
@@ -309,7 +309,7 @@ ZCode plugin source in this repository:
 - Runtime skills: `skills/`
 - Plugin commands: `commands/`
 - Plugin agents: `agents/`
-- Host adapter: `skills/mstar-host/references/zcode.md`
+- Host adapter: **`mstar-host`** → `references/zcode.md`
 
 
 ### omp
@@ -342,7 +342,7 @@ npx @mstar-harness/cli doctor --target omp --scope project
 - Plugin package name in `omp plugin list` is root **`morning-star`** (`package.json` name); display name remains **morning-star-harness**.
 - Skills/commands are discovered from the linked/installed package root (`skills/`, `commands/`).
 - Enter PM with `/skill:pm`. Iteration commands are filename-based: `/iteration-start`, `/iteration-drive`, `/iteration-loop`.
-- Host adapter: `skills/mstar-host/references/omp.md`.
+- Host adapter: **`mstar-host`** → `references/omp.md` (`skill://mstar-host/references/omp.md`).
 
 omp plugin source in this repository:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,7 +55,7 @@ Kimi is **not** a CLI `--target`. Install via Kimi TUI:
 /plugins reload
 ```
 
-See [INSTALL.md](../INSTALL.md#kimi) and `skills/mstar-host/references/kimi.md` for host behavior (`sessionStart.skill: pm`, `/morning-star-harness:iteration-*`, C5/C5b role-in-prompt).
+See [INSTALL.md](../INSTALL.md#kimi) and **`mstar-host`** → `references/kimi.md` for host behavior (`sessionStart.skill: pm`, `/morning-star-harness:iteration-*`, C5/C5b role-in-prompt).
 
 
 ### omp
@@ -73,7 +73,7 @@ Alternate without the CLI:
 - `omp plugin install github:btspoony/mstar-harness`
 - or `omp plugin link ~/.mstar/harness`
 
-See [INSTALL.md](../INSTALL.md#omp) and `skills/mstar-host/references/omp.md` for host behavior (`/skill:pm`, filename `/iteration-*` commands, live-schema role `task.agent` preference + C5b skill load).
+See [INSTALL.md](../INSTALL.md#omp) and **`mstar-host`** → `references/omp.md` for host behavior (`/skill:pm`, filename `/iteration-*` commands, live-schema role `task.agent` preference + C5b skill load).
 
 
 ## Install
@@ -128,7 +128,7 @@ Codex install:
   - Codex custom agents are linked from `~/.mstar/harness/codex/agents/*.toml`.
   - **Project scope only:** `iteration-start`, `iteration-drive`, and `iteration-loop` are installed as project-local skills under `.agents/skills/<name>/SKILL.md` (symlinked to `~/.mstar/harness/commands/<name>.md`); the CLI gitignores those paths.
   - **Global scope:** iteration skills are **not** installed (avoids polluting other projects); `init` prints a warning — re-run with `--scope project` to enable them.
-  - Codex-specific clarify, dispatch, sandbox, and tool-discovery rules live in `skills/mstar-host/references/codex.md`.
+  - Codex-specific clarify, dispatch, sandbox, and tool-discovery rules live in **`mstar-host`** → `references/codex.md`.
 
 Kimi: not a CLI target — use `/plugins install` in Kimi TUI (see [INSTALL.md](../INSTALL.md#kimi)).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,15 @@ The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface re
 
 ## [Unreleased]
 
+## [1.8.5] - 2026-08-06
+
+### Changed
+
+- omp `init` post-install note: Host adapter now `mstar-host → references/omp.md` (`skill://…`) instead of consumer-cwd `skills/mstar-host/…`.
+- Version alignment with harness **1.8.5**.
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.8.5**.
+
 ## [1.8.4] - 2026-08-06
 
 - Version alignment with harness **1.8.4** (skill-relative script path docs; no CLI API change).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex, ZCode, omp).",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/adapters/omp.ts
+++ b/packages/cli/src/adapters/omp.ts
@@ -172,7 +172,7 @@ function runInit(scope: Scope, dryRun: boolean) {
 
   notes.push("Verify with: omp plugin list");
   notes.push("Enter PM with /skill:pm ; commands: /iteration-start /iteration-drive /iteration-loop /codebase-audit");
-  notes.push(`Host adapter: skills/mstar-host/references/omp.md`);
+  notes.push(`Host adapter: mstar-host → references/omp.md (skill://mstar-host/references/omp.md)`);
   notes.push(`Alternate install without CLI link: omp plugin install ${REPO_URL.replace("https://github.com/", "github:").replace(/\.git$/, "")}`);
 
   return {

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -6,6 +6,15 @@ The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface re
 
 ## [Unreleased]
 
+## [1.8.5] - 2026-08-06
+
+### Bundled harness skills (`harness-skills/` at publish)
+
+- Sync `mstar-host` § Resolve loaded skill root + host-reference skill-root cues; `mstar-skill-authoring` anti-pattern for rules/CLI cwd paths.
+- Version alignment with harness **1.8.5** (no OpenCode package API change).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.8.5**.
+
 ## [1.8.4] - 2026-08-06
 
 - **Bundled skills**: skill-relative script path naming (`mstar-sdd` → `scripts/…`) so agents resolve scripts from the loaded skill directory instead of consumer-cwd `skills/…` paths.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/rules/mstar-cursor-plan-mode.mdc
+++ b/rules/mstar-cursor-plan-mode.mdc
@@ -43,7 +43,7 @@ When Plan mode is used to **start a new iteration**:
 - After user signals feedback-close: optional **minimal** deferred interview **only if** blocking gaps remain — still edit the **same** file. Never open a second CreatePlan.
 - If a duplicate plan file appears: merge into the original and delete the duplicate.
 - **Do not** dispatch Review & Edit, commit, or create the integration branch until the user clicks **Build**.
-- Detail: `skills/mstar-host/references/cursor-plan-mode-bridge.md` § `mstar-iteration` Phase 1 in Plan mode.
+- Detail: **`mstar-host`** → `references/cursor-plan-mode-bridge.md` § `mstar-iteration` Phase 1 in Plan mode.
 
 ## Build resume contract
 
@@ -58,4 +58,4 @@ When the user clicks **Build** or Cursor switches from Plan mode to Agent mode:
 
 ## Detail
 
-Read `skills/mstar-host/references/cursor-plan-mode-bridge.md` (via `mstar-host` skill) for templates and checklists. Conflict with harness invariants → **`mstar-harness-core`** wins.
+Read **`mstar-host`** → `references/cursor-plan-mode-bridge.md` for templates and checklists. Conflict with harness invariants → **`mstar-harness-core`** wins.

--- a/rules/mstar-entry.mdc
+++ b/rules/mstar-entry.mdc
@@ -3,7 +3,7 @@ description: Ensure Morning Star core skill is loaded first in Cursor plugin usa
 alwaysApply: true
 ---
 
-When this plugin is active, always read `skills/mstar-harness-core/SKILL.md` before non-trivial tasks, including relevant files in its `references/` directory.
+When this plugin is active, always load skill **`mstar-harness-core`** first (`SKILL.md` and relevant `references/`) before non-trivial tasks. Resolve it from the loaded plugin skill root — **not** as a consumer-project path `skills/mstar-harness-core/…`.
 
 `mstar-harness-core` is the single source of truth for lifecycle gates, routing, host entry behavior, skill loading order, and execution invariants across all `mstar-*` skills.
 

--- a/skills/mstar-host/SKILL.md
+++ b/skills/mstar-host/SKILL.md
@@ -41,6 +41,20 @@ Order matters: check `cursor` → `opencode` → `omp` → `kimi` → `zcode` �
 
 When PM dispatches **N >= 2** concurrent assignees (QC tri-review, dual-track implement, etc.) and the host exposes actual invoke / Task / subagent tools, read **`references/parallel-dispatch.md`** in the dispatch round (shared with `mstar-dispatch-gates`). Without a callable invoke tool when dispatch is required → **`Blocked`**; Assignment Markdown alone is not dispatch.
 
+## Resolve loaded skill root
+
+Docs name assets as skill **`<name>`** → `scripts/…` / `references/…`. **Resolve the loaded skill directory first** — do **not** open `skills/<name>/…` from a consumer app cwd (that layout exists in the harness source / plugin package only).
+
+| Host | Prefer | Filesystem fallback (only if the host cannot load by name) |
+|------|--------|--------------------------------------------------------------|
+| **omp** | `skill://<name>` / `skill://<name>/<rel>` / `/skill:<name>` | Plugin package root `skills/<name>/` after install/link — not app cwd |
+| **Cursor** | Skill **name** via plugin skills | Global `~/.cursor/plugins/local/morning-star-harness/skills/<name>/`; project `.cursor/plugins/morning-star-harness/skills/<name>/` |
+| **Codex** | Skill **name** via plugin | Plugin-mounted `skills/<name>/`; project command skills under `.agents/skills/<name>/` |
+| **OpenCode** | Skill **name** via `@mstar-harness/opencode` | Package-internal `harness-skills/<name>/` — never `process.cwd()/skills/` |
+| **Kimi / ZCode** | Skill **name** / `/skill:<name>` | Plugin mount `./skills/<name>/` from the installed plugin root |
+
+Authoring convention: **`mstar-skill-authoring`** § Skill-relative script and asset paths. Per-host URI / mount detail: `references/<host>.md`.
+
 ## Conflict order
 
 1. User explicit instructions (this turn)

--- a/skills/mstar-host/references/codex.md
+++ b/skills/mstar-host/references/codex.md
@@ -23,7 +23,7 @@ Parallel PM dispatch: read **`parallel-dispatch.md`** only when Codex exposes an
 4. Load `mstar-roles` and the active role reference.
 5. Load topic skills on demand per the role reference.
 
-Use skill names in prompts and references. Avoid absolute local paths unless the user is maintaining this repository or the skill is not installed and must be read from the checkout.
+Use skill names in prompts and references. Avoid absolute local paths unless the user is maintaining this repository or the skill is not installed and must be read from the checkout. Skill-root resolve (plugin `skills/<name>/`, project `.agents/skills/<name>/`) → `mstar-host` § Resolve loaded skill root.
 
 ## Clarify
 

--- a/skills/mstar-host/references/cursor.md
+++ b/skills/mstar-host/references/cursor.md
@@ -6,6 +6,7 @@ Parallel PM dispatch: **`parallel-dispatch.md`** (Task tool uses same turn model
 
 ## Cursor-only context
 
+- Skill root: load by skill **name**; filesystem fallback → `mstar-host` § Resolve loaded skill root (`~/.cursor/plugins/local/morning-star-harness/skills/<name>/` or project `.cursor/plugins/morning-star-harness/skills/<name>/`). Never app-cwd `skills/<name>/`.
 - Role prompts: `mstar-roles`; **`/pm`** or **`pm` skill** → general PM orchestration (per-plan dispatch, gates, QC) without an iteration command. Host **`commands/`** for formal iteration Phase 1–5 (semantics → **`mstar-iteration`**).
 - Routing-eval: `.cursor/skills/mstar-routing-eval/` — regression tooling only; not runtime load order.
 

--- a/skills/mstar-host/references/kimi.md
+++ b/skills/mstar-host/references/kimi.md
@@ -25,7 +25,7 @@ Parallel PM dispatch: read **`parallel-dispatch.md`** when dispatching **N ≥ 2
 4. Load `mstar-roles` and the active role reference.
 5. Load topic skills on demand per the role reference.
 
-Use skill names in prompts and references. Avoid absolute local paths unless maintaining this repository or skills are not installed.
+Use skill names in prompts and references. Avoid absolute local paths unless maintaining this repository or skills are not installed. Skill-root resolve (plugin mount `./skills/<name>/`) → `mstar-host` § Resolve loaded skill root.
 
 ## Tools map (default agent)
 

--- a/skills/mstar-host/references/omp.md
+++ b/skills/mstar-host/references/omp.md
@@ -28,7 +28,7 @@ Parallel PM dispatch: read **`parallel-dispatch.md`** when dispatching **N ≥ 2
 4. Load `mstar-roles` and the active role reference.
 5. Load topic skills on demand per the role reference.
 
-Use skill names in prompts and references. Prefer `skill://<name>/…` / `/skill:<name>` over absolute local paths unless maintaining this repository.
+Use skill names in prompts and references. Prefer `skill://<name>/…` / `/skill:<name>` over absolute local paths unless maintaining this repository. Full skill-root table (all hosts) → `mstar-host` § Resolve loaded skill root.
 
 ## Internal URLs
 

--- a/skills/mstar-host/references/opencode.md
+++ b/skills/mstar-host/references/opencode.md
@@ -6,6 +6,7 @@ Parallel PM dispatch: **`parallel-dispatch.md`** (read in dispatch rounds).
 
 ## Role loading
 
+- Skill root: load by skill **name** from `@mstar-harness/opencode` (`harness-skills/<name>/` inside the package). Never `process.cwd()/skills/` — see `mstar-host` § Resolve loaded skill root.
 - **PM entry**: **`/pm`** or **`pm` skill** → `project-manager` for general orchestration; host **`commands/`** for formal iteration Phase 1–5 (semantics → **`mstar-iteration`**).
 - **Role shell**: `agents/<id>.md` referenced by `opencode.json` `agent.<id>` (frontmatter + role binding only).
 - **Role body**: `mstar-roles` `references/<id>.md` (or shared references + parameters).

--- a/skills/mstar-host/references/zcode.md
+++ b/skills/mstar-host/references/zcode.md
@@ -25,7 +25,7 @@ Parallel PM dispatch: read **`parallel-dispatch.md`** when dispatching **N ≥ 2
 4. Load `mstar-roles` and the active role reference.
 5. Load topic skills on demand per the role reference.
 
-Use skill names in prompts and references. Avoid absolute local paths unless maintaining this repository or skills are not installed.
+Use skill names in prompts and references. Avoid absolute local paths unless maintaining this repository or skills are not installed. Skill-root resolve (plugin mount `./skills/<name>/`) → `mstar-host` § Resolve loaded skill root.
 
 ## Tools map (default agent)
 

--- a/skills/mstar-skill-authoring/SKILL.md
+++ b/skills/mstar-skill-authoring/SKILL.md
@@ -110,8 +110,9 @@ When a skill ships executables or assets under `scripts/` / `templates/` / `refe
 - Good: skill **`mstar-sdd`** → `scripts/sdd-workspace`
 - Good: `<mstar-sdd>/scripts/sdd-workspace` (placeholder for the loaded skill root)
 - Bad in runtime docs: `skills/mstar-sdd/scripts/sdd-workspace` as if it were a consumer-project cwd path
+- Bad in shipped rules / CLI notes: `skills/mstar-host/references/…` as a consumer cwd path — use **`mstar-host`** → `references/…` (omp may also cite `skill://mstar-host/references/…`)
 
-Agents discover skills by **name**; they often miss files when docs present a full repo-relative path and they search that literal string under the app checkout. Resolve the loaded skill directory first, then append `scripts/…`. Reserve `skills/<name>/…` only for harness-repo maintenance notes that explicitly say “from this repository root”.
+Agents discover skills by **name**; they often miss files when docs present a full repo-relative path and they search that literal string under the app checkout. Resolve the loaded skill directory first, then append `scripts/…` / `references/…`. **How** to resolve differs by host — use **`mstar-host`** § Resolve loaded skill root (omp `skill://`, Cursor plugin checkout under `~/.cursor/plugins/…` or `.cursor/plugins/…`, OpenCode `harness-skills/`, Codex/Kimi/ZCode plugin mounts). Reserve `skills/<name>/…` only for harness-repo maintenance notes that explicitly say "from this repository root".
 
 ## Progressive Disclosure
 


### PR DESCRIPTION
## Summary
- Follow-up to #56: close remaining cwd-looking `skills/mstar-*` traps on **shipped runtime surfaces** — Cursor `rules/mstar-entry.mdc` / `rules/mstar-cursor-plan-mode.mdc`, omp CLI post-install note, plus INSTALL / `docs/cli.md` Host adapter bullets.
- Add **`mstar-host` § Resolve loaded skill root** (per-host prefer + filesystem fallback: omp `skill://`, Cursor plugin checkouts, OpenCode `harness-skills/`, Codex/Kimi/ZCode mounts) and point host references + `mstar-skill-authoring` at it.
- Patch bump all harness surfaces **1.8.4 → 1.8.5** with bilingual + package changelogs.

## Test plan
- [x] `bun run release:validate -- v1.8.5`
- [x] Spot-check rules no longer tell agents to open consumer-cwd `skills/mstar-harness-core/…` / `skills/mstar-host/references/…`
- [x] Confirm omp `init` note cites `mstar-host → references/omp.md` / `skill://…`
- [ ] Optional: in a consumer app, confirm Cursor/omp agents resolve skill assets via name / `skill://` instead of app-cwd `skills/…`