### PR TITLE
release v2.0.0

### DIFF
--- a/scripts/release-surfaces.ts
+++ b/scripts/release-surfaces.ts
@@ -55,3 +55,6 @@ export function compareSemver(a: string, b: string): number {
   }
   return 0;
 }
+
+// Release note: v2.0.0 first release attempt failed at install (engine runtime-dep 404);
+// engine is now a build-time devDependency (consumers bundle it) — see git history.


### PR DESCRIPTION
Retry of the v2.0.0 release.

First attempt (PR #71) failed at the Release/CI install step: @mstar-harness/engine@1.8.9 could not be resolved from the registry (404) because cli/opencode declared it as a RUNTIME dependency with a version spec that had drifted from the workspace engine.

Fixed on main (9f7fbef): engine is now a **build-time devDependency** — cli/opencode bundle it into their dist at build time (verified), so the published artifacts are self-contained and never resolve the engine from the registry. No publish-order constraint, no workspace-protocol machinery.

This PR is a minimal docs commit so merging it triggers the Release workflow (validate 2.0.0 → build → npm publish engine/cli/opencode @2.0.0 → tag v2.0.0 → GitHub Release).