### PR TITLE
docs(iteration): Phase 5 edits directly on integration checkout

### DIFF
--- a/.changes/unreleased/phase5-direct-integration-checkout.md
+++ b/.changes/unreleased/phase5-direct-integration-checkout.md
@@ -1,0 +1,9 @@
+---
+category: Harness
+packages: root, opencode
+---
+
+- **Phase 5 checkout**: merge-ready product fixes edit **directly** on the control / `spec_integration_branch` checkout; **forbid** opening a separate Phase 5 feature/fix worktree or applying Phase 2's "no product edits on control" rule. SSOT stays in `mstar-iteration` (`phase-4-5-pr-delivery` §5.0); **not** in the general `mstar-branch-worktree` skill.
+
+<!-- CN -->
+- **Phase 5 checkout**：merge-ready 产品修复直接在 control / `spec_integration_branch` checkout 上改；**禁止**另开 Phase 5 feature/fix worktree，也**禁止**套用 Phase 2「control 禁止产品编辑」。SSOT 在 `mstar-iteration`（`phase-4-5-pr-delivery` §5.0）；**不**写入通用 `mstar-branch-worktree` skill。

--- a/commands/iteration-drive.md
+++ b/commands/iteration-drive.md
@@ -101,7 +101,7 @@ Helper 搜索路径 → **`mstar-iteration/references/phase5-helper-discovery.md
 
 ### 5.1 Loop + review fix hygiene（all modes）
 
-Execute **`mstar-iteration` §5.1 loop**（`references/phase-4-5-pr-delivery.md` §5.1）：status（`gh pr view <number> --json mergeable,mergeStateStatus,statusCheckRollup,reviewDecision` 或宿主等价 API）→ merge conflicts → unresolved reviews → CI → **§5.1a idle push**（一批修复一次 push）→ mode-specific pass（babysit SKILL / greploop / fallback）→ §5.1 review fix hygiene（**comment on same thread + resolve**）→ repeat until §5.5。Fixes **push 到 `spec_integration_branch`**（PR head）；禁止另开分支替代。产品代码修复 → **dispatch** dev/ops；PM 线程不代写。**禁止**为「让 CI 变绿」而改 workflow，除非用户明确授权。多轮仍 blocked → 升级用户。
+Execute **`mstar-iteration` §5.1 loop**（`references/phase-4-5-pr-delivery.md` §5.1）：status（`gh pr view <number> --json mergeable,mergeStateStatus,statusCheckRollup,reviewDecision` 或宿主等价 API）→ merge conflicts → unresolved reviews → CI → **§5.1a idle push**（一批修复一次 push）→ mode-specific pass（babysit SKILL / greploop / fallback）→ §5.1 review fix hygiene（**comment on same thread + resolve**）→ repeat until §5.5。Fixes **push 到 `spec_integration_branch`**（PR head）；禁止另开分支替代。**Checkout（HARD，§5.0）**：直接在 control / 集成分支 checkout 上修；**禁止**另开 Phase 5 fix worktree，**禁止**套用 Phase 2 control 产品编辑禁令。产品代码修复 → **dispatch** dev/ops（Assignment cwd = control）；PM 线程不代写。**禁止**为「让 CI 变绿」而改 workflow，除非用户明确授权。多轮仍 blocked → 升级用户。
 
 ### 5.2 Phase 5 exit checklist（iteration-drive Done）
 

--- a/skills/mstar-iteration/SKILL.md
+++ b/skills/mstar-iteration/SKILL.md
@@ -355,7 +355,7 @@ Iteration Phase 2 附加：
 
 **Phase 4**（开 PR）与 **Phase 5**（merge-ready loop）完整流程（§4、§5.0、§5.1a push cadence、§5.1 loop、§5.2 exit checklist）→ **`references/phase-4-5-pr-delivery.md`**。
 
-**关键定位（hard）**：Phase 4 开 PR **≠** 迭代交付完成；必须完成 Phase 5 §5.2 merge-ready exit。**Push cadence（§5.1a HARD）**：本地可提前修，**禁止**在 CI / AI review 波次未结束时 `git push`。
+**关键定位（hard）**：Phase 4 开 PR **≠** 迭代交付完成；必须完成 Phase 5 §5.2 merge-ready exit。**Push cadence（§5.1a HARD）**：本地可提前修，**禁止**在 CI / AI review 波次未结束时 `git push`。**Checkout（HARD）**：Phase 5 修复直接在 control / `spec_integration_branch` 上做；**禁止**另开 Phase 5 fix worktree，**禁止**套用 Phase 2「control 禁止产品编辑」（细则 → **`references/phase-4-5-pr-delivery.md`** §5.0）。
 
 ---
 
@@ -379,6 +379,7 @@ Iteration Phase 2 附加：
 
 - **不要将 Phase 4 开 PR 等同于迭代交付完成** — 必须完成 Phase 5 §5.2 merge-ready loop
 - **不要在 Phase 5 CI 仍跑或 AI review 波次未结束时 push**（§5.1a）— 本地可提前修，push 等 idle
+- **不要为 Phase 5 另开 feature/fix worktree**，也不要把 Phase 2 control 产品编辑禁令套到 Phase 5 — 直接在集成分支 checkout 上修
 - **不要在缺 `iteration_base_branch` / `target_branch` 时默认 `main` / `master`**
 - **不要在 iteration-start §1.6 由 product/architect 向 `{KNOWLEDGE_DIR}/` 新增**（知识 → iteration-close **`mstar-compound`**）
 - **不要在 per-plan Done 后立即 compound** — 等 iteration-close 统一做

--- a/skills/mstar-iteration/references/phase-2-worktree-lease.md
+++ b/skills/mstar-iteration/references/phase-2-worktree-lease.md
@@ -18,6 +18,8 @@ required.
 Phase 1 Review & Edit may stay on the primary checkout. The control-worktree gate
 starts at **Phase 2 entry**.
 
+**Phase scope**：本参考仅约束 **Phase 2**（含 serial integration merge 与「control 禁止产品编辑 / 每 plan feature worktree」）。**Phase 5** PR merge-ready 修复 **不**沿用该产品编辑隔离——直接在 control / `spec_integration_branch` 上改，**禁止**另开 Phase 5 fix worktree → **`phase-4-5-pr-delivery.md`** §5.0。
+
 ## Control worktree (Phase 2 entry)
 
 1. Resolve all active plans' `metadata.spec_integration_branch` to the **same**

--- a/skills/mstar-iteration/references/phase-4-5-pr-delivery.md
+++ b/skills/mstar-iteration/references/phase-4-5-pr-delivery.md
@@ -23,7 +23,8 @@
 ### 5.0 Phase boundary
 
 - Phase 5 在 PR head（`spec_integration_branch`）上 push 修复；**禁止**另开替代分支
-- 产品代码修复 → PM **dispatch** dev/ops（`mstar-dispatch-gates`）；PM 线程不代写实现
+- **Checkout / worktree（HARD）**：Phase 5 是 PR 级 **hotfix** loop，**不是** Phase 2 plan 实现。修复直接在 **control worktree**（已检出 `spec_integration_branch` 的 checkout）上编辑、commit、再按 §5.1a push。**禁止**为 Phase 5 另开 feature / fix worktree；**禁止**把 Phase 2「control 禁止产品编辑 / 须 feature worktree」套用到 Phase 5。另开 worktree 浪费时间、磁盘与计算，与 Phase 5 快速收敛 CI/review 的目标相悖。
+- 产品代码修复 → PM **dispatch** dev/ops（`mstar-dispatch-gates`）；Assignment **`Worktree path`** / cwd = control（`metadata.control_worktree_path` 或当前已在集成分支上的 checkout）；PM 线程不代写实现
 - 禁止为「让 CI 变绿」而改 workflow，除非用户明确授权
 - **Push cadence** → **§5.1a**（本地可提前修；**禁止**在 CI / AI review 波次未结束时 push）
 
@@ -66,7 +67,7 @@
 | 2 | `greploop` | **Optional** — only when the **repo** uses Greptile / has `greploop` available; then run for Greptile **5/5** in addition to babysit/`*-babysit` (or fallback) gates |
 | 3 | neither | Command fallback = babysit-equivalent CI + reviews gates |
 
-When both babysit/`*-babysit` and `greploop` apply: **babysit/`*-babysit` first**（CI + reviews），then optional greploop for Greptile score. Discovery paths → host `commands/iteration-drive` / `iteration-loop` Phase 5.
+When both babysit/`*-babysit` and greploop apply: **babysit/`*-babysit` first**（CI + reviews），then optional greploop for Greptile score. Discovery paths → host `commands/iteration-drive` / `iteration-loop` Phase 5.
 
 ### 5.2 Phase 5 exit checklist（迭代交付完成）
 


### PR DESCRIPTION
## Summary
- Clarify Phase 5 merge-ready hotfix checkout: edit/commit on the control / `spec_integration_branch` checkout; do not open a Phase 5 feature/fix worktree.
- Scope Phase 2 worktree lease so its “no product edits on control” rule is not applied to Phase 5.
- Keep SSOT in `mstar-iteration` (not the general `mstar-branch-worktree` skill); add changelog fragment.

## Test plan
- [ ] Read `skills/mstar-iteration/references/phase-4-5-pr-delivery.md` §5.0 — checkout HARD rule present
- [ ] Confirm `skills/mstar-branch-worktree/SKILL.md` has no Phase 5 exception
- [ ] After merge: `git -C ~/.cursor/plugins/local/morning-star-harness pull` so Cursor sessions pick up the rule