### PR TITLE
fix(ci): grant issues:write so release-prep can create/apply labels

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: release-prep


### PR DESCRIPTION
## What & why

Release prep run #1 failed at step "Open or update release PR":

```
could not add label: 'release' not found
```

[Run 31077229281](https://github.com/btspoony/mstar-harness/actions/runs/31077229281)

**Root cause:** the `permissions:` block had `contents: write` + `pull-requests: write` but **not** `issues: write`. Labels are governed by the **issues** permission scope. The "Ensure release label" step (`gh label create release --if-not-exists … || true`) failed on permission denial, `|| true` swallowed the error, and the next step's `gh pr create --label release` then failed because the label didn't exist.

## Fix

One line — add `issues: write`:

```diff
 permissions:
   contents: write
   pull-requests: write
+  issues: write
```

## Unblocked

The `release` label was also **created manually** (color `0E8A16`) so the current v1.8.7 prep can re-run immediately without waiting for this PR to merge. This commit prevents recurrence on fresh repos.

## Verification

- Confirmed label was absent before fix (`gh api …/labels/release` → 404).
- Confirmed `release` label now exists after manual creation.
- No other workflow uses labels (`release.yml` has no label ops).