### PR TITLE
docs(changelog): bump published surface registry to 1.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.8.4** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.8.5** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.8.4** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.8.4** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.8.4** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.8.4** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.8.4** |
-| Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.4** |
-| ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.4** |
-| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.4** |
+| Monorepo root | `morning-star` (`package.json`) | **1.8.5** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.8.5** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.8.5** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.8.5** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.8.5** |
+| Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.5** |
+| ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.5** |
+| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.5** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,17 +1,17 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.8.4**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.8.5**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.8.4** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.8.4** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.8.4** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.8.4** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.8.4** |
-| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.4** |
-| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.4** |
-| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.4** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.8.5** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.8.5** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.8.5** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.8.5** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.8.5** |
+| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.5** |
+| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.5** |
+| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.5** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 


### PR DESCRIPTION
## Summary
- Follow-up to #57: bump the published harness surface registry headers in `CHANGELOG.md` and `CHANGELOG_CN.md` from **1.8.4** → **1.8.5** (manifests/tag already at 1.8.5; registry tables were stale).

## Test plan
- [x] Header line + surface tables in both language changelogs show **1.8.5**
- [x] No leftover **1.8.4** in the registry header blocks