### PR TITLE
feat: Agent Plugins v1.0.0 portable package support

### DIFF
--- a/.changes/unreleased/agent-plugins-v1.md
+++ b/.changes/unreleased/agent-plugins-v1.md
@@ -1,0 +1,8 @@
+---
+packages: root, cli
+---
+
+- Added a portable **Agent Plugins v1.0.0** manifest (`plugin.json`) at the repo root, aligned with the CLI release surface (`skills/` is the Agent Skills component), plus `mstar-harness plugin validate` to check the package (including `mcp.json` / `skills/`) against the Agent Plugins v1.0.0 spec.
+
+<!-- CN -->
+- 在仓库根新增便携式 **Agent Plugins v1.0.0** manifest（`plugin.json`），与 CLI 发布面保持一致（`skills/` 为 Agent Skills 组件），并新增 `mstar-harness plugin validate` 按 Agent Plugins v1.0.0 规范校验插件包（含 `mcp.json` / `skills/`）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ When a change affects shared harness behavior, treat OpenCode, Cursor, Codex, Ki
 
 ## Release Process
 
-Releases are PR-driven and mostly automated. Every release ships one version across all 9 surfaces (root + 2 npm packages + 6 plugin manifests + INSTALL.md marketplace example).
+Releases are PR-driven and mostly automated. Every release ships one version across all 10 surfaces (root + 2 npm packages + 7 plugin manifests [6 host + portable Agent Plugins] + INSTALL.md marketplace example).
 
 ### 1. During development — add a changelog fragment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this repository are documented here. Published harness su
 | Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.8** |
 | ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.8** |
 | omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.8** |
-| Agent Plugins manifest | plugin.json | **1.8.8** |
+| Agent Plugins manifest | `plugin.json` | **1.8.8** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this repository are documented here. Published harness su
 | Kimi plugin | `.kimi-plugin/plugin.json` | **1.8.8** |
 | ZCode plugin | `.zcode-plugin/plugin.json` | **1.8.8** |
 | omp plugin | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.8** |
+| Agent Plugins manifest | plugin.json | **1.8.8** |
 
 Package-specific histories: [`packages/cli/CHANGELOG.md`](packages/cli/CHANGELOG.md), [`packages/opencode/CHANGELOG.md`](packages/opencode/CHANGELOG.md).
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -12,7 +12,7 @@
 | Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.8** |
 | ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.8** |
 | omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.8** |
-| Agent Plugins 清单 | plugin.json | **1.8.8** |
+| Agent Plugins 清单 | `plugin.json` | **1.8.8** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -12,6 +12,7 @@
 | Kimi 插件 | `.kimi-plugin/plugin.json` | **1.8.8** |
 | ZCode 插件 | `.zcode-plugin/plugin.json` | **1.8.8** |
 | omp 插件 | `.omp-plugin/plugin.json` / `.claude-plugin/plugin.json` | **1.8.8** |
+| Agent Plugins 清单 | plugin.json | **1.8.8** |
 
 各包独立日志：[packages/cli/CHANGELOG.md](packages/cli/CHANGELOG.md)、[packages/opencode/CHANGELOG.md](packages/opencode/CHANGELOG.md)。
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -351,6 +351,20 @@ omp plugin source in this repository:
 - Plugin commands: `commands/`
 - Plugin agents: `agents/` (discovered into live `task.agent` after install/link + reload; prefer `agent: "<role-id>"`, keep C5b skill load — see `omp.md` C5/C5b)
 
+### Agent Plugins (generic)
+
+Install this repo as a portable [Agent Plugins v1.0.0](https://agent-plugins.org) package (no host-specific glue):
+
+```bash
+git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness
+```
+
+Point any Agent Plugins v1.0.0 conformant client at that directory: root `plugin.json` is the portable manifest and `skills/` is the Agent Skills component. Validate:
+
+```bash
+npx @mstar-harness/cli plugin validate --root ~/.mstar/harness
+```
+
 ## Post-install
 
 1. **Enter PM orchestration**

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ npx @mstar-harness/cli init
 | Kimi | Kimi TUI: `/plugins install https://github.com/btspoony/mstar-harness` → `/plugins reload` |
 | ZCode | `npx @mstar-harness/cli init --target zcode` then install **morning-star-harness** in ZCode → Settings → Plugin Management |
 | Codex | `npx @mstar-harness/cli init --target codex` then `codex plugin add morning-star-harness --marketplace personal` |
+| Generic (Agent Plugins v1) | point any Agent Plugins v1.0.0 conformant client at this repo root (`plugin.json` + `skills/` are the portable package) |
+
+The repo ships a portable **Agent Plugins v1.0.0** manifest (`plugin.json`) at its root; `skills/` is the Agent Skills component. Verify with `npx @mstar-harness/cli plugin validate`.
 
 Verify: `npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp>`.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -41,6 +41,9 @@ npx @mstar-harness/cli init
 | Kimi | Kimi TUI：`/plugins install https://github.com/btspoony/mstar-harness` → `/plugins reload` |
 | ZCode | `npx @mstar-harness/cli init --target zcode`，然后在 ZCode → 设置 → 插件管理安装 **morning-star-harness** |
 | Codex | `npx @mstar-harness/cli init --target codex`，然后 `codex plugin add morning-star-harness --marketplace personal` |
+| Generic（Agent Plugins v1） | 任意 Agent Plugins v1.0.0 兼容客户端直接指向本仓库根（`plugin.json` + `skills/` 即便携包） |
+
+仓库根提供便携式 **Agent Plugins v1.0.0** manifest（`plugin.json`），`skills/` 为 Agent Skills 组件。可用 `npx @mstar-harness/cli plugin validate` 校验。
 
 校验：`npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp>`。
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -144,6 +144,20 @@ Check an existing config:
 
 If validation fails, `doctor` exits with a non-zero status code.
 
+### `mstar-harness plugin validate`
+
+Validate a plugin package against the [Agent Plugins v1.0.0](https://agent-plugins.org/specification) portable format. The root `plugin.json` is checked against the closed manifest schema (required `$schema` and `name`, metadata types, plugin name rules, `extensions`), `mcp.json` per §7.2.1 if present (closed `$schema` + `mcpServers`, stdio/streamable-http/sse server variants, `env`/`cwd`/`url`/`headers` rules), and `skills/` discovery per §6.1 (immediate child directories with `SKILL.md`; frontmatter `name` must equal the directory name and `description` must be non-empty). No schemas are fetched at runtime.
+
+- `npx @mstar-harness/cli plugin validate`
+- `npx @mstar-harness/cli plugin validate --root /path/to/plugin`
+
+Exit codes:
+
+- `0` — conformant: prints `OK <root>: Agent Plugins v1.0.0 conformant`
+- `1` — non-conformant: prints one error line per finding, prefixed with `plugin.json:` / `mcp.json:` / `skills:`
+
+Non-fatal findings are reported separately: an unknown top-level field is reported and ignored (validation continues), and a `skills/` child directory without `SKILL.md` prints a yellow warning without failing validation.
+
 ## What `init` Ensures
 
 OpenCode `init` enforces these baseline requirements in `opencode.json`:
@@ -220,6 +234,10 @@ Or re-run `npx @mstar-harness/cli init --target cursor --scope global`.
 - `--target <agent>`
 - `--scope <global|project>`
 - `--output <path>`
+
+### `plugin validate` options
+
+- `--root <path>`: plugin root directory to validate (default: project root)
 
 ## Development (Repository)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -156,7 +156,7 @@ Exit codes:
 - `0` — conformant: prints `OK <root>: Agent Plugins v1.0.0 conformant`
 - `1` — non-conformant: prints one error line per finding, prefixed with `plugin.json:` / `mcp.json:` / `skills:`
 
-Non-fatal findings are reported separately: an unknown top-level field is reported and ignored (validation continues), and a `skills/` child directory without `SKILL.md` prints a yellow warning without failing validation. Non-conforming skills are skipped the same way (§7.1): a `SKILL.md` with missing or invalid frontmatter, a `name` that does not match its directory or violates Agent Skills name rules, or a missing `description` prints a `skills:` warning and that skill is skipped while validation of the remaining components continues.
+Non-fatal findings are reported separately: an unknown top-level field, a non-object `extensions` field, or a non-object `extensions.<namespace>` entry is reported and ignored (validation continues), and a `skills/` child directory without `SKILL.md` prints a yellow warning without failing validation. Non-conforming skills are skipped the same way (§7.1): a `SKILL.md` with missing or invalid frontmatter, a `name` that does not match its directory or violates Agent Skills name rules, or a missing `description` prints a `skills:` warning and that skill is skipped while validation of the remaining components continues.
 
 ## What `init` Ensures
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -146,7 +146,7 @@ If validation fails, `doctor` exits with a non-zero status code.
 
 ### `mstar-harness plugin validate`
 
-Validate a plugin package against the [Agent Plugins v1.0.0](https://agent-plugins.org/specification) portable format. The root `plugin.json` is checked against the closed manifest schema (required `$schema` and `name`, metadata types, plugin name rules, `extensions`), `mcp.json` per §7.2.1 if present (closed `$schema` + `mcpServers`, stdio/streamable-http/sse server variants, `env`/`cwd`/`url`/`headers` rules), and `skills/` discovery per §6.1 (immediate child directories with `SKILL.md`; frontmatter `name` must equal the directory name and `description` must be non-empty). No schemas are fetched at runtime.
+Validate a plugin package against the [Agent Plugins v1.0.0](https://agent-plugins.org/specification) portable format. The root `plugin.json` is checked against the closed manifest schema (required `$schema` and `name`, metadata types, plugin name rules, `extensions`), `mcp.json` per §7.2.1 if present (closed `$schema` + `mcpServers`, stdio/streamable-http/sse server variants, `env`/`cwd`/`url`/`headers` rules), and `skills/` discovery per §6.1 (immediate child directories with `SKILL.md`; frontmatter `name` must equal the directory name and `description` must be non-empty). No schemas are fetched at runtime. Without `--root`, the command starts at the project root and walks up to the nearest ancestor containing `plugin.json`; use `--root` for an unambiguous target.
 
 - `npx @mstar-harness/cli plugin validate`
 - `npx @mstar-harness/cli plugin validate --root /path/to/plugin`
@@ -237,7 +237,7 @@ Or re-run `npx @mstar-harness/cli init --target cursor --scope global`.
 
 ### `plugin validate` options
 
-- `--root <path>`: plugin root directory to validate (default: project root)
+- `--root <path>`: plugin root directory to validate (default: nearest ancestor of the project root that contains `plugin.json`)
 
 ## Development (Repository)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -156,7 +156,7 @@ Exit codes:
 - `0` — conformant: prints `OK <root>: Agent Plugins v1.0.0 conformant`
 - `1` — non-conformant: prints one error line per finding, prefixed with `plugin.json:` / `mcp.json:` / `skills:`
 
-Non-fatal findings are reported separately: an unknown top-level field is reported and ignored (validation continues), and a `skills/` child directory without `SKILL.md` prints a yellow warning without failing validation.
+Non-fatal findings are reported separately: an unknown top-level field is reported and ignored (validation continues), and a `skills/` child directory without `SKILL.md` prints a yellow warning without failing validation. Non-conforming skills are skipped the same way (§7.1): a `SKILL.md` with missing or invalid frontmatter, a `name` that does not match its directory or violates Agent Skills name rules, or a missing `description` prints a `skills:` warning and that skill is skipped while validation of the remaining components continues.
 
 ## What `init` Ensures
 

--- a/packages/cli/src/agent-plugins.ts
+++ b/packages/cli/src/agent-plugins.ts
@@ -15,9 +15,11 @@ import { readJson } from "./utils";
  *   line carries a `plugin.json:` / `mcp.json:` / `skills:` prefix.
  * - `warnings` — report-and-ignore findings that do not fail validation:
  *   unknown top-level plugin.json fields are reported and ignored while the
- *   plugin keeps loading (§5.2), and non-conforming skills are skipped while
- *   other skills and component types keep loading (§7.1). A child directory
- *   under skills/ without SKILL.md is simply not a skill.
+ *   plugin keeps loading (§5.2), non-object `extensions` fields and namespace
+ *   entries are reported and ignored without validating their contents
+ *   (§5.2/§8.1), and non-conforming skills are skipped while other skills and
+ *   component types keep loading (§7.1). A child directory under skills/
+ *   without SKILL.md is simply not a skill.
  *
  * Validation continues past report-and-ignore findings so one run aggregates
  * every issue; `ok` is false when any error was recorded.
@@ -205,17 +207,17 @@ function validateManifest(manifest: unknown, errors: string[], warnings: string[
     }
   }
 
-  // §5.6/§8.1: extensions is an object of objects; non-object values are
-  // reported and ignored. Member contents are client-defined — never validated.
+  // §5.2/§8.1: a non-object extensions field (or namespace entry) is
+  // report-and-ignore, not fatal. The validator implements no client
+  // namespaces, so all extensions content is unimplemented-namespace content:
+  // report it, ignore it, and never validate its values.
   if (doc.extensions !== undefined) {
     if (!isPlainObject(doc.extensions)) {
-      errors.push('plugin.json: "extensions" must be an object of objects (field ignored)');
+      warnings.push('plugin.json: "extensions" is not an object — ignored');
     } else {
       for (const [namespace, value] of Object.entries(doc.extensions as Record<string, unknown>)) {
         if (!isPlainObject(value)) {
-          errors.push(
-            `plugin.json: "extensions.${namespace}" must be an object (entry ignored)`,
-          );
+          warnings.push(`plugin.json: "extensions.${namespace}" is not an object — ignored`);
         }
       }
     }

--- a/packages/cli/src/agent-plugins.ts
+++ b/packages/cli/src/agent-plugins.ts
@@ -1,0 +1,455 @@
+import fs from "node:fs";
+import path from "node:path";
+import { readJson } from "./utils";
+
+/**
+ * Agent Plugins v1.0.0 conformance validator (https://agent-plugins.org/specification).
+ *
+ * Implements the closed plugin.json manifest schema (§5), mcp.json component
+ * configuration (§7.2.1), and skills discovery (§6.1/§7.1) without any runtime
+ * schema fetching. All validation rules are implemented locally in TS.
+ *
+ * Severity model:
+ * - `errors` — findings that make the package non-conformant (fatal manifest
+ *   violations plus closed-schema violations such as unknown top-level fields,
+ *   which the spec reports and ignores for loading but which still mean the
+ *   manifest "does not conform to the schema", §5.2). Each line carries a
+ *   `plugin.json:` / `mcp.json:` / `skills:` prefix.
+ * - `warnings` — tolerated findings that do not affect conformance (a child
+ *   directory under skills/ without SKILL.md is simply not a skill, §7.1).
+ *
+ * Validation continues past report-and-ignore findings so one run aggregates
+ * every issue; `ok` is false when any error was recorded.
+ */
+
+export type AgentPluginValidation = {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+};
+
+const PLUGIN_SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
+const MCP_SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json";
+
+const PLUGIN_TOP_LEVEL_FIELDS: Record<string, true> = {
+  $schema: true,
+  name: true,
+  version: true,
+  description: true,
+  author: true,
+  homepage: true,
+  repository: true,
+  license: true,
+  keywords: true,
+  extensions: true,
+};
+
+/** §5.5: lowercase alphanumerics, hyphens, periods; no `--` or `..`; alnum start/end; 1-64 chars. */
+const PLUGIN_NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+
+/** §7.2.1 stdio cwd: `./…`, `${PLUGIN_ROOT}` (or `/…`), `${PLUGIN_DATA}` (or `/…`). */
+const MCP_CWD_PATTERN = /^(?:\.\/|\$\{PLUGIN_ROOT\}(?:\/|$)|\$\{PLUGIN_DATA\}(?:\/|$))/;
+
+/** Agent Skills name rules: lowercase alphanumerics + hyphens, no `--`, no leading/trailing hyphen. */
+const SKILL_NAME_PATTERN = /^(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+/** RFC 7230 token: valid HTTP header field name. */
+const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+const MCP_SERVER_TYPES: Record<string, true> = {
+  stdio: true,
+  "streamable-http": true,
+  sse: true,
+};
+const STDIO_FIELDS: Record<string, true> = { type: true, command: true, args: true, env: true, cwd: true };
+const REMOTE_FIELDS: Record<string, true> = { type: true, url: true, headers: true };
+const AUTHOR_FIELDS: Record<string, true> = { name: true, email: true, url: true };
+
+function describeType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseScalar(raw: string): string {
+  const trimmed = raw.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * Minimal YAML frontmatter extractor for SKILL.md files. Returns the parsed
+ * key/value map (string scalars only) or null when no `---` block is present.
+ */
+function parseFrontmatter(filePath: string): Record<string, string> | null {
+  const content = fs.readFileSync(filePath, "utf8");
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!match) return null;
+  const result: Record<string, string> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const field = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!field) continue;
+    result[field[1]] = parseScalar(field[2]);
+  }
+  return result;
+}
+
+function isValidMcpUrl(raw: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  if (!parsed.hostname) return false;
+  // §7.2.1: no user information, no fragment.
+  if (parsed.username || parsed.password || parsed.hash) return false;
+  const host = parsed.hostname;
+  const isLoopback =
+    host === "localhost" ||
+    host === "::1" ||
+    host === "[::1]" ||
+    /^127\.\d+\.\d+\.\d+$/.test(host);
+  // Non-loopback endpoints MUST use HTTPS.
+  if (!isLoopback && parsed.protocol !== "https:") return false;
+  return true;
+}
+
+function validateManifest(manifest: unknown, errors: string[]) {
+  if (!isPlainObject(manifest)) {
+    errors.push("plugin.json: manifest must be a JSON object");
+    return;
+  }
+  const doc = manifest as Record<string, unknown>;
+
+  // §5.2: closed top-level schema — unknown fields are reported and ignored,
+  // but still mean the manifest does not conform to the schema.
+  for (const key of Object.keys(doc)) {
+    if (!Object.hasOwn(PLUGIN_TOP_LEVEL_FIELDS, key)) {
+      errors.push(
+        `plugin.json: unknown top-level field "${key}" (ignored; client-specific data belongs under "extensions")`,
+      );
+    }
+  }
+
+  // §5.3: required $schema + name.
+  const schema = doc["$schema"];
+  if (typeof schema !== "string") {
+    errors.push(`plugin.json: "$schema" is required and must be the string ${PLUGIN_SCHEMA_URL}`);
+  } else if (schema !== PLUGIN_SCHEMA_URL) {
+    errors.push(
+      `plugin.json: unsupported "$schema" ${JSON.stringify(schema)} (expected ${PLUGIN_SCHEMA_URL})`,
+    );
+  }
+
+  const name = doc.name;
+  if (typeof name !== "string" || name.length === 0) {
+    errors.push('plugin.json: "name" is required and must be a non-empty string');
+  } else {
+    if (name.length > 64) {
+      errors.push(`plugin.json: "name" must be 1-64 characters (got ${name.length})`);
+    }
+    if (!PLUGIN_NAME_PATTERN.test(name)) {
+      errors.push(
+        `plugin.json: "name" ${JSON.stringify(name)} violates Agent Plugins name rules ` +
+          `(lowercase alphanumerics, hyphens, periods; no "--" or ".."; must start and end alphanumeric)`,
+      );
+    }
+  }
+
+  // §5.4: metadata field types.
+  for (const field of ["version", "description", "homepage", "repository", "license"] as const) {
+    const value = doc[field];
+    if (value === undefined) continue;
+    if (typeof value !== "string") {
+      errors.push(`plugin.json: "${field}" must be a string (got ${describeType(value)})`);
+    }
+  }
+
+  if (doc.author !== undefined) {
+    if (!isPlainObject(doc.author)) {
+      errors.push('plugin.json: "author" must be an object with optional string fields name/email/url');
+    } else {
+      const author = doc.author as Record<string, unknown>;
+      for (const key of Object.keys(author)) {
+        if (!Object.hasOwn(AUTHOR_FIELDS, key)) {
+          errors.push(
+            `plugin.json: "author" has unknown field "${key}" (only name, email, url are allowed)`,
+          );
+        }
+      }
+      for (const key of ["name", "email", "url"]) {
+        const value = author[key];
+        if (value !== undefined && typeof value !== "string") {
+          errors.push(`plugin.json: "author.${key}" must be a string (got ${describeType(value)})`);
+        }
+      }
+    }
+  }
+
+  if (doc.keywords !== undefined) {
+    if (!Array.isArray(doc.keywords) || doc.keywords.some((entry) => typeof entry !== "string")) {
+      errors.push('plugin.json: "keywords" must be an array of strings');
+    }
+  }
+
+  // §5.6/§8.1: extensions is an object of objects; non-object values are
+  // reported and ignored. Member contents are client-defined — never validated.
+  if (doc.extensions !== undefined) {
+    if (!isPlainObject(doc.extensions)) {
+      errors.push('plugin.json: "extensions" must be an object of objects (field ignored)');
+    } else {
+      for (const [namespace, value] of Object.entries(doc.extensions as Record<string, unknown>)) {
+        if (!isPlainObject(value)) {
+          errors.push(
+            `plugin.json: "extensions.${namespace}" must be an object (entry ignored)`,
+          );
+        }
+      }
+    }
+  }
+}
+
+function validateMcpServer(name: string, entry: unknown, errors: string[]) {
+  const prefix = `mcp.json: mcpServers.${name}`;
+  if (!isPlainObject(entry)) {
+    errors.push(`${prefix} must be an object`);
+    return;
+  }
+  const server = entry as Record<string, unknown>;
+  const type = server.type;
+  if (typeof type !== "string" || !Object.hasOwn(MCP_SERVER_TYPES, type)) {
+    errors.push(
+      `${prefix}: "type" must be one of "stdio" | "streamable-http" | "sse" (got ${JSON.stringify(type)})`,
+    );
+    return;
+  }
+
+  if (type === "stdio") {
+    for (const key of Object.keys(server)) {
+      if (!Object.hasOwn(STDIO_FIELDS, key)) {
+        errors.push(
+          `${prefix}: unknown field "${key}" for stdio server (allowed: type, command, args, env, cwd)`,
+        );
+      }
+    }
+    const command = server.command;
+    if (typeof command !== "string" || command.length === 0) {
+      errors.push(`${prefix}: "command" is required and must be a non-empty string`);
+    } else {
+      if (/\s/.test(command)) {
+        errors.push(
+          `${prefix}: "command" must be a single executable token, not a shell command string`,
+        );
+      } else if (command.includes("/") && !command.startsWith("./")) {
+        errors.push(
+          `${prefix}: "command" must be a bare executable name or a plugin-relative path beginning with "./"`,
+        );
+      }
+    }
+    if (server.args !== undefined) {
+      if (!Array.isArray(server.args) || server.args.some((arg) => typeof arg !== "string")) {
+        errors.push(`${prefix}: "args" must be an array of strings`);
+      }
+    }
+    if (server.env !== undefined) {
+      if (!isPlainObject(server.env)) {
+        errors.push(`${prefix}: "env" must be an object of strings`);
+      } else {
+        for (const [key, value] of Object.entries(server.env as Record<string, unknown>)) {
+          if (key === "PLUGIN_ROOT" || key === "PLUGIN_DATA") {
+            errors.push(
+              `${prefix}: "env" must not set reserved variable "${key}" (clients supply it themselves)`,
+            );
+          }
+          if (typeof value !== "string") {
+            errors.push(`${prefix}: "env.${key}" must be a string`);
+          }
+        }
+      }
+    }
+    if (server.cwd !== undefined) {
+      if (typeof server.cwd !== "string") {
+        errors.push(`${prefix}: "cwd" must be a string`);
+      } else if (!MCP_CWD_PATTERN.test(server.cwd)) {
+        errors.push(
+          `${prefix}: "cwd" must be "./…", "${"${PLUGIN_ROOT}"}…", or "${"${PLUGIN_DATA}"}…"`,
+        );
+      }
+    }
+    return;
+  }
+
+  // streamable-http / sse
+  for (const key of Object.keys(server)) {
+    if (!Object.hasOwn(REMOTE_FIELDS, key)) {
+      errors.push(
+        `${prefix}: unknown field "${key}" for ${type} server (allowed: type, url, headers)`,
+      );
+    }
+  }
+  const url = server.url;
+  if (typeof url !== "string" || url.length === 0) {
+    errors.push(`${prefix}: "url" is required and must be a non-empty string`);
+  } else if (!isValidMcpUrl(url)) {
+    errors.push(
+      `${prefix}: "url" must be an absolute http(s) URL without user info or fragment; non-loopback endpoints must use https`,
+    );
+  }
+  if (server.headers !== undefined) {
+    if (!isPlainObject(server.headers)) {
+      errors.push(`${prefix}: "headers" must be an object of strings`);
+    } else {
+      const seen = new Set<string>();
+      for (const [key, value] of Object.entries(server.headers as Record<string, unknown>)) {
+        if (typeof value !== "string") {
+          errors.push(`${prefix}: "headers.${key}" must be a string`);
+          continue;
+        }
+        if (value.includes("\r") || value.includes("\n")) {
+          errors.push(`${prefix}: "headers.${key}" value must be a single HTTP header value`);
+        }
+        if (!HTTP_HEADER_NAME_PATTERN.test(key)) {
+          errors.push(`${prefix}: "headers.${key}" is not a valid HTTP header name`);
+        } else {
+          const lower = key.toLowerCase();
+          if (seen.has(lower)) {
+            errors.push(`${prefix}: header "${key}" is duplicated (case-insensitive)`);
+          }
+          seen.add(lower);
+        }
+      }
+    }
+  }
+}
+
+function validateMcp(root: string, manifestSchema: unknown, errors: string[]) {
+  const mcpPath = path.join(root, "mcp.json");
+  if (!fs.existsSync(mcpPath)) return; // §6.2: absent fixed location is not an error.
+  let parsed: unknown;
+  try {
+    parsed = readJson(mcpPath);
+  } catch (error) {
+    errors.push(`mcp.json: ${(error as Error).message}`);
+    return;
+  }
+  if (!isPlainObject(parsed)) {
+    errors.push("mcp.json: configuration must be a JSON object");
+    return;
+  }
+  const doc = parsed as Record<string, unknown>;
+
+  // §7.2.1: closed top level — exactly $schema + mcpServers.
+  for (const key of Object.keys(doc)) {
+    if (key !== "$schema" && key !== "mcpServers") {
+      errors.push(`mcp.json: unknown top-level field "${key}" (only "$schema" and "mcpServers" allowed)`);
+    }
+  }
+
+  const schema = doc["$schema"];
+  if (typeof schema !== "string") {
+    errors.push(`mcp.json: "$schema" is required and must be the string ${MCP_SCHEMA_URL}`);
+  } else if (schema !== MCP_SCHEMA_URL) {
+    errors.push(`mcp.json: unsupported "$schema" ${JSON.stringify(schema)} (expected ${MCP_SCHEMA_URL})`);
+  } else {
+    // §10.1: mcp.json $schema version MUST match plugin.json's version.
+    const manifestVersion =
+      typeof manifestSchema === "string"
+        ? manifestSchema.match(/^https:\/\/agent-plugins\.org\/schemas\/([^/]+)\/plugin\.schema\.json$/)?.[1]
+        : undefined;
+    const mcpVersion = schema.match(/^https:\/\/agent-plugins\.org\/schemas\/([^/]+)\/mcp\.schema\.json$/)?.[1];
+    if (manifestVersion && mcpVersion && manifestVersion !== mcpVersion) {
+      errors.push(
+        `mcp.json: "$schema" targets Agent Plugins ${mcpVersion} but plugin.json targets ${manifestVersion} (versions must match)`,
+      );
+    }
+  }
+
+  const servers = doc.mcpServers;
+  if (!isPlainObject(servers)) {
+    errors.push('mcp.json: "mcpServers" is required and must be an object');
+    return;
+  }
+  for (const [serverName, entry] of Object.entries(servers as Record<string, unknown>)) {
+    validateMcpServer(serverName, entry, errors);
+  }
+}
+
+function validateSkills(root: string, errors: string[], warnings: string[]) {
+  const skillsPath = path.join(root, "skills");
+  if (!fs.existsSync(skillsPath)) return; // §6.2: absent fixed location is not an error.
+  if (!fs.statSync(skillsPath).isDirectory()) {
+    errors.push("skills: skills/ is not a directory (component type invalid)");
+    return;
+  }
+  const entries = fs.readdirSync(skillsPath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue; // §7.1: only immediate child directories can be skills.
+    const skillDir = entry.name;
+    const skillMdPath = path.join(skillsPath, skillDir, "SKILL.md");
+    if (!fs.existsSync(skillMdPath) || !fs.statSync(skillMdPath).isFile()) {
+      warnings.push(
+        `skills: ${skillDir}/ has no SKILL.md (directory is not a skill; ignored)`,
+      );
+      continue;
+    }
+    const frontmatter = parseFrontmatter(skillMdPath);
+    if (!frontmatter) {
+      errors.push(`skills: ${skillDir}/SKILL.md is missing YAML frontmatter (name and description are required)`);
+      continue;
+    }
+    const skillName = frontmatter.name;
+    if (skillName !== skillDir) {
+      errors.push(
+        `skills: ${skillDir}/SKILL.md frontmatter "name" ${JSON.stringify(skillName)} must equal the directory name "${skillDir}"`,
+      );
+    } else if (!SKILL_NAME_PATTERN.test(skillName)) {
+      errors.push(
+        `skills: ${skillDir}/SKILL.md frontmatter "name" violates Agent Skills name rules ` +
+          `(lowercase alphanumerics and hyphens, no "--", no leading or trailing hyphen)`,
+      );
+    }
+    const description = frontmatter.description;
+    if (typeof description !== "string" || description.trim().length === 0) {
+      errors.push(`skills: ${skillDir}/SKILL.md frontmatter "description" is required and must be non-empty`);
+    }
+  }
+}
+
+export function validateAgentPlugin(root: string): AgentPluginValidation {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const manifestPath = path.join(root, "plugin.json");
+  if (!fs.existsSync(manifestPath)) {
+    errors.push(`plugin.json: manifest not found at ${manifestPath} (plugin root must contain plugin.json)`);
+    return { ok: false, errors, warnings };
+  }
+  let manifest: unknown;
+  try {
+    manifest = readJson(manifestPath);
+  } catch (error) {
+    errors.push(`plugin.json: ${(error as Error).message}`);
+    return { ok: false, errors, warnings };
+  }
+
+  validateManifest(manifest, errors);
+  // Keep checking components even after manifest errors: aggregated diagnostics
+  // help authors fix every issue in one run. `ok` stays false on any error.
+  const manifestSchema = isPlainObject(manifest) ? (manifest as Record<string, unknown>)["$schema"] : undefined;
+  validateMcp(root, manifestSchema, errors);
+  validateSkills(root, errors, warnings);
+
+  return { ok: errors.length === 0, errors, warnings };
+}

--- a/packages/cli/src/agent-plugins.ts
+++ b/packages/cli/src/agent-plugins.ts
@@ -10,13 +10,14 @@ import { readJson } from "./utils";
  * schema fetching. All validation rules are implemented locally in TS.
  *
  * Severity model:
- * - `errors` — findings that make the package non-conformant (fatal manifest
- *   violations plus closed-schema violations such as unknown top-level fields,
- *   which the spec reports and ignores for loading but which still mean the
- *   manifest "does not conform to the schema", §5.2). Each line carries a
- *   `plugin.json:` / `mcp.json:` / `skills:` prefix.
- * - `warnings` — tolerated findings that do not affect conformance (a child
- *   directory under skills/ without SKILL.md is simply not a skill, §7.1).
+ * - `errors` — findings that make the package non-conformant (missing/invalid
+ *   manifest, `$schema`, `name`, or metadata types; mcp.json violations). Each
+ *   line carries a `plugin.json:` / `mcp.json:` / `skills:` prefix.
+ * - `warnings` — report-and-ignore findings that do not fail validation:
+ *   unknown top-level plugin.json fields are reported and ignored while the
+ *   plugin keeps loading (§5.2), and non-conforming skills are skipped while
+ *   other skills and component types keep loading (§7.1). A child directory
+ *   under skills/ without SKILL.md is simply not a skill.
  *
  * Validation continues past report-and-ignore findings so one run aggregates
  * every issue; `ok` is false when any error was recorded.
@@ -126,18 +127,18 @@ function isValidMcpUrl(raw: string): boolean {
   return true;
 }
 
-function validateManifest(manifest: unknown, errors: string[]) {
+function validateManifest(manifest: unknown, errors: string[], warnings: string[]) {
   if (!isPlainObject(manifest)) {
     errors.push("plugin.json: manifest must be a JSON object");
     return;
   }
   const doc = manifest as Record<string, unknown>;
 
-  // §5.2: closed top-level schema — unknown fields are reported and ignored,
-  // but still mean the manifest does not conform to the schema.
+  // §5.2: unknown top-level fields are reported and ignored; loading continues
+  // when the manifest otherwise satisfies this section.
   for (const key of Object.keys(doc)) {
     if (!Object.hasOwn(PLUGIN_TOP_LEVEL_FIELDS, key)) {
-      errors.push(
+      warnings.push(
         `plugin.json: unknown top-level field "${key}" (ignored; client-specific data belongs under "extensions")`,
       );
     }
@@ -406,23 +407,31 @@ function validateSkills(root: string, errors: string[], warnings: string[]) {
     }
     const frontmatter = parseFrontmatter(skillMdPath);
     if (!frontmatter) {
-      errors.push(`skills: ${skillDir}/SKILL.md is missing YAML frontmatter (name and description are required)`);
+      // §7.1: missing frontmatter means the skill does not conform; report and skip it.
+      warnings.push(
+        `skills: ${skillDir}/SKILL.md is missing YAML frontmatter (name and description are required; skill skipped)`,
+      );
       continue;
     }
     const skillName = frontmatter.name;
+    const problems: string[] = [];
     if (skillName !== skillDir) {
-      errors.push(
-        `skills: ${skillDir}/SKILL.md frontmatter "name" ${JSON.stringify(skillName)} must equal the directory name "${skillDir}"`,
+      problems.push(
+        `frontmatter "name" ${JSON.stringify(skillName)} must equal the directory name "${skillDir}"`,
       );
     } else if (!SKILL_NAME_PATTERN.test(skillName)) {
-      errors.push(
-        `skills: ${skillDir}/SKILL.md frontmatter "name" violates Agent Skills name rules ` +
+      problems.push(
+        `frontmatter "name" violates Agent Skills name rules ` +
           `(lowercase alphanumerics and hyphens, no "--", no leading or trailing hyphen)`,
       );
     }
     const description = frontmatter.description;
     if (typeof description !== "string" || description.trim().length === 0) {
-      errors.push(`skills: ${skillDir}/SKILL.md frontmatter "description" is required and must be non-empty`);
+      problems.push(`frontmatter "description" is required and must be non-empty`);
+    }
+    // §7.1: a non-conforming skill is skipped; the remaining skills still load.
+    for (const problem of problems) {
+      warnings.push(`skills: ${skillDir}/SKILL.md ${problem} (skill skipped)`);
     }
   }
 }
@@ -444,7 +453,7 @@ export function validateAgentPlugin(root: string): AgentPluginValidation {
     return { ok: false, errors, warnings };
   }
 
-  validateManifest(manifest, errors);
+  validateManifest(manifest, errors, warnings);
   // Keep checking components even after manifest errors: aggregated diagnostics
   // help authors fix every issue in one run. `ok` stays false on any error.
   const manifestSchema = isPlainObject(manifest) ? (manifest as Record<string, unknown>)["$schema"] : undefined;

--- a/packages/cli/src/agent-plugins.ts
+++ b/packages/cli/src/agent-plugins.ts
@@ -50,8 +50,30 @@ const PLUGIN_TOP_LEVEL_FIELDS: Record<string, true> = {
 /** §5.5: lowercase alphanumerics, hyphens, periods; no `--` or `..`; alnum start/end; 1-64 chars. */
 const PLUGIN_NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
 
-/** §7.2.1 stdio cwd: `./…`, `${PLUGIN_ROOT}` (or `/…`), `${PLUGIN_DATA}` (or `/…`). */
-const MCP_CWD_PATTERN = /^(?:\.\/|\$\{PLUGIN_ROOT\}(?:\/|$)|\$\{PLUGIN_DATA\}(?:\/|$))/;
+/**
+ * §7.2.1 stdio path containment: cwd/command values must begin with a
+ * recognized prefix (`./`, `${PLUGIN_ROOT}/`, `${PLUGIN_DATA}/` — or the bare
+ * `${PLUGIN_ROOT}` / `${PLUGIN_DATA}` variable forms for cwd) and the
+ * remainder must resolve to a path inside the plugin root. Returns the
+ * remainder after the matched prefix, or null when no prefix matches.
+ */
+function stripMcpPathPrefix(raw: string): string | null {
+  if (raw.startsWith("./")) return raw.slice(2);
+  if (raw.startsWith("${PLUGIN_ROOT}/")) return raw.slice("${PLUGIN_ROOT}/".length);
+  if (raw.startsWith("${PLUGIN_DATA}/")) return raw.slice("${PLUGIN_DATA}/".length);
+  if (raw === "${PLUGIN_ROOT}" || raw === "${PLUGIN_DATA}") return "";
+  return null;
+}
+
+/**
+ * True when a prefix-stripped relative path escapes the plugin root after
+ * POSIX normalization (leading `..` or an absolute remainder). Pure textual
+ * check — no filesystem access.
+ */
+function escapesPluginRoot(remainder: string): boolean {
+  const normalized = path.posix.normalize(remainder);
+  return normalized.startsWith("..") || path.posix.isAbsolute(normalized);
+}
 
 /** Agent Skills name rules: lowercase alphanumerics + hyphens, no `--`, no leading/trailing hyphen. */
 const SKILL_NAME_PATTERN = /^(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
@@ -259,6 +281,10 @@ function validateMcpServer(name: string, entry: unknown, errors: string[]) {
         errors.push(
           `${prefix}: "command" must be a bare executable name or a plugin-relative path beginning with "./"`,
         );
+      } else if (command.startsWith("./") && escapesPluginRoot(command.slice(2))) {
+        errors.push(
+          `${prefix}: "command" must remain within the plugin root (got "${command}")`,
+        );
       }
     }
     if (server.args !== undefined) {
@@ -285,10 +311,17 @@ function validateMcpServer(name: string, entry: unknown, errors: string[]) {
     if (server.cwd !== undefined) {
       if (typeof server.cwd !== "string") {
         errors.push(`${prefix}: "cwd" must be a string`);
-      } else if (!MCP_CWD_PATTERN.test(server.cwd)) {
-        errors.push(
-          `${prefix}: "cwd" must be "./…", "${"${PLUGIN_ROOT}"}…", or "${"${PLUGIN_DATA}"}…"`,
-        );
+      } else {
+        const remainder = stripMcpPathPrefix(server.cwd);
+        if (remainder === null) {
+          errors.push(
+            `${prefix}: "cwd" must be "./…", "${"${PLUGIN_ROOT}"}…", or "${"${PLUGIN_DATA}"}…"`,
+          );
+        } else if (escapesPluginRoot(remainder)) {
+          errors.push(
+            `${prefix}: "cwd" must remain within the plugin root (got "${server.cwd}")`,
+          );
+        }
       }
     }
     return;
@@ -391,50 +424,84 @@ function validateMcp(root: string, manifestSchema: unknown, errors: string[]) {
 
 function validateSkills(root: string, errors: string[], warnings: string[]) {
   const skillsPath = path.join(root, "skills");
-  if (!fs.existsSync(skillsPath)) return; // §6.2: absent fixed location is not an error.
-  if (!fs.statSync(skillsPath).isDirectory()) {
-    errors.push("skills: skills/ is not a directory (component type invalid)");
-    return;
-  }
-  const entries = fs.readdirSync(skillsPath, { withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue; // §7.1: only immediate child directories can be skills.
-    const skillDir = entry.name;
-    const skillMdPath = path.join(skillsPath, skillDir, "SKILL.md");
-    if (!fs.existsSync(skillMdPath) || !fs.statSync(skillMdPath).isFile()) {
-      warnings.push(
-        `skills: ${skillDir}/ has no SKILL.md (directory is not a skill; ignored)`,
-      );
-      continue;
+  try {
+    if (!fs.existsSync(skillsPath)) return; // §6.2: absent fixed location is not an error.
+    if (!fs.statSync(skillsPath).isDirectory()) {
+      errors.push("skills: skills/ is not a directory (component type invalid)");
+      return;
     }
-    const frontmatter = parseFrontmatter(skillMdPath);
-    if (!frontmatter) {
-      // §7.1: missing frontmatter means the skill does not conform; report and skip it.
-      warnings.push(
-        `skills: ${skillDir}/SKILL.md is missing YAML frontmatter (name and description are required; skill skipped)`,
-      );
-      continue;
+    const entries = fs.readdirSync(skillsPath, { withFileTypes: true });
+    const realRoot = fs.realpathSync(root);
+    for (const entry of entries) {
+      // §7.1: only immediate child directories can be skills. A symlink to a
+      // directory counts when its target stays inside the plugin root.
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      const skillDir = entry.name;
+      // §4.1: package paths must resolve within the plugin root; a symlinked
+      // skill that resolves outside the root is skipped with a warning.
+      let realSkillPath: string;
+      try {
+        realSkillPath = fs.realpathSync(path.join(skillsPath, skillDir));
+      } catch (error) {
+        warnings.push(
+          `skills: ${skillDir}/ cannot be resolved (${(error as Error).message}; skill skipped)`,
+        );
+        continue;
+      }
+      const relative = path.relative(realRoot, realSkillPath);
+      if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+        warnings.push(
+          `skills: ${skillDir}/ resolves outside the plugin root (${realSkillPath}; skill skipped)`,
+        );
+        continue;
+      }
+      const skillMdPath = path.join(skillsPath, skillDir, "SKILL.md");
+      if (!fs.existsSync(skillMdPath) || !fs.statSync(skillMdPath).isFile()) {
+        warnings.push(
+          `skills: ${skillDir}/ has no SKILL.md (directory is not a skill; ignored)`,
+        );
+        continue;
+      }
+      const frontmatter = parseFrontmatter(skillMdPath);
+      if (!frontmatter) {
+        // §7.1: missing frontmatter means the skill does not conform; report and skip it.
+        warnings.push(
+          `skills: ${skillDir}/SKILL.md is missing YAML frontmatter (name and description are required; skill skipped)`,
+        );
+        continue;
+      }
+      const skillName = frontmatter.name;
+      const problems: string[] = [];
+      if (skillName !== skillDir) {
+        problems.push(
+          `frontmatter "name" ${JSON.stringify(skillName)} must equal the directory name "${skillDir}"`,
+        );
+      } else if (!SKILL_NAME_PATTERN.test(skillName)) {
+        problems.push(
+          `frontmatter "name" violates Agent Skills name rules ` +
+            `(lowercase alphanumerics and hyphens, no "--", no leading or trailing hyphen)`,
+        );
+      }
+      if (typeof skillName === "string" && skillName.length > 64) {
+        problems.push(`frontmatter "name" must be at most 64 characters (got ${skillName.length})`);
+      }
+      const description = frontmatter.description;
+      if (typeof description !== "string" || description.trim().length === 0) {
+        problems.push(`frontmatter "description" is required and must be non-empty`);
+      } else if (description.length > 1024) {
+        problems.push(
+          `frontmatter "description" must be at most 1024 characters (got ${description.length})`,
+        );
+      }
+      // §7.1: a non-conforming skill is skipped; the remaining skills still load.
+      for (const problem of problems) {
+        warnings.push(`skills: ${skillDir}/SKILL.md ${problem} (skill skipped)`);
+      }
     }
-    const skillName = frontmatter.name;
-    const problems: string[] = [];
-    if (skillName !== skillDir) {
-      problems.push(
-        `frontmatter "name" ${JSON.stringify(skillName)} must equal the directory name "${skillDir}"`,
-      );
-    } else if (!SKILL_NAME_PATTERN.test(skillName)) {
-      problems.push(
-        `frontmatter "name" violates Agent Skills name rules ` +
-          `(lowercase alphanumerics and hyphens, no "--", no leading or trailing hyphen)`,
-      );
-    }
-    const description = frontmatter.description;
-    if (typeof description !== "string" || description.trim().length === 0) {
-      problems.push(`frontmatter "description" is required and must be non-empty`);
-    }
-    // §7.1: a non-conforming skill is skipped; the remaining skills still load.
-    for (const problem of problems) {
-      warnings.push(`skills: ${skillDir}/SKILL.md ${problem} (skill skipped)`);
-    }
+  } catch (error) {
+    // Filesystem/permission failures keep the structured `skills:` prefix
+    // instead of escaping to the generic command-level catch.
+    errors.push(`skills: ${(error as Error).message}`);
   }
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,13 +1,16 @@
 #!/usr/bin/env bun
 
+import fs from "node:fs";
+import path from "node:path";
 import { select } from "@inquirer/prompts";
 import pc from "picocolors";
 import { Command } from "commander";
+import { validateAgentPlugin } from "./agent-plugins";
 import { buildModelAssignments } from "./assignment";
 import { getAdapter } from "./adapters";
-import type { DoctorOptions, InitOptions, Target } from "./types";
+import type { DoctorOptions, InitOptions, PluginValidateOptions, Target } from "./types";
 import { SUPPORTED_TARGETS } from "./types";
-import { parseCsv, readJson, writeJson, readHarnessVersion } from "./utils";
+import { parseCsv, readJson, writeJson, readHarnessVersion, resolveProjectRoot } from "./utils";
 
 const packageVersion = readHarnessVersion();
 
@@ -165,6 +168,39 @@ function runDoctor(options: DoctorOptions) {
   process.exitCode = 1;
 }
 
+/**
+ * Resolve the plugin root for `plugin validate`: explicit `--root` wins;
+ * otherwise start from `resolveProjectRoot()` and walk up to the nearest
+ * ancestor containing `plugin.json` (bun run --cwd rewrites PWD, so the
+ * project root is not always the resolved cwd).
+ */
+function resolvePluginRoot(options: PluginValidateOptions): string {
+  if (options.root) return path.resolve(options.root);
+  let candidate = resolveProjectRoot();
+  while (!fs.existsSync(path.join(candidate, "plugin.json"))) {
+    const parent = path.dirname(candidate);
+    if (parent === candidate) break;
+    candidate = parent;
+  }
+  return candidate;
+}
+
+function runPluginValidate(options: PluginValidateOptions) {
+  const root = resolvePluginRoot(options);
+  const result = validateAgentPlugin(root);
+  for (const warning of result.warnings) {
+    console.warn(pc.yellow(warning));
+  }
+  if (result.ok) {
+    console.log(pc.green(`OK ${root}: Agent Plugins v1.0.0 conformant`));
+    return;
+  }
+  for (const error of result.errors) {
+    console.error(pc.red(error));
+  }
+  process.exitCode = 1;
+}
+
 program
   .name("mstar-harness")
   .description("Morning Star harness CLI for target-based agent bootstrap")
@@ -195,6 +231,18 @@ program
   .option("--output <path>", "Config file path override, relative to project root")
   .action((options: DoctorOptions) => {
     runDoctor(options);
+  });
+
+const pluginCommand = program
+  .command("plugin")
+  .description("Agent Plugins v1.0.0 portable package commands");
+
+pluginCommand
+  .command("validate")
+  .description("Validate a plugin package against Agent Plugins v1.0.0")
+  .option("--root <path>", "Plugin root directory to validate (default: project root)")
+  .action((options: PluginValidateOptions) => {
+    runPluginValidate(options);
   });
 
 program.parseAsync(process.argv).catch((error: unknown) => {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -21,6 +21,10 @@ export type DoctorOptions = {
   output?: string;
 };
 
+export type PluginValidateOptions = {
+  root?: string;
+};
+
 export type ModelSelections = {
   pm: string[];
   strategic: string[];

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "morning-star-harness",
+  "version": "1.8.8",
+  "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, ZCode, and omp.",
+  "author": {
+    "name": "Bohao Tang",
+    "email": "tech@btang.cn"
+  },
+  "homepage": "https://github.com/btspoony/mstar-harness",
+  "repository": "https://github.com/btspoony/mstar-harness.git",
+  "license": "MIT",
+  "keywords": [
+    "morning-star",
+    "mstar",
+    "harness",
+    "agent",
+    "multi-agent",
+    "agent-plugin",
+    "specification-engineering",
+    "harness-engineering",
+    "quality-gates",
+    "workflow",
+    "role-based-workflow"
+  ]
+}

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -12,7 +12,7 @@
  *   2. Reads `.changes/unreleased/*.md` fragments and groups them by changelog + category.
  *   3. Inserts a new `## [<version>] - <date>` section into each changelog
  *      (under `## [Unreleased]`), auto-appending a Version-alignment block.
- *   4. Bumps all 9 version surfaces + the INSTALL.md ZCode marketplace example.
+ *   4. Bumps all 10 version surfaces (including the portable Agent Plugins manifest) + the INSTALL.md ZCode marketplace example.
  *   5. Bumps the version registry table cells in the root changelogs (head region only).
  *   6. Moves consumed fragments to `.changes/archive/<version>/`.
  *
@@ -155,14 +155,14 @@ function buildSectionBody(target: (typeof CHANGELOGS)[number], frags: Fragment[]
       lines.push(
         "### 版本对齐",
         "",
-        `- 提升 monorepo 根、\`@mstar-harness/opencode\`、\`@mstar-harness/cli\`、Cursor/Codex/Kimi/ZCode/omp/Claude 插件清单：**→ ${version}**。`,
+        `- 提升 monorepo 根、\`@mstar-harness/opencode\`、\`@mstar-harness/cli\`、Cursor/Codex/Kimi/ZCode/omp/Claude 插件清单及便携式 Agent Plugins 清单：**→ ${version}**。`,
         "",
       );
     } else {
       lines.push(
         "### Version alignment",
         "",
-        `- Bump monorepo root, \`@mstar-harness/opencode\`, \`@mstar-harness/cli\`, Cursor/Codex/Kimi/ZCode/omp/Claude plugin manifests: **→ ${version}**.`,
+        `- Bump monorepo root, \`@mstar-harness/opencode\`, \`@mstar-harness/cli\`, Cursor/Codex/Kimi/ZCode/omp/Claude plugin manifests, and the portable Agent Plugins manifest: **→ ${version}**.`,
         "",
       );
     }

--- a/scripts/release-surfaces.ts
+++ b/scripts/release-surfaces.ts
@@ -19,6 +19,7 @@ export const VERSION_SURFACES: readonly VersionSurface[] = [
   { label: "ZCode plugin", path: ".zcode-plugin/plugin.json" },
   { label: "omp plugin", path: ".omp-plugin/plugin.json" },
   { label: "Claude plugin", path: ".claude-plugin/plugin.json" },
+  { label: "Agent Plugins manifest", path: "plugin.json" },
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Make the repo a conformant **Agent Plugins v1.0.0** package (latest generic agent-plugin protocol, spec: https://agent-plugins.org/specification).

## Changes

- **`plugin.json` (new, repo root)** — portable Agent Plugins v1.0.0 manifest: canonical `$schema`, `name: morning-star-harness`, version 1.8.8, metadata, keywords. Closed schema per spec §5.2; `skills/` at root is the Agent Skills component location (§6.1).
- **Release alignment** — `scripts/release-surfaces.ts` gains the `Agent Plugins manifest` surface (single source consumed by `prepare-release.ts` and `validate-release-version.ts`); AGENTS.md surface count 9 → 10; CHANGELOG registry rows (EN + CN); prepare-release.ts comment/bullet wording updated.
- **CLI `mstar-harness plugin validate [--root <path>]`** — new command in `packages/cli/src/agent-plugins.ts` implementing spec validation locally (no new deps, no runtime schema fetch):
  - `plugin.json`: closed top-level fields, required `$schema`/`name` (§5.2–5.3), name pattern (§5.5), metadata types (§5.4), report-and-ignore for unknown fields and non-object `extensions` (§5.2/§8.1)
  - `mcp.json` (if present): closed shape, stdio/streamable-http/sse variants, `PLUGIN_ROOT`/`PLUGIN_DATA` reserved-env guard, cwd forms + path containment (§4.1/§7.2.1/§9.2)
  - `skills/`: immediate-child discovery, frontmatter name=dir + Agent Skills name/length rules, skip-and-continue warnings (§6.1/§7.1), symlink containment
  - Exit 0 conformant / 1 non-conformant; structured prefixed errors (`plugin.json:` / `mcp.json:` / `skills:`)
- **Docs** — README.md + README_CN.md (generic Agent Plugins install row + paragraph), INSTALL.md (Agent Plugins (generic) section), docs/cli.md (validate command incl. walk-up behavior).
- **Changelog fragment** — `.changes/unreleased/agent-plugins-v1.md` (packages: root, cli).

## Verification

- `bun run typecheck` — PASS
- `bun run release:validate -- v1.8.8` — all 10 surfaces + INSTALL.md aligned (incl. `OK Agent Plugins manifest: 1.8.8`)
- `mstar-harness plugin validate` at repo root — exit 0, `OK … Agent Plugins v1.0.0 conformant`
- Negative fixtures (missing `$schema`, `./..` cwd escape, symlinked skill escaping root, description >1024) — exit 1/0 with structured errors as specified

Host plugin manifests (`.cursor-plugin/` etc.) untouched. No `mcp.json` shipped (repo has no MCP servers; optional per spec §6.2).