### PR TITLE
fix(opencode): harden hook validators against non-string tool args

### DIFF
--- a/.changes/unreleased/opencode-hook-type-guards.md
+++ b/.changes/unreleased/opencode-hook-type-guards.md
@@ -1,0 +1,9 @@
+---
+category: Fixed
+packages: root, opencode
+---
+
+- OpenCode plugin hooks no longer abort-log on non-string `task`/`write` args: Assignment and `status.json` validators refuse non-string input before `.match` / `path.resolve`, and the `tool.execute.before` hook snapshots `prompt`/`filePath` once (avoids getter/Proxy type flips).
+
+<!-- CN -->
+- OpenCode 插件钩子不再因非 string 的 `task`/`write` 参数刷 abort 日志：Assignment 与 `status.json` 校验在 `.match` / `path.resolve` 前拒绝非 string 输入，且 `tool.execute.before` 对 `prompt`/`filePath` 只读取一次（避免 getter/Proxy 类型翻转）。

--- a/packages/opencode/src/mstar.ts
+++ b/packages/opencode/src/mstar.ts
@@ -285,6 +285,10 @@ export function validateStatusWrite(
 ): GateResult | null {
   const log = opts.log ?? defaultStatusLogger;
   try {
+    // Host tool args are `any` — refuse non-string paths before path.resolve
+    // (Bun: `The "paths[0]" property must be of type string, got object`).
+    if (typeof targetPath !== "string" || targetPath.trim() === "") return null;
+
     const resolved = path.resolve(targetPath);
     if (path.basename(resolved) !== STATUS_FILE) return null;
 
@@ -347,9 +351,12 @@ const ASSIGNMENT_FIELD_RE =
  * True when the text looks like an Assignment: carries the `## Assignment`
  * heading or at least one core field line (`Execute as` / `Delegation` /
  * `Task category`). Non-Assignment prompts (plain task instructions) stay
- * silent — no false-positive warnings.
+ * silent — no false-positive warnings. Non-string input is never shaped
+ * (host tool args are `any`; RegExp.test coerces objects to "[object Object]"
+ * which would then blow up on `.match`).
  */
-function isAssignmentShaped(assignmentText: string): boolean {
+function isAssignmentShaped(assignmentText: unknown): boolean {
+  if (typeof assignmentText !== "string") return false;
   return ASSIGNMENT_HEADING_RE.test(assignmentText) || assignmentText.match(ASSIGNMENT_FIELD_RE) !== null;
 }
 
@@ -409,8 +416,11 @@ export function validateDispatchAssignment(
 ): GateResult | null {
   const log = opts.log ?? defaultStatusLogger;
   try {
-    // Shape guard: non-Assignment prompts stay silent (no false positives).
-    if (!isAssignmentShaped(assignmentText)) return { ok: true, violations: [] };
+    // Shape guard: non-strings and non-Assignment prompts stay silent
+    // (no false positives / no `assignmentText.match is not a function`).
+    if (typeof assignmentText !== "string" || !isAssignmentShaped(assignmentText)) {
+      return { ok: true, violations: [] };
+    }
 
     const violations: ValidationResult[] = [];
     const fields = parseAssignmentFields(assignmentText);
@@ -506,7 +516,16 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
     },
 
     "tool.execute.before": async (input, output) => {
+      // Snapshot once: host `args` may be getter/Proxy-backed; re-reading
+      // `args.prompt` / `args.filePath` between a typeof check and the call
+      // can observe a different type (then `.match` / `path.resolve` throw
+      // into the abort log channel).
       const args = (output?.args ?? {}) as Record<string, unknown>;
+      const prompt = args.prompt;
+      const rawFilePath = args.filePath;
+      const rawPath = args.path;
+      const filePath =
+        typeof rawFilePath === "string" ? rawFilePath : typeof rawPath === "string" ? rawPath : undefined;
 
       // beforeDispatch-equivalent (Slice 5, dual-mode): Assignment
       // validation on subagent dispatch. OpenCode's `task` tool carries the
@@ -520,14 +539,14 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
       // on this host (`@opencode-ai/plugin` 1.4.8 — no refusal channel), so a
       // hard gate degrades to the explicit refusal-channel log below. The
       // role binding key is `subagent` (OpenCode) / `subagent_type` (Cursor).
-      if (input.tool === "task" && typeof args.prompt === "string") {
+      if (input.tool === "task" && typeof prompt === "string") {
         const subagentType =
           typeof args.subagent === "string"
             ? args.subagent
             : typeof args.subagent_type === "string"
               ? args.subagent_type
               : "";
-        const gate = validateDispatchAssignment(args.prompt, { subagentType });
+        const gate = validateDispatchAssignment(prompt, { subagentType });
         if (gate?.hardBlocked) {
           defaultStatusLogger(
             "error",
@@ -541,13 +560,14 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
       // hard mode (repo compass `enforcement: hard`) logs error-level lines
       // + a `hardBlocked` result. Never modifies args and never throws in
       // either mode. Structured file-write tools (`write`/`edit`) carry the
-      // target path in `args.filePath`; bash-heredoc writes are out of
-      // scope. Tool implementations may call `validateStatusWrite` directly.
-      if (typeof args.filePath !== "string") return;
+      // target path in `args.filePath` (fallback `args.path`); bash-heredoc
+      // writes are out of scope. Tool implementations may call
+      // `validateStatusWrite` directly.
+      if (typeof filePath !== "string") return;
 
       if (input.tool === "write") {
-        // Validate the document about to be written when it parses as JSON;
-        // otherwise fall back to the current on-disk state.
+        // Validate the document about to be written when it is already an
+        // object or parses as JSON; otherwise fall back to on-disk state.
         const rawContent = args.content;
         let doc: unknown;
         if (typeof rawContent === "string") {
@@ -556,8 +576,10 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
           } catch {
             doc = undefined;
           }
+        } else if (rawContent !== null && typeof rawContent === "object") {
+          doc = rawContent;
         }
-        const gate = validateStatusWrite(args.filePath, { doc });
+        const gate = validateStatusWrite(filePath, { doc });
         if (gate?.hardBlocked) {
           defaultStatusLogger(
             "error",
@@ -570,7 +592,7 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
         // invalid is caught by the subsequent write, and editing an already
         // invalid file re-warns about the state being replaced. Computing the
         // patched doc for `edit` is a later-slice improvement.
-        const gate = validateStatusWrite(args.filePath);
+        const gate = validateStatusWrite(filePath);
         if (gate?.hardBlocked) {
           defaultStatusLogger(
             "error",

--- a/packages/opencode/test/dispatch-presence-hook.test.ts
+++ b/packages/opencode/test/dispatch-presence-hook.test.ts
@@ -279,6 +279,20 @@ describe("validateDispatchAssignment (warn-only wrapper, full validation)", () =
     expect(warnings).toEqual([]);
   });
 
+  test("non-string prompt stays silent (no assignmentText.match abort)", () => {
+    // Host tool args are `any`; RegExp.test coerces objects then `.match` throws.
+    // Exported helper must fail soft — same abort line the user saw on OpenCode boot.
+    const entries: Array<[string, string]> = [];
+    const log: StatusLogger = (level, message) => {
+      entries.push([level, message]);
+    };
+    for (const bad of [{ text: "Execute as: x" }, 123, true, ["Execute as: x"], null, undefined] as unknown[]) {
+      const result = validateDispatchAssignment(bad as string, { log });
+      expect(result).toEqual({ ok: true, violations: [] });
+    }
+    expect(entries.filter(([, msg]) => msg.includes("assignment validation aborted"))).toEqual([]);
+  });
+
   test("field fragment without heading is linted, not silent", () => {
     // A bare `Execute as:` line is Assignment-shaped — the other two fields
     // still warn (engine field codes only; presence codes are aliases).

--- a/packages/opencode/test/status-write-hook.test.ts
+++ b/packages/opencode/test/status-write-hook.test.ts
@@ -179,6 +179,18 @@ describe("validateStatusWrite (exported hook module)", () => {
       rmSync(project, { recursive: true, force: true });
     }
   });
+
+  test("non-string targetPath stays silent (no paths[0] abort)", () => {
+    // Bun path.resolve(object) → `The "paths[0]" property must be of type string, got object`.
+    const entries: Array<[string, string]> = [];
+    const log: StatusLogger = (level, message) => {
+      entries.push([level, message]);
+    };
+    for (const bad of [{ path: "/tmp/.mstar/status.json" }, ["/tmp/.mstar/status.json"], 123, null, undefined] as unknown[]) {
+      expect(validateStatusWrite(bad as string, { log })).toBeNull();
+    }
+    expect(entries.filter(([, msg]) => msg.includes("status.json validation aborted"))).toEqual([]);
+  });
 });
 
 describe("plugin wiring (tool.execute.before)", () => {
@@ -247,6 +259,46 @@ describe("plugin wiring (tool.execute.before)", () => {
       expect(warnings.filter((w) => w.includes("[mstar-harness]"))).toEqual([]);
     } finally {
       rmSync(statusPath, { recursive: true, force: true });
+    }
+  });
+
+  test("write tool accepts args.path alias and object content; getter re-access stays quiet", async () => {
+    const plugin = await MorningStarHarnessPlugin();
+    const project = mkdtempSync(join(tmpdir(), "mstar-opencode-"));
+    mkdirSync(join(project, ".mstar"));
+    const statusPath = join(project, ".mstar", "status.json");
+    try {
+      const beforeWrite = plugin["tool.execute.before"];
+      expect(beforeWrite).toBeDefined();
+
+      const errors: string[] = [];
+      const originalError = console.error;
+      console.error = (message?: unknown) => {
+        errors.push(String(message));
+      };
+      try {
+        // path alias + already-parsed object content
+        await beforeWrite!(
+          { tool: "write", sessionID: "s1", callID: "c1" },
+          { args: { path: statusPath, content: invalidDoc } },
+        );
+        // Getter that flips type after the typeof snapshot would previously
+        // reach path.resolve(object) and log status.json validation aborted.
+        let reads = 0;
+        const flakyArgs = {
+          get filePath() {
+            reads += 1;
+            return reads === 1 ? statusPath : ({ path: statusPath } as unknown as string);
+          },
+          content: JSON.stringify(validDoc),
+        };
+        await beforeWrite!({ tool: "write", sessionID: "s1", callID: "c2" }, { args: flakyArgs });
+      } finally {
+        console.error = originalError;
+      }
+      expect(errors.filter((e) => e.includes("status.json validation aborted"))).toEqual([]);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
- Stop OpenCode startup abort spam when `task`/`write` tool args are non-string (`assignmentText.match is not a function`, Bun `paths[0] … got object`).
- Validators refuse non-string input before `.match` / `path.resolve`; `tool.execute.before` snapshots `prompt`/`filePath` once (and accepts `args.path` + object `content`).
- Adds regression tests and a changelog fragment.

## Test plan
- [x] `bun test test/dispatch-presence-hook.test.ts test/status-write-hook.test.ts` in `packages/opencode`
- [ ] Point OpenCode at local `packages/opencode` (or post-merge `@latest`) and confirm the two `[mstar-harness] … validation aborted` lines no longer appear on startup / first tool use


Made with [Cursor](https://cursor.com)