### PR TITLE
fix(opencode): default-export PluginModule { server } entry

### DIFF
--- a/.changes/unreleased/opencode-plugin-export-shape.md
+++ b/.changes/unreleased/opencode-plugin-export-shape.md
@@ -1,0 +1,9 @@
+---
+category: Fixed
+packages: root, opencode
+---
+
+- OpenCode plugin entry now default-exports `{ server: MorningStarHarnessPlugin }` so helper function exports are not registered as plugins (fixes `plugin config hook failed: N.config` / `N.dispose` on startup).
+
+<!-- CN -->
+- OpenCode 插件入口改为 default export `{ server: MorningStarHarnessPlugin }`，避免辅助函数被当成 plugin 注册（修复启动时 `plugin config hook failed: N.config` / `N.dispose`）。

--- a/packages/opencode/src/mstar.ts
+++ b/packages/opencode/src/mstar.ts
@@ -629,3 +629,21 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
     },
   };
 };
+
+/**
+ * OpenCode plugin entry (v1 PluginModule).
+ *
+ * OpenCode's legacy loader treats **every function export** on the package
+ * entry as a plugin (`getLegacyPlugins` → `Object.values(mod)`). Our named
+ * helpers (`validateStatusWrite` / `validateDispatchAssignment`) are also
+ * functions — when invoked with `PluginInput` they return `null` / a
+ * GateResult, which then gets pushed into the hooks list and blows up as
+ * `plugin config hook failed: null is not an object (evaluating 'N.config')`.
+ *
+ * Default-exporting `{ server }` makes `readV1Plugin` win and skip the legacy
+ * scan, so only `MorningStarHarnessPlugin` is registered. Named helper
+ * exports stay available for tests and direct callers.
+ */
+export default {
+  server: MorningStarHarnessPlugin,
+};

--- a/packages/opencode/test/plugin-entry-shape.test.ts
+++ b/packages/opencode/test/plugin-entry-shape.test.ts
@@ -1,0 +1,47 @@
+/**
+ * OpenCode plugin entry shape — default export must be a v1 PluginModule
+ * (`{ server }`) so OpenCode does not treat helper function exports as plugins.
+ *
+ * Regression: without this, `validateStatusWrite` / `validateDispatchAssignment`
+ * were invoked with PluginInput, returned `null`, and OpenCode logged
+ * `plugin config hook failed: null is not an object (evaluating 'N.config')`.
+ */
+import { describe, expect, test } from "bun:test";
+import pluginModule, {
+  MorningStarHarnessPlugin,
+  validateDispatchAssignment,
+  validateStatusWrite,
+} from "../src/mstar.js";
+
+describe("OpenCode plugin module entry", () => {
+  test("default export is PluginModule with server === MorningStarHarnessPlugin", () => {
+    expect(pluginModule).toBeDefined();
+    expect(typeof pluginModule).toBe("object");
+    expect(pluginModule).not.toBeNull();
+    expect(typeof pluginModule.server).toBe("function");
+    expect(pluginModule.server).toBe(MorningStarHarnessPlugin);
+  });
+
+  test("helpers stay callable but must not be treated as the plugin entry", () => {
+    // Simulates what OpenCode would observe if it fell through to getLegacyPlugins:
+    // calling validators with a PluginInput-shaped object must not throw, and
+    // validateStatusWrite must return null (not a Hooks object).
+    const fakePluginInput = {
+      client: {},
+      directory: "/tmp",
+      worktree: "/tmp",
+      project: {},
+    };
+    expect(validateStatusWrite(fakePluginInput as unknown as string)).toBeNull();
+    expect(validateDispatchAssignment(fakePluginInput as unknown as string)).toEqual({
+      ok: true,
+      violations: [],
+    });
+  });
+
+  test("server() returns real hooks with config", async () => {
+    const hooks = await pluginModule.server();
+    expect(typeof hooks.config).toBe("function");
+    expect(typeof hooks["tool.execute.before"]).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- Root cause of remaining OpenCode startup errors (`plugin config hook failed: N.config` / `N.dispose`): OpenCode's legacy loader treats every function export as a plugin, so `validateStatusWrite` / `validateDispatchAssignment` were invoked with `PluginInput` and pushed `null` into the hooks list.
- Default-export `{ server: MorningStarHarnessPlugin }` so `readV1Plugin` wins and skips the legacy scan.
- Adds entry-shape regression test + changelog fragment.

## Test plan
- [x] `bun test test/plugin-entry-shape.test.ts test/dispatch-presence-hook.test.ts test/status-write-hook.test.ts`
- [ ] Point OpenCode at local `packages/opencode` (or post-publish `@latest`) and confirm log no longer shows `plugin config hook failed` / `N.config` on startup


Made with [Cursor](https://cursor.com)