### PR TITLE
fix(sdd): host-neutral dispatch templates + trim envelope-first prose

### DIFF
--- a/.changes/unreleased/sdd-dispatch-host-neutral-templates.md
+++ b/.changes/unreleased/sdd-dispatch-host-neutral-templates.md
@@ -1,0 +1,11 @@
+---
+category: Harness
+packages: root
+---
+
+- Made the SDD dispatch templates **host-neutral** so they no longer prime a single host's tool schema: `implementer-prompt.md`, `task-reviewer-prompt.md`, and `implementer-continuation-prompt.md` now use `Dispatch:` / `Role:` / `Name:` / `Prompt body:` labels with an inline host-field map (`omp agent / Cursor subagent_type / OpenCode subagent → mstar-host C5`) instead of Cursor-only fields (`subagent_type`, `description`, `prompt`). The L2 task reviewer template now states the omp `agent` value directly (`reviewer` or `task` + C5b), closing the mapping confusion that produced generic-worker fallbacks under SDD.
+- Trimmed the **envelope-first** rationale repeated across `mstar-host/references/omp.md` and `parallel-dispatch.md` to a one-line mechanical rule + SSOT pointer (the long-body prose was itself contributing to attention crowding), and added the L2 reviewer `agent` mapping to the omp SDD section.
+
+<!-- CN -->
+- 将 SDD 派发模板改为**宿主中立**，不再固定引发单一宿主工具 schema：`implementer-prompt.md`、`task-reviewer-prompt.md`、`implementer-continuation-prompt.md` 改用 `Dispatch:` / `Role:` / `Name:` / `Prompt body:` 标签 + 内联宿主字段映射（`omp agent / Cursor subagent_type / OpenCode subagent → mstar-host C5`），替代 Cursor 专有字段（`subagent_type`、`description`、`prompt`）。L2 任务 reviewer 模板现直接给出 omp `agent` 取值（`reviewer` 或 `task` + C5b），消除 SDD 下导致 generic worker 回退的映射困惑。
+- 精简 `mstar-host/references/omp.md` 与 `parallel-dispatch.md` 中**envelope-first** 的重复论述为单行机械规则 + SSOT 指针（长段散文本身会加剧注意力挤占），并在 omp SDD 段补充 L2 reviewer `agent` 映射。

--- a/skills/mstar-host/references/omp.md
+++ b/skills/mstar-host/references/omp.md
@@ -77,7 +77,7 @@ task(
 
 Single-task shorthand may exist depending on host version — always match the live schema. Parallel **N** Morning Star assignees ⇒ **one** `task` call with **N** `tasks[]` entries **or** **N** `task` calls in one assistant message when the host requires that shape. Count emitted dispatches = **N**.
 
-**Construct the envelope first (production cue — prevents the omission at the source, not just at the gate).** When building a `tasks[]` entry, write **`agent`** + **`name`** as the first fields, *before* the long `task` body. The Assignment body is hundreds of lines of structured text and dominates working memory; `agent`/`name` are one-line envelope fields with no intrinsic saliency and no auto-check — writing the body first and the envelope last is how `agent` gets silently dropped (omp then defaults to generic `task`). The pre-send field gate (see **C5** below) catches it, but **envelope-first is the cheaper failure mode**: it makes the high-stakes-but-low-saliency field structural, so it cannot be forgotten by attention drift while authoring the body.
+**Envelope-first**: write `agent` + `name` as the first fields of each `tasks[]` entry, before the long `task` body — the body crowds them out and `agent` gets silently dropped (omp defaults to generic `task`, no error). SSOT → `parallel-dispatch.md` § Mandatory order.
 
 ## Role agents (C5 — hard constraint)
 
@@ -150,26 +150,13 @@ task(
 Review & Edit / Prepare specialist chain (sequential, **N=1** each turn — re-set **`agent`** on **every** dispatch; at N=1 the count gate is trivial, so the **field** gate is the only protection):
 
 ```text
+# pass 1 — product-manager
 task(
   context: "Review & Edit — product scope",
-  tasks: [{
-    name: "ReviewEditProduct",
-    agent: "product-manager",
-    task: "<Assignment: Execute as product-manager; Act as + skill load>"
-  }]
+  tasks: [{ name: "ReviewEditProduct", agent: "product-manager",
+            task: "<Assignment: Execute as product-manager; Act as + skill load>" }]
 )
-# pass 2 — architect (re-set agent on EVERY dispatch; a bare tasks:[{task:"…"}] with no agent silently falls back to generic task — C5 anti-pattern)
-task(
-  context: "Review & Edit — architecture",
-  tasks: [{ name: "ReviewEditArchitect", agent: "architect",
-            task: "<Assignment: Execute as architect; Act as + skill load>" }]
-)
-# pass 3 — writing-specialist
-task(
-  context: "Review & Edit — writing",
-  tasks: [{ name: "ReviewEditWriting", agent: "writing-specialist",
-            task: "<Assignment: Execute as writing-specialist; Act as + skill load>" }]
-)
+# repeat for architect, writing-specialist, … — each a separate N=1 dispatch with agent re-set
 ```
 
 For explore-only orientation (no Morning Star role deliverable):
@@ -203,7 +190,7 @@ Cannot emit required **N** → **`Blocked`**.
 
 ### SDD implement (serial)
 
-- **`Execution mode: sdd`**: one implementer `task` entry per task id with `agent` matching the implementer role when listed; task reviewer = new entry (no sticky resume unless host resume/id is available and recorded). Serial rule → **`parallel-dispatch.md`** § SDD implement.
+- **`Execution mode: sdd`**: one implementer `task` entry per task id with `agent` matching the implementer role when listed; task reviewer = new entry with `agent: "reviewer"` (omp L2 review; not qc-specialist*) or `agent: "task"` as last resort + C5b — no sticky resume unless host resume/id is available and recorded. Serial rule → **`parallel-dispatch.md`** § SDD implement.
 - **Never** multiple implementer entries in one message for the same plan.
 
 ## Clarify

--- a/skills/mstar-host/references/parallel-dispatch.md
+++ b/skills/mstar-host/references/parallel-dispatch.md
@@ -15,7 +15,7 @@ Printing `## Assignment` in the main thread **without** matching host invocation
 
 ## Mandatory order (dispatch turn)
 
-1. Finalize all `N` Assignment payloads (after any prerequisite turn). **Build each invoke entry envelope-first**: set the role-binding field (omp `agent` / Cursor `subagent_type` / OpenCode `subagent` / Kimi·ZCode `subagent_type`) + `name` *before* writing the long Assignment body — the body is high-volume and will crowd out the one-line envelope field from working memory.
+1. Finalize all `N` Assignment payloads (after any prerequisite turn). **Build each invoke entry envelope-first**: set the role-binding field (omp `agent` / Cursor `subagent_type` / OpenCode `subagent` / Kimi·ZCode `subagent_type`) + `name` *before* writing the long Assignment body.
 2. Count distinct `Execute as` sessions (`N`).
 3. Issue **`N` host invocations first** — OpenCode: **N `task` tool** calls with **subagent**; Cursor: **N `Task`** with `subagent_type` (JSON field shape → `cursor.md` § Task invoke schema); Kimi: **N `Agent`** calls (each prompt carries **Act as** + skill load; `subagent_type` ∈ {`coder`,`explore`,`plan`} only — see `kimi.md` C5/C5b); omp: **one `task` call with N `tasks[]`** (or N `task` calls) with `agent` = live-schema role id matching `Execute as` when listed (else generic built-in) + **Act as** / skill load (see `omp.md` C5/C5b); each with one Assignment body. For parallel work, **all `N` tool calls in one assistant message** when the host allows.
 4. Optionally post a short **Status Update** after invocations (audit trail only — does not replace step 3).

--- a/skills/mstar-sdd/SKILL.md
+++ b/skills/mstar-sdd/SKILL.md
@@ -45,7 +45,7 @@ Batch all findings for the human in one message. If clean, proceed silently.
    - **`SDD implementer session: fresh`** (default) — new subagent; templates: `references/implementer-prompt.md`
    - **`SDD implementer session: sticky`** — first task: same as fresh + write `{SDD_DIR}/implementer-session.json` with `host_agent_id`; later tasks: host **resume** + `references/implementer-continuation-prompt.md` (see **`references/sticky-implementer-session.md`**)
 5. On `DONE`: `scripts/review-package BASE HEAD` → diff file
-6. Dispatch **fresh** task reviewer — **`subagent_type: generalPurpose`** (L2; **not** `qc-specialist*`) — brief, report, diff, Global Constraints — `references/task-reviewer-prompt.md` — **never** sticky resume for reviewers
+6. Dispatch **fresh** task reviewer — role **`generalPurpose`** (L2; **not** `qc-specialist*`; host role field → `mstar-host` C5) — brief, report, diff, Global Constraints — `references/task-reviewer-prompt.md` — **never** sticky resume for reviewers
 7. Fix loop for Critical/Important; re-review until approved
 8. Append `progress.md`; update `status.json` `task_commits[]` and `implementer-session.json` `last_task` if sticky
 9. Next task

--- a/skills/mstar-sdd/references/implementer-continuation-prompt.md
+++ b/skills/mstar-sdd/references/implementer-continuation-prompt.md
@@ -3,11 +3,11 @@
 Use when PM continues **`SDD implementer session: sticky`** for Task N>1. Host: **resume** same agent when supported (`sticky-implementer-session.md`).
 
 ```
-Task / subagent:
-  resume: [HOST_AGENT_ID from implementer-session.json]
-  description: "SDD continue Task N: <name>"
-  model: [same tier as session start unless PM upgrades]
-  prompt: |
+Dispatch:
+  Resume: [HOST_AGENT_ID from implementer-session.json]
+  Name: <CamelCaseId>                 # omp/Cursor name
+  Model: [same tier as session start unless PM upgrades]
+  Prompt body:
     <SUBAGENT-STOP> Skip PM orchestration skills. You are a leaf implementer continuing a sticky SDD session.</SUBAGENT-STOP>
 
     Continue as the same implementer on plan <plan-id>, Working branch: <branch>.

--- a/skills/mstar-sdd/references/implementer-prompt.md
+++ b/skills/mstar-sdd/references/implementer-prompt.md
@@ -5,10 +5,11 @@ Use when PM dispatches an SDD implementer (`mstar-sdd`) — **first task** or **
 For **sticky** continuation (task 2+), use **`implementer-continuation-prompt.md`** instead.
 
 ```
-Task / subagent:
-  description: "SDD implement Task N: <name>"
-  model: [REQUIRED — per Model tier in Assignment and mstar-sdd SKILL]
-  prompt: |
+Dispatch:
+  Role: <Execute as role-id>          # omp agent / Cursor subagent_type / OpenCode subagent → mstar-host C5
+  Name: <CamelCaseId>                 # omp/Cursor name
+  Model: [REQUIRED — per Model tier in Assignment and mstar-sdd SKILL]
+  Prompt body:
     <SUBAGENT-STOP> Skip PM orchestration skills. You are a leaf implementer.</SUBAGENT-STOP>
 
     You are implementing Task N: <name>

--- a/skills/mstar-sdd/references/task-reviewer-prompt.md
+++ b/skills/mstar-sdd/references/task-reviewer-prompt.md
@@ -3,11 +3,12 @@
 One reviewer per task: spec compliance + code quality (`mstar-sdd`).
 
 ```
-Task / subagent:
-  subagent_type: generalPurpose
-  description: "SDD review Task N (spec + quality)"
-  model: [REQUIRED — standard tier default; capable if diff is large/subtle]
-  prompt: |
+Dispatch:
+  Role: generalPurpose                # L2 SDD task reviewer; NOT qc-specialist*
+                                      # omp: agent = "reviewer" or "task" + C5b; Cursor: subagent_type = "generalPurpose" → mstar-host C5
+  Name: <CamelCaseId>                 # omp/Cursor name
+  Model: [REQUIRED — standard tier default; capable if diff is large/subtle]
+  Prompt body:
     <SUBAGENT-STOP> Skip PM orchestration. Read-only review.</SUBAGENT-STOP>
 
     Review one task implementation: spec compliance first, then quality.


### PR DESCRIPTION
## What & why

Follow-up to the **1.8.6 dispatch-fidelity fix** (PR #59). That release closed two of three co-contributors to the omp `agent`-field-drop failure (attention crowding → envelope-first gate; N=1 vacuousness → field gate), but left the third — **schema priming** — unaddressed.

The agent's own self-diagnosis (in the failure transcript that drove 1.8.6) flagged it explicitly: *the SDD templates use Cursor field names (`subagent_type`, `description`, `prompt`), so on omp the model's JSON-schema model never activates `agent`/`name`*. It then spent 20+ lines confused mapping `generalPurpose` to omp (transcript L56-104). 1.8.6 did not fix this surface.\n
This PR closes that gap and trims the verbose envelope-first prose that 1.8.6 added (the long-body rationale was itself contributing to the attention-crowding failure mode).

## Changes (6 files, net −11 lines)

**Schema-priming fix (root cause #2):**
- `implementer-prompt.md` / `task-reviewer-prompt.md` / `implementer-continuation-prompt.md` → host-neutral `Dispatch:` / `Role:` / `Name:` / `Prompt body:` labels with an inline host-field map (`# omp agent / Cursor subagent_type / OpenCode subagent → mstar-host C5`) instead of Cursor-only fields.
- `task-reviewer-prompt.md` now states the omp `agent` value directly (`reviewer` or `task` + C5b) — removes the L2-mapping confusion.
- `sdd/SKILL.md` L48: host-neutral role reference.

**Redundancy trim (root cause #1):**
- `omp.md`: verbose envelope-first paragraph → one-line mechanical rule + SSOT pointer; Review-&-Edit example compressed from 3 redundant passes to 1 + repeat note.
- `parallel-dispatch.md`: SSOT rationale tail trimmed.
- `omp.md` SDD section: added L2 reviewer `agent` mapping (was missing — the exact gap that caused the transcript confusion).

## Evidence

- **Before**: SDD templates primed `subagent_type`/`description`/`prompt`; on omp the model composed `tasks:[{task:"…"}]` with no `agent` (silent generic fallback, animal names). Transcript confirms 4+ failed attempts in one session.
- **After**: templates use host-neutral labels + explicit field map; the model cannot reach a dispatch without seeing the omp `agent` field name in the template. L2 reviewer mapping is now explicit, removing the `generalPurpose`→omp confusion.
- No new skills/sections; no runtime behavior change for Cursor (field map comment is additive).

## Fragment

`.changes/unreleased/sdd-dispatch-host-neutral-templates.md` added per the changelog-fragment workflow.

## Checklist (AGENTS.md quality gate)

- [x] Solves a real, observed maintenance problem (transcript-evidenced schema priming).
- [x] Not a duplicate — 1.8.6 addressed the other two root causes; this is the remaining one.
- [x] Belongs in core harness (dispatch SSOT).
- [x] Surgical — only the dispatch-template + envelope-prose surfaces touched.
- [x] Behavior-shaping change with transcript evidence (not a style-only rewrite).