### PR TITLE
release v2.0.0

### DIFF
--- a/scripts/release-surfaces.ts
+++ b/scripts/release-surfaces.ts
@@ -58,3 +58,5 @@ export function compareSemver(a: string, b: string): number {
 
 // Release note: v2.0.0 first release attempt failed at install (engine runtime-dep 404);
 // engine is now a build-time devDependency (consumers bundle it) — see git history.
+
+// Trusted publishing for @mstar-harness/engine configured 2026-08-08 (registry API).


### PR DESCRIPTION
Retry the v2.0.0 release.

Previous attempts:
1. PR #71: failed at install (@mstar-harness/engine runtime-dep 404) — fixed on main (9f7fbef): engine is a build-time devDependency, consumers bundle it.
2. PR #72: Release workflow reached Publish @mstar-harness/engine but npm rejected with 404 PUT (trusted publisher not yet configured for the new package) — resolved: trusted publisher registered for btspoony/mstar-harness (workflow release.yml, refs/heads/main) on 2026-08-08.

This PR is a minimal docs commit to trigger the Release workflow: validate 2.0.0 → build → npm publish @mstar-harness/engine + cli + opencode @2.0.0 → tag v2.0.0 → GitHub Release.