### PR TITLE
fix(dispatch): invoke field-completeness gate + envelope-first construction (1.8.6)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "morning-star-harness",
   "displayName": "Morning Star Harness",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Morning Star harness engineering framework as a Cursor plugin.",
   "author": {
     "name": "Bohao Tang",

--- a/.cursor/skills/mstar-routing-eval/SKILL.md
+++ b/.cursor/skills/mstar-routing-eval/SKILL.md
@@ -99,6 +99,7 @@ description: "[Cursor maint] Morning Star 路由与 prompt 迭代评估 —— �
 - **跨 plan 无 lease 并行**：迭代 Phase 2 跨 plan 可写派发无 verified **`plans[].execution_lease`** + 独立 feature **`Worktree path`**；或 steal / 覆盖活跃 **`execution_lease`** / **`integration_merge_lease`**；或并行 integration merge；或 **`InProgress`** 无 lease 未恢复即 writable-dispatch（见 **`mstar-iteration`** §2.6 · **`mstar-dispatch-gates`**）
 - **跨 plan 并行无 same-host 锁**：跨主机 / 无共享 flock 仍 dispatch 跨 plan 并行可写 implement，且 **无** 用户本轮 `Cross-host lease race: accepted`（或等价）+ audit `plans[].notes`；应 **Blocked** 或改为 **`Plan parallelism: serial`**（见 **`mstar-plan-artifacts`** · **`mstar-iteration`** §2.0 #5）— **含 `Worktree mode: waived`**
 - **`Worktree mode: waived` 误作并行授权**：Assignment 含 waived 且无 same-host 锁、无 serial、无 `Cross-host lease race: accepted` + audit 仍 dispatch 跨 plan 并行可写 implement
+- **invoke 角色字段缺失（静默 generic 回退）**：已发 Task/subagent invoke，但 item 漏写与 **`Execute as`** 匹配的角色绑定字段（omp **`agent`** / Cursor **`subagent_type`** / OpenCode **`subagent`** / Kimi·ZCode **`subagent_type`**）⇒ 宿主静默回退 generic worker，却因 count=N 通过而误判「派发完成」（见 **`mstar-dispatch-gates`**、**`mstar-host/references/parallel-dispatch.md`**）。**N=1 顺序 Review-&-Edit 链**最易触发——count 门恒过，字段门是唯一保护
 
 ## 3. 迭代规则
 

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.omp-plugin/plugin.json
+++ b/.omp-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/.zcode-plugin/plugin.json
+++ b/.zcode-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star-harness",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
   "author": {
     "name": "Bohao Tang",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,34 @@
 
 Chinese summary: [CHANGELOG_CN.md](CHANGELOG_CN.md).
 
-All notable changes to this repository are documented here. Published harness surfaces are at **1.8.5** unless noted:
+All notable changes to this repository are documented here. Published harness surfaces are at **1.8.6** unless noted:
 
 | Surface | Package / manifest | Version |
 | --- | --- | --- |
-| Monorepo root | `morning-star` (`package.json`) | **1.8.5** |
-| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.8.5** |
-| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.8.5** |
-| Cursor plugin | `.cursor-plugin/plugin.json` | **1.8.5** |
-| Codex plugin | `.codex-plugin/plugin.json` | **1.8.5** |
-| Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.5** |
-| ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.5** |
-| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.5** |
+| Monorepo root | `morning-star` (`package.json`) | **1.8.6** |
+| CLI | `@mstar-harness/cli` (`packages/cli`) | **1.8.6** |
+| OpenCode plugin | `@mstar-harness/opencode` (`packages/opencode`) | **1.8.6** |
+| Cursor plugin | `.cursor-plugin/plugin.json` | **1.8.6** |
+| Codex plugin | `.codex-plugin/plugin.json` | **1.8.6** |
+| Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.6** |
+| ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.6** |
+| omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.6** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 
 ## [Unreleased]
+
+## [1.8.6] - 2026-08-06
+
+### Harness (dispatch fidelity — invoke field-completeness gate)
+
+- Added a per-item **field-completeness gate** at the dispatch self-check: every Task/subagent invoke must carry the role-binding field matching `Execute as` (omp `agent` / Cursor `subagent_type` / OpenCode `subagent` / Kimi·ZCode `subagent_type`). A missing field (e.g. omp omitting `agent` ⇒ silent generic `task` fallback) is now **dispatch incomplete** — same severity as paste-only zero-invoke — so a bare `tasks:[{task:"…"}]` no longer passes just because invoke count = N. N=1 sequential Review-&-Edit chains are explicitly covered (count gate is vacuous there).
+- `mstar-dispatch-gates`: pre-send self-check line + anti-pattern bullet; `mstar-host/references/parallel-dispatch.md`: hard rule + self-check step; `mstar-host/references/omp.md`: Review-&-Edit example now shows a full `task(...)` block per pass (architect / writing-specialist) with `agent` set, plus an N=1 gotcha.
+- `.cursor/skills/mstar-routing-eval`: regression signal for "invoke role field missing ⇒ silent generic fallback".
+
+### Version alignment
+
+- Bump monorepo root, `@mstar-harness/opencode`, `@mstar-harness/cli`, Cursor/Codex/Kimi/ZCode/omp plugin manifests: **→ 1.8.6**.
 
 ## [1.8.5] - 2026-08-06
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,21 +1,33 @@
 # 更新日志
 
-本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.8.5**。
+本仓库 harness 发布面版本以 [CHANGELOG.md](CHANGELOG.md) 为准：**1.8.6**。
 
 | 发布面 | 位置 | 版本 |
 | --- | --- | --- |
-| monorepo 根 | `morning-star`（`package.json`） | **1.8.5** |
-| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.8.5** |
-| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.8.5** |
-| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.8.5** |
-| Codex 插件 | `.codex-plugin/plugin.json` | **1.8.5** |
-| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.5** |
-| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.5** |
-| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.5** |
+| monorepo 根 | `morning-star`（`package.json`） | **1.8.6** |
+| CLI | `@mstar-harness/cli`（`packages/cli`） | **1.8.6** |
+| OpenCode 插件 | `@mstar-harness/opencode`（`packages/opencode`） | **1.8.6** |
+| Cursor 插件 | `.cursor-plugin/plugin.json` | **1.8.6** |
+| Codex 插件 | `.codex-plugin/plugin.json` | **1.8.6** |
+| Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.6** |
+| ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.6** |
+| omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.6** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 
 ## [Unreleased]
+
+## [1.8.6] - 2026-08-06
+
+### Harness（派发保真 — invoke 字段完整性门禁）
+
+- 在派发自检处新增**逐项字段完整性门禁**：每条 Task/subagent invoke 必须携带与 `Execute as` 匹配的角色绑定字段（omp `agent` / Cursor `subagent_type` / OpenCode `subagent` / Kimi·ZCode `subagent_type`）。漏写字段（如 omp 漏 `agent` ⇒ 静默回退 generic `task`）现为**派发未完成**——与 paste-only（零 invoke）同级——避免裸 `tasks:[{task:"…"}]` 仅因 invoke 计数 = N 而蒙混过关。N=1 顺序 Review-&-Edit 链显式覆盖（count 门在该处恒过）。
+- `mstar-dispatch-gates`：发送前自检 + 反模式条目；`mstar-host/references/parallel-dispatch.md`：硬规则 + 自检步骤；`mstar-host/references/omp.md`：Review-&-Edit 示例为每轮（architect / writing-specialist）展示完整 `task(...)` 块并显式 `agent`，并加 N=1 gotcha。
+- `.cursor/skills/mstar-routing-eval`：新增回归信号「invoke 角色字段缺失 ⇒ 静默 generic 回退」。
+
+### 版本对齐
+
+- 提升 monorepo 根、`@mstar-harness/opencode`、`@mstar-harness/cli`、Cursor/Codex/Kimi/ZCode/omp 插件清单：**→ 1.8.6**。
 
 ## [1.8.5] - 2026-08-06
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -280,7 +280,7 @@ Register the harness as a marketplace (without the CLI). Create `~/.zcode/cli/pl
       "name": "morning-star-harness",
       "source": { "source": "github", "repo": "btspoony/mstar-harness", "ref": "main" },
       "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "category": "Productivity"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-star",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "private": true,
   "type": "module",
   "main": "packages/opencode/src/mstar.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,14 @@ The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface re
 
 ## [Unreleased]
 
+## [1.8.6] - 2026-08-06
+
+### Changed
+
+- Version alignment with harness **1.8.6** (no CLI API change).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.8.6**.
+
 ## [1.8.5] - 2026-08-06
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/cli",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Morning Star harness installer CLI (OpenCode, Cursor, Codex, ZCode, omp).",
   "license": "MIT",
   "repository": {

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -6,6 +6,15 @@ The monorepo root [CHANGELOG.md](../../CHANGELOG.md) summarizes cross-surface re
 
 ## [Unreleased]
 
+## [1.8.6] - 2026-08-06
+
+### Bundled harness skills (`harness-skills/` at publish)
+
+- Sync dispatch field-completeness gate: `mstar-dispatch-gates` self-check + anti-pattern, `mstar-host/references/parallel-dispatch.md` hard rule + self-check, `mstar-host/references/omp.md` Review-&-Edit example + N=1 gotcha.
+- Version alignment with harness **1.8.6** (no OpenCode package API change).
+
+See root [CHANGELOG.md](../../CHANGELOG.md) **1.8.6**.
+
 ## [1.8.5] - 2026-08-06
 
 ### Bundled harness skills (`harness-skills/` at publish)

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mstar-harness/opencode",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Morning Star harness OpenCode plugin (skills bootstrap and agent loading).",
   "license": "MIT",
   "repository": {

--- a/skills/mstar-dispatch-gates/SKILL.md
+++ b/skills/mstar-dispatch-gates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mstar-dispatch-gates
-description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent、`Execute as` 与 `Delegation`、承接方反递归 NEVER 红线、SDD implement 串行派发、**SDD 路径 plan QC 强制 tri-review（N=3）**、inline 单席 QC 例外、Assignment 文案≠派发、未齐不发。`project-manager` 派发时必读；leaf 动手前必读反递归。worktree 见 `mstar-branch-worktree`；SDD 见 `mstar-sdd`；宿主见 `mstar-host`。
+description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent、`Execute as` 与 `Delegation`、承接方反递归 NEVER 红线、SDD implement 串行派发、**SDD 路径 plan QC 强制 tri-review（N=3）**、inline 单席 QC 例外、Assignment 文案≠派发、未齐不发、**invoke 角色字段必填（漏写=静默 generic 回退=派发未完成）**。`project-manager` 派发时必读；leaf 动手前必读反递归。worktree 见 `mstar-branch-worktree`；SDD 见 `mstar-sdd`；宿主见 `mstar-host`。
 ---
 
 ## Load order（必读顺序）
@@ -58,6 +58,7 @@ description: Morning Star 派发与委派门禁 —— 仅 PM 可增派 subagent
 - **QC 单席（例外）**：`Execution mode: inline`（hotfix 等），或 Assignment 显式 `QC mode: single` / `QC mode: single — override: <reason>` → `qc-specialist` ×1，`N=1`，写 `{SDD_DIR}/review/qc.md`。
 - **QC targeted re-review**：Assignment 含 **`QC re-review: targeted — reviewers: …`** 时，**N** = 所列席位数（1–3），同条消息发满 **N**。
 - **先自检再发送**：发送前核对「Assignment 条数 = 本条消息中的实际 **派发** 调用条数」。
+- **先自检字段再发送（与 count 同级门禁）**：核对**每条** invoke 都携带与 **`Execute as`** 匹配的角色绑定字段——omp **`agent`** / Cursor **`subagent_type`** / OpenCode **`subagent`** / Kimi·ZCode **`subagent_type`**。**漏写或取默认通用值**（omp 漏 `agent` ⇒ 自动回退 generic `task`，无报错）= **派发未完成**，与 paste-only（零 invoke）**同等级**：当场补齐重发，不得进入下一 gate。**N=1 顺序链（Review & Edit）不豁免**——count 门在 N=1 恒过，**字段门是唯一保护**。
 - **前置步骤与派发回合分离（防串行 rollout）**：为派发准备的 **`bash` / `read` / `glob` / `grep`**（如 `merge-base`、`Review range`、`git rev-parse`）**不计入** `N` 次派发；可在上一条仅含准备的消息完成。准备完成后，**下一条派发消息**须**一次性**含 **`N` 次** Task / subagent invoke。**禁止**先发 `1` 次、等返回再补发其余 `N-1` 次。
 - **未齐不发（emit zero until batch-ready）**：需并发 `N≥2` 而当前只能发 `1` 条时，本条应发 **`0` 条派发 invoke`**（可继续 read/bash 补齐），**禁止**「先发一个顶一下」；`N` 份 payload 就绪后**单次消息发满 `N`**。见 **`mstar-host`** → `references/parallel-dispatch.md`（具备 invoke / Task / subagent 工具的宿主共用）。
 
@@ -114,6 +115,7 @@ When **`Execution mode: sdd`** (`mstar-sdd`):
 - Review-and-edit 链未完成即 commit integration 分支；PM 代做专业角色编辑而不 invoke。
 - Phase 1 review-and-edit 链三角色并行派发，或未等上一角色返回即派发下一角色。
 - Assignment 已写、invoke 为零（paste-only）却进入下一 gate。
+- Task/subagent item 漏写角色绑定字段（omp 漏 `agent` / Cursor 漏 `subagent_type` / OpenCode 漏 `subagent`）⇒ **静默回退 generic worker**，却因 count=N 通过而误判「派发完成」；属 paste-only 同级的 **dispatch-incomplete**。N=1 顺序 Review-&-Edit 链最易在此漏字段。
 
 ## References
 

--- a/skills/mstar-host/references/omp.md
+++ b/skills/mstar-host/references/omp.md
@@ -77,6 +77,8 @@ task(
 
 Single-task shorthand may exist depending on host version — always match the live schema. Parallel **N** Morning Star assignees ⇒ **one** `task` call with **N** `tasks[]` entries **or** **N** `task` calls in one assistant message when the host requires that shape. Count emitted dispatches = **N**.
 
+**Construct the envelope first (production cue — prevents the omission at the source, not just at the gate).** When building a `tasks[]` entry, write **`agent`** + **`name`** as the first fields, *before* the long `task` body. The Assignment body is hundreds of lines of structured text and dominates working memory; `agent`/`name` are one-line envelope fields with no intrinsic saliency and no auto-check — writing the body first and the envelope last is how `agent` gets silently dropped (omp then defaults to generic `task`). The pre-send field gate (see **C5** below) catches it, but **envelope-first is the cheaper failure mode**: it makes the high-stakes-but-low-saliency field structural, so it cannot be forgotten by attention drift while authoring the body.
+
 ## Role agents (C5 — hard constraint)
 
 **Live `task` tool schema is SSOT every session.** Exact `agent` names vary by omp version and which `agents/*.md` were discovered after plugin install/link. Read the tool's Available Agents list before dispatch — do not invent names; do not hard-code stale tables over the live list.
@@ -145,7 +147,7 @@ task(
 )
 ```
 
-Review & Edit / Prepare specialist chain (sequential, **N=1** each turn):
+Review & Edit / Prepare specialist chain (sequential, **N=1** each turn — re-set **`agent`** on **every** dispatch; at N=1 the count gate is trivial, so the **field** gate is the only protection):
 
 ```text
 task(
@@ -156,7 +158,18 @@ task(
     task: "<Assignment: Execute as product-manager; Act as + skill load>"
   }]
 )
-# wait for return, then architect, then writing-specialist — each with agent: "<role-id>"
+# pass 2 — architect (re-set agent on EVERY dispatch; a bare tasks:[{task:"…"}] with no agent silently falls back to generic task — C5 anti-pattern)
+task(
+  context: "Review & Edit — architecture",
+  tasks: [{ name: "ReviewEditArchitect", agent: "architect",
+            task: "<Assignment: Execute as architect; Act as + skill load>" }]
+)
+# pass 3 — writing-specialist
+task(
+  context: "Review & Edit — writing",
+  tasks: [{ name: "ReviewEditWriting", agent: "writing-specialist",
+            task: "<Assignment: Execute as writing-specialist; Act as + skill load>" }]
+)
 ```
 
 For explore-only orientation (no Morning Star role deliverable):
@@ -230,3 +243,4 @@ Cannot emit required **N** → **`Blocked`**.
 - omp has no `sessionStart.skill`; new sessions do **not** auto-load PM — invoke `/skill:pm` manually.
 - Do not confuse omp **`task.agent`** with OpenCode **`subagent`** or Cursor **`subagent_type`**.
 - Do not treat Kimi/ZCode “built-ins only → always `coder`/`task`” habits as omp defaults when Morning Star role agents are listed.
+- **Sequential N=1 Review-&-Edit turns are where `agent` gets dropped**: the “all N in one message” pressure is absent and the count gate passes trivially — re-verify **`agent: "<Execute as>"`** on every single dispatch; `tasks:[{task:"…"}]` with no `agent` is a silent generic fallback, not a valid role invoke.

--- a/skills/mstar-host/references/parallel-dispatch.md
+++ b/skills/mstar-host/references/parallel-dispatch.md
@@ -15,7 +15,7 @@ Printing `## Assignment` in the main thread **without** matching host invocation
 
 ## Mandatory order (dispatch turn)
 
-1. Finalize all `N` Assignment payloads (after any prerequisite turn).
+1. Finalize all `N` Assignment payloads (after any prerequisite turn). **Build each invoke entry envelope-first**: set the role-binding field (omp `agent` / Cursor `subagent_type` / OpenCode `subagent` / Kimi·ZCode `subagent_type`) + `name` *before* writing the long Assignment body — the body is high-volume and will crowd out the one-line envelope field from working memory.
 2. Count distinct `Execute as` sessions (`N`).
 3. Issue **`N` host invocations first** — OpenCode: **N `task` tool** calls with **subagent**; Cursor: **N `Task`** with `subagent_type` (JSON field shape → `cursor.md` § Task invoke schema); Kimi: **N `Agent`** calls (each prompt carries **Act as** + skill load; `subagent_type` ∈ {`coder`,`explore`,`plan`} only — see `kimi.md` C5/C5b); omp: **one `task` call with N `tasks[]`** (or N `task` calls) with `agent` = live-schema role id matching `Execute as` when listed (else generic built-in) + **Act as** / skill load (see `omp.md` C5/C5b); each with one Assignment body. For parallel work, **all `N` tool calls in one assistant message** when the host allows.
 4. Optionally post a short **Status Update** after invocations (audit trail only — does not replace step 3).
@@ -26,6 +26,7 @@ Printing `## Assignment` in the main thread **without** matching host invocation
 - Do not end the dispatch turn until **`N` invocations emitted**, or mark `Blocked` / `dispatch incomplete`.
 - Dual-track implement: **`N = 2` ⇒ two invocations in one message** when parallel is required.
 - Status Update on dispatch turns: **`Subagent invokes issued: N`** (must match Assignment count). If Assignments were written but `N = 0` → **`dispatch failed — paste-only`**; fix next message.
+- **Per-item field completeness (same severity as paste-only)**: every invocation must carry the role-binding field set to **`Execute as`** — omp **`agent`** / Cursor **`subagent_type`** / OpenCode **`subagent`** / Kimi·ZCode **`subagent_type`**. A missing field (e.g. omp omitting `agent` ⇒ silent generic `task` fallback) = **dispatch incomplete** even though count = N passes. Sequential **N=1** Review-&-Edit turns are not exempt — re-set the field on **every** dispatch.
 
 ## QC default (initial wave)
 
@@ -62,5 +63,6 @@ Formal iteration Phase 2 uses the same SDD + tri rule — not a separate carve-o
 1. Required assignments this turn? (`N`)
 2. Prerequisite-only message? → **zero** batch dispatches unless `N = 1`.
 3. Dispatch message contains **exactly `N`** invocation calls?
-4. QC initial: **`Execution mode: sdd`** → **N=3**? **`inline`** → **N=1**? Targeted re-review → **N** = Assignment reviewer count?
-5. SDD implement → **serial** (never batch implementers); sticky = **resume** same implementer, not parallel
+4. **Each** invocation carries its role-binding field set to **`Execute as`** (omp `agent` / Cursor `subagent_type` / OpenCode `subagent` / Kimi·ZCode `subagent_type`)? A bare `task`/prompt item with no role field = **incomplete**, even at **N=1**.
+5. QC initial: **`Execution mode: sdd`** → **N=3**? **`inline`** → **N=1**? Targeted re-review → **N** = Assignment reviewer count?
+6. SDD implement → **serial** (never batch implementers); sticky = **resume** same implementer, not parallel


### PR DESCRIPTION
## Problem

On omp, PM dispatch silently fell back to generic `task` workers (`RetiredCondor`, `HotReindeer`, `BiologicalMite`) across sequential Review-&-Edit passes when the `agent` field was omitted. omp's `task.agent` defaults to `"task"` (generic worker) with no error, so a bare `tasks:[{task:"…"}]` ran as a generic worker instead of the intended role (`architect`).

## Root cause

The two dispatch SSOTs (`mstar-dispatch-gates`, `mstar-host/references/parallel-dispatch.md`) enforced invoke **COUNT** but never per-item **FIELD COMPLETENESS**. The `agent` anti-pattern lived only as prose in `omp.md`, never wired into a pre-send gate.

At **N=1** (sequential Review-&-Edit chains: product-manager → architect → writing-specialist), the count gate is vacuous — it always passes — so when the PM dropped the `agent` field there was no protection. This is confirmed by the failing PM's own self-diagnosis: the error only stopped when it made "write `agent`+`name` first, before the long body" a fixed mechanical action.

## Fix — two complementary levers

**1. Field-completeness gate (catch at send).** Every Task/subagent invoke must carry the role-binding field matching `Execute as` (omp `agent` / Cursor `subagent_type` / OpenCode `subagent` / Kimi·ZCode `subagent_type`). A missing field = **dispatch incomplete** — same severity as paste-only zero-invoke — so a bare `tasks:[{task:"…"}]` no longer passes just because count = N. N=1 sequential chains are explicitly covered.
- `mstar-dispatch-gates/SKILL.md`: pre-send self-check line + anti-pattern bullet + description clause
- `mstar-host/references/parallel-dispatch.md`: hard rule + self-check step 4 (renumbered)
- `mstar-host/references/omp.md`: Review-&-Edit example now shows a full `task(...)` block per pass with `agent` set + N=1 gotcha
- `.cursor/skills/mstar-routing-eval/SKILL.md`: regression signal

**2. Envelope-first construction order (prevent at source).** Build each `tasks[]` entry by writing `agent` + `name` as the first fields, *before* the long Assignment body. The body is hundreds of lines and dominates working memory; `agent`/`name` are one-line envelope fields with no intrinsic saliency and no auto-check. Writing body-first is how `agent` gets silently dropped. Envelope-first makes the high-stakes-but-low-saliency field **structural** — the cheaper failure mode, and empirically what stopped the recurrence.

## SkillsBench compliance

Encodes an observed, recurring failure + the agent's proven cure (not model-generated opinion). Compact/programmatic: no new skills or sections; added to the pre-send self-check the PM already runs. Only knowledge gap encoded: the gate + construction order at dispatch moment, not generic facts.

## Validation

- `bun run release:validate -- v1.8.6` ✅ (all surfaces aligned)
- All surfaces bumped 1.8.5 → 1.8.6; bilingual changelog [1.8.6] sections + registry headers aligned (avoids #58-class drift)

## Release

After merge: signed annotated tag `v1.8.6` → GitHub Actions release workflow.