### PR TITLE
feat(iteration-start): auto-continue Phase 2->5 by default; add pause arg

### DIFF
--- a/.changes/unreleased/iteration-start-auto-continue.md
+++ b/.changes/unreleased/iteration-start-auto-continue.md
@@ -2,7 +2,7 @@
 category: Harness
 packages: root, opencode
 ---
-- `/iteration-start`: auto-continue into Phase 2→5 (execute → close → PR → merge-ready) after Phase 1 lock + integration branch, by default. New `pause` arg stops after Phase 1 (run `/iteration-drive` to resume). `/iteration-drive` remains standalone for re-entry/resume on an already-locked iteration. Updated `iteration-loop` vs-commands table, README/README_CN command tables + workflow diagrams, OpenCode package quick start; added routing eval `iteration-start-auto-continue-phase2`.
+- `/iteration-start`: accepts an optional `direction` hint (constrains §2 candidates, seeds §3 grill-me — start stays interactive) and a `pause` flag; auto-continues into Phase 2→5 (execute → close → PR → merge-ready) after Phase 1 lock + integration branch, by default. `/iteration-drive` remains standalone for re-entry/resume on an already-locked iteration. Updated `iteration-loop` vs-commands table, README/README_CN command tables + workflow diagrams, OpenCode package quick start; added routing eval `iteration-start-auto-continue-phase2`.
 
 <!-- CN -->
-- `/iteration-start`：Phase 1 锁定 + integration branch 后默认自动推进 Phase 2→5（execute → close → PR → merge-ready）。新增 `pause` 参数可止于 Phase 1（后续用 `/iteration-drive` 恢复）。`/iteration-drive` 仍作为独立 re-entry/resume 命令保留。同步更新 `iteration-loop` 对比表、README/README_CN 命令表与流程图、OpenCode 包 quick start；新增 routing eval `iteration-start-auto-continue-phase2`。
+- `/iteration-start`：新增可选 `direction` 提示（约束 §2 候选、种子 §3 grill-me —— start 仍为交互式）与 `pause` 标志；Phase 1 锁定 + integration branch 后默认自动推进 Phase 2→5（execute → close → PR → merge-ready）。`/iteration-drive` 仍作为独立 re-entry/resume 命令保留。同步更新 `iteration-loop` 对比表、README/README_CN 命令表与流程图、OpenCode 包 quick start；新增 routing eval `iteration-start-auto-continue-phase2`。

--- a/.changes/unreleased/iteration-start-auto-continue.md
+++ b/.changes/unreleased/iteration-start-auto-continue.md
@@ -1,0 +1,8 @@
+---
+category: Harness
+packages: root, opencode
+---
+- `/iteration-start`: auto-continue into Phase 2→5 (execute → close → PR → merge-ready) after Phase 1 lock + integration branch, by default. New `pause` arg stops after Phase 1 (run `/iteration-drive` to resume). `/iteration-drive` remains standalone for re-entry/resume on an already-locked iteration. Updated `iteration-loop` vs-commands table, README/README_CN command tables + workflow diagrams, OpenCode package quick start; added routing eval `iteration-start-auto-continue-phase2`.
+
+<!-- CN -->
+- `/iteration-start`：Phase 1 锁定 + integration branch 后默认自动推进 Phase 2→5（execute → close → PR → merge-ready）。新增 `pause` 参数可止于 Phase 1（后续用 `/iteration-drive` 恢复）。`/iteration-drive` 仍作为独立 re-entry/resume 命令保留。同步更新 `iteration-loop` 对比表、README/README_CN 命令表与流程图、OpenCode 包 quick start；新增 routing eval `iteration-start-auto-continue-phase2`。

--- a/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
+++ b/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
@@ -979,6 +979,50 @@
         "inline whole-plan dispatch instead of SDD per-task",
         "assignment uses non-English field keys"
       ]
+    },
+    {
+      "id": "iteration-start-direction-hint-parse",
+      "prompt": "/iteration-start 补齐 deferred auth 缺口。请开局。",
+      "expected_route": [
+        "@project-manager"
+      ],
+      "must_have_artifacts": [
+        "Context Loaded declaration",
+        "direction hint parsed as '补齐 deferred auth 缺口' (not treated as pause flag)",
+        "§2 candidates narrowed toward the auth-deferred hint while still scoping 2-4",
+        "grill-me seeded with the direction hint as recommended direction (start stays interactive)",
+        "auto-continue into Phase 2 (no separate /iteration-drive invocation required)"
+      ],
+      "hard_fail_if": [
+        "missing Context Loaded declaration",
+        "treats the Chinese direction text as the pause flag",
+        "skips grill-me and auto-locks the direction (start must stay interactive)",
+        "ignores the direction hint entirely",
+        "assignment uses non-English field keys"
+      ]
+    },
+    {
+      "id": "iteration-start-pause-stops-at-phase1",
+      "prompt": "/iteration-start pause。开局一个新迭代。",
+      "expected_route": [
+        "@project-manager",
+        "@product-manager",
+        "@architect",
+        "@writing-specialist"
+      ],
+      "must_have_artifacts": [
+        "Context Loaded declaration",
+        "pause flag parsed — no auto-continue into Phase 2",
+        "Phase 1 full run: research → grill-me → compass → sequential Review & Edit chain → PM lock → integration branch",
+        "command ends at §6 with a note to run /iteration-drive to resume"
+      ],
+      "hard_fail_if": [
+        "missing Context Loaded declaration",
+        "auto-continues into Phase 2 despite the pause flag",
+        "treats pause as a direction hint",
+        "skips the Review & Edit chain or PM lock",
+        "assignment uses non-English field keys"
+      ]
     }
   ]
 }

--- a/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
+++ b/.cursor/skills/mstar-routing-eval/assets/routing-evals.json
@@ -957,6 +957,28 @@
         "parks unrelated fixable findings as residual alongside blocker defer",
         "assignment uses non-English field keys"
       ]
+    },
+    {
+      "id": "iteration-start-auto-continue-phase2",
+      "prompt": "iteration-start：Phase 1 已完成——grill-me 收敛了方向，compass 已 locked，integration branch 已 push。继续推进，不要等我再发指令",
+      "expected_route": [
+        "@project-manager",
+        "@fullstack-dev"
+      ],
+      "must_have_artifacts": [
+        "Context Loaded declaration",
+        "Phase 2 boot (mstar-sdd, mstar-review-qc, mstar-branch-worktree, phase-2-worktree-lease)",
+        "continuous execution — Phase 1 lock then immediate Phase 2 dispatch without asking user to run /iteration-drive",
+        "SDD per-task implement dispatch (not inline whole-plan)",
+        "in-flight dispatch as turn closure (no confirmation question)"
+      ],
+      "hard_fail_if": [
+        "missing Context Loaded declaration",
+        "stops after Phase 1 and asks user to run /iteration-drive",
+        "ends turn with a confirmation question instead of dispatch",
+        "inline whole-plan dispatch instead of SDD per-task",
+        "assignment uses non-English field keys"
+      ]
     }
   ]
 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -375,7 +375,8 @@ npx @mstar-harness/cli plugin validate --root ~/.mstar/harness
    - omp: use `/skill:pm` (no session auto-load).
 
 2. **Run an iteration** (see [README — Harness Commands](README.md#harness-commands))
-   - **Deep / first iteration:** `/iteration-start` (Phase 1) → `/iteration-drive` (Phase 2–5).
+   - **Deep / first iteration:** `/iteration-start` (Phase 1 grill-me → auto-continues Phase 2→5; `pause` to stop after Phase 1).
+   - **Resume interrupted iteration:** `/iteration-drive` (Phase 2→5 re-entry).
    - **Fast autonomous loop:** `/iteration-loop` (Phase 1→5, optional `direction` + `scale`).
 
 3. **Project knowledge** — bootstrap or refresh via the `mstar-compound-refresh` skill (`references/project-knowledge-bootstrap.md`), not a separate install step.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ Enter PM, then run the per-plan cycle: `Prepare → Execute → QC → QA gate �
 
 | Path | When |
 |------|------|
-| `/iteration-start` → `/iteration-drive` | First iteration, or need human direction lock before execute |
-| `/iteration-loop` | Full Phase 1→5 with minimal check-ins (optional `direction`, `scale` S\|M\|L\|XL) |
+| `/iteration-start` | Phase 1 (interactive grill-me) then auto-continues Phase 2→5; `pause` to stop after Phase 1 |
+| `/iteration-drive` | Resume Phase 2→5 on an already-locked iteration |
+| `/iteration-loop` | Full Phase 1→5 autonomous (no grill-me; optional `direction`, `scale` S\|M\|L\|XL) |
 
 ### Codebase audit
 
@@ -117,11 +118,11 @@ flowchart TD
     C --> B
     B -->|Yes| D["PM: initialize/load HARNESS_DIR and PLAN_DIR"]
     D --> E{"Iteration scope needed"}
-    E -->|Deep / first iteration| F["iteration-start: compass, plans, review chain"]
+    E -->|Deep / first iteration| F["iteration-start: grill-me → compass → review → lock"]
     E -->|Fast autonomous loop| F2["iteration-loop: Phase 1→5 continuous"]
     F --> G["PM: lock compass and create integration branch"]
     F2 --> G
-    G --> H["iteration-drive or loop continues: execute → close → PR → merge-ready"]
+    G --> H["Phase 2→5: execute → close → PR → merge-ready"]
     E -->|No| I["PM: select active plan from status.json"]
     H --> I
     I --> J{"Any plan not Done"}

--- a/README_CN.md
+++ b/README_CN.md
@@ -83,8 +83,9 @@ npx @mstar-harness/cli init
 
 | 路径 | 何时 |
 |------|------|
-| `/iteration-start` → `/iteration-drive` | 首次迭代，或需要人工方向锁定后再执行 |
-| `/iteration-loop` | Phase 1→5 连续少确认（可选 `direction`、`scale` S\|M\|L\|XL） |
+| `/iteration-start` | Phase 1（交互式 grill-me）后自动推进 Phase 2→5；`pause` 可止于 Phase 1 |
+| `/iteration-drive` | 在已锁定的迭代上恢复 / 继续推进 Phase 2→5 |
+| `/iteration-loop` | Phase 1→5 全自动（无 grill-me；可选 `direction`、`scale` S\|M\|L\|XL） |
 
 ### 代码库审计
 
@@ -117,11 +118,11 @@ flowchart TD
     C --> B
     B -->|是| D["PM: 初始化或加载 HARNESS_DIR 与 PLAN_DIR"]
     D --> E{"是否需要 iteration scope"}
-    E -->|深度 / 首次 iteration| F["iteration-start: compass、plans、review chain"]
+    E -->|深度 / 首次 iteration| F["iteration-start: grill-me → compass → review → lock"]
     E -->|快速自动化闭环| F2["iteration-loop: Phase 1→5 连续"]
     F --> G["PM: 锁定 compass 并创建 integration branch"]
     F2 --> G
-    G --> H["iteration-drive 或 loop 继续: execute → close → PR → merge-ready"]
+    G --> H["Phase 2→5: execute → close → PR → merge-ready"]
     E -->|否| I["PM: 从 status.json 选择 active plan"]
     H --> I
     I --> J{"是否仍有 plan 未 Done"}

--- a/commands/iteration-loop.md
+++ b/commands/iteration-loop.md
@@ -11,9 +11,8 @@ Run a **full** Morning Star iteration with minimal human intervention. **Done = 
 **vs other commands:**
 
 | Command | Scope |
-|---------|--------|
-| `iteration-start` | Phase 1 only; **grill-me** with user |
-| `iteration-drive` | Phase 2→5 on an already locked iteration |
+| `iteration-start` | Phase 1 (**grill-me** with user) → **auto-continue** Phase 2→5（`pause` 止于 Phase 1） |
+| `iteration-drive` | Phase 2→5 re-entry / resume on an already locked iteration |
 | **`iteration-loop`** | Phase 1→5 end-to-end; **autonomous** direction lock |
 
 Phase gate SSOT → **`mstar-iteration`** §1–§5. This command is a **consumer**; it does not redefine skill semantics.

--- a/commands/iteration-start.md
+++ b/commands/iteration-start.md
@@ -1,12 +1,22 @@
 ---
 name: iteration-start
-description: Start a new harness iteration — research, grill-me, compass/plans, Review & Edit chain (long-lived {SPECS_DIR}/ + {ITERATION_DIR}/<id>/ package; compound promotes package at close only), PM lock, integration branch.
+description: "Start a new harness iteration — research, grill-me, compass/plans, Review & Edit chain (long-lived {SPECS_DIR}/ + {ITERATION_DIR}/<id>/ package; compound promotes package at close only), PM lock, integration branch; then auto-continue Phase 2→5 (execute → close → PR → merge-ready) unless `pause` arg given."
 agent: project-manager
 ---
 
 # Start Iteration
 
-Start a new Morning Star harness iteration. **Not Done until the Review & Edit chain runs via dispatched roles and PM lock — not when compass files are first written.**
+Start a new Morning Star harness iteration. **Phase 1 is not complete until the Review & Edit chain runs via dispatched roles and PM lock — not when compass files are first written.** By default, after Phase 1 lock + integration branch, **auto-continue into Phase 2→5** (execute → close → PR → merge-ready); pass **`pause`** to stop after Phase 1 and resume later with `/iteration-drive`.
+
+## Args
+
+```text
+/iteration-start [pause]
+```
+
+| Arg | Meaning | Default |
+|-----|---------|---------|
+| `pause` | Stop after Phase 1 (lock + integration branch); run `/iteration-drive` later to resume | **Auto-continue** into Phase 2→5 |
 
 ## PM invariants（本命令全程有效 — 读完再动手）
 
@@ -20,9 +30,11 @@ Start a new Morning Star harness iteration. **Not Done until the Review & Edit c
 
 派发细则 → **`mstar-dispatch-gates`**（specialist review-and-edit dispatch）+ **`mstar-host`**（宿主 invoke 能力）。**不得**在 PM 线程加载其他 role reference 代劳。
 
-**完成定义**：compass `status: locked` + 三角色 invoke 已返回 + pre-commit checklist 全 `[x]` — 不是初稿落盘。
+**Phase 1 完成定义**：compass `status: locked` + 三角色 invoke 已返回 + pre-commit checklist 全 `[x]` — 不是初稿落盘。**Command Done**（§7 auto-continue）= Phase 5 §5.5 exit checklist 全 `[x]`（同 `iteration-drive`）；`pause` 时 = Phase 1 完成。
 
 Detailed workflow → **`mstar-iteration` § Phase 1**；per-plan Prepare gates → **`mstar-phase-gates`**（specify → clarify → plan）。
+
+**Phase 2–5 auto-continue（§7）invariants** → **`iteration-drive`**「PM invariants」表（不写产品代码 / 不 inline 大包 / 每 Assignment 1 invoke / Phase 3→4→5 顺序 / Phase 5 dispatch 改代码）。
 
 ## Path split（HARD — 路由）
 
@@ -30,6 +42,8 @@ Detailed workflow → **`mstar-iteration` § Phase 1**；per-plan Prepare gates 
 |------------|--------|
 | **Cursor Plan mode**（CreatePlan / Plan 会话活跃） | §0 Boot → **§P** — **先**空白 CreatePlan，再 **feedback-driven** 自主改同一份 plan；grill-me **仅**在用户明确结束反馈后、仍有阻塞疑问时；**Build 前不执行** Review 链 / commit / integration 分支 |
 | **其它**（Agent、OpenCode、非 Plan） | §0 Boot → §1–§6（Research → Explore → grill-me → Write → Review → branch） |
+
+**Both paths converge at §6**（integration branch）。Default → §7 auto-continue Phase 2→5；`pause` → command ends at §6。
 
 ## 0. Boot
 
@@ -130,6 +144,34 @@ git checkout -b <spec_integration_branch> <iteration_base_branch>
 - Register `iteration_base_branch`, `spec_integration_branch`, and `target_branch` in compass frontmatter **and** `{HARNESS_DIR}/status.json` root `metadata`
 - Commit all documents to the integration branch and push to remote
 
-**Phase 2 note**：control worktree + `execution_lease` 门控在 Phase 2 入口（`iteration-drive` / `iteration-loop`）——见 **`mstar-iteration/references/phase-2-worktree-lease.md`**。
-
 **STOP** if `iteration_base_branch` or `target_branch` is missing. Ask the user or derive only from an already documented project/iteration policy; never silently substitute `main`.
+
+---
+
+## 7. Phase 2–5: Execute → close → PR → merge-ready（auto-continue）
+
+**`pause` arg → command ends here.** Phase 1 locked + integration branch pushed；run `/iteration-drive` later to resume。
+
+**Default（no `pause`）→ auto-continue** into Phase 2→5。
+
+### Phase 2 boot（load before delegating）
+
+1. `mstar-iteration` → **§ Phase 2–5**（§2 Autonomous Execute、§3 close、§4 PR、§5 merge-ready）
+2. **`mstar-sdd`** — before first implement dispatch（per-task loop SSOT）
+3. `mstar-review-qc` — before first QC dispatch
+4. `mstar-compound` — before Phase 3 §3.2
+5. `mstar-branch-worktree` + **`mstar-iteration/references/phase-2-worktree-lease.md`** — control worktree + lease（§2.0 #5 未 waive）
+
+### Delegate to `iteration-drive` Phase 2→5
+
+Execute **`iteration-drive`** Phase 2–5 exactly：Phase 2 → **`mstar-iteration` §2**（§2.0 五道闸 → §2.6 push 纪律；SDD per-task；QC tri N=3 + QA）、Phase 3 → **§3** + `references/phase-3-iteration-close.md`、Phase 4/5 → **§4–§5** + `references/phase-4-5-pr-delivery.md`、Phase 5 helper discovery → `mstar-iteration/references/phase5-helper-discovery.md`。
+
+**Continuous execution（HARD）**：自 Phase 2 进入至 Phase 5 §5.5 exit，PM **连续编排**（**`mstar-iteration` §2.6**），进度汇报后下一条必须是 dispatch 或下一 phase 步骤，不向用户例行 yes/no check-in。合法 STOP 仅限：branch metadata 缺失、真冲突 / secrets / 不可逆范围缺口、Phase 5 多轮仍无法 merge-ready、用户本轮显式打断。
+
+**Assignment preflight**：同 §5（每次 implement/QC/QA 派发前校验；`mstar-harness` bin 未安装时静默跳过）。
+
+**Done = Phase 5 §5.5 exit checklist 全 `[x]`**（同 `iteration-drive`）。
+
+**Then** report: iteration id, direction lock summary, plans completed, compound summary, PR link, merge-ready evidence（CI snapshot + review resolution + Greptile if applicable）。
+
+PR merge itself may remain manual unless user authorized auto-merge.

--- a/commands/iteration-start.md
+++ b/commands/iteration-start.md
@@ -85,6 +85,8 @@ Scope **2–4** candidates targeting **product completeness**（default to defer
 
 **Direction lock mode: `interactive`**（`mstar-iteration` §1.2 默认；本命令不使用 `autonomous`）。
 
+This command bundles a **non-`mstar-*`** skill at `skills/grill-me/SKILL.md`. **Only this command step**（及 §P.3.5 deferred grill）references it — **do not** load it from `mstar-harness-core` or other `mstar-*` skills.
+
 **Before this step:** Read `skills/grill-me/SKILL.md`. Run **grill-me** to stress-test candidate directions with the user: walk through trade-offs, converge on a **single iteration direction** with shared understanding, document locked direction + success criteria + non-goals。**If `direction` arg given** — seed grill-me with it as the recommended direction (still interactive: user may correct/refine; the hint does **not** skip grill-me)。Confirm delivery branch policy（`iteration_base_branch`、`target_branch`）per **`mstar-iteration` §1.2** — **Do not default to `main` / `master` just because those names exist.**
 
 ## 4. Write Compass & Plans

--- a/commands/iteration-start.md
+++ b/commands/iteration-start.md
@@ -1,6 +1,6 @@
 ---
 name: iteration-start
-description: "Start a new harness iteration — research, grill-me, compass/plans, Review & Edit chain (long-lived {SPECS_DIR}/ + {ITERATION_DIR}/<id>/ package; compound promotes package at close only), PM lock, integration branch; then auto-continue Phase 2→5 (execute → close → PR → merge-ready) unless `pause` arg given."
+description: "Start a new harness iteration — optional direction hint, research, grill-me, compass/plans, Review & Edit chain (long-lived {SPECS_DIR}/ + {ITERATION_DIR}/<id>/ package; compound promotes package at close only), PM lock, integration branch; then auto-continue Phase 2→5 (execute → close → PR → merge-ready) unless `pause` arg given."
 agent: project-manager
 ---
 
@@ -11,12 +11,15 @@ Start a new Morning Star harness iteration. **Phase 1 is not complete until the 
 ## Args
 
 ```text
-/iteration-start [pause]
+/iteration-start [direction] [pause]
 ```
 
 | Arg | Meaning | Default |
 |-----|---------|---------|
+| `direction` | Iteration direction hint — constrains §2 candidates and seeds §3 grill-me; **not** a lock (start stays interactive) | Research → grill-me converges with user |
 | `pause` | Stop after Phase 1 (lock + integration branch); run `/iteration-drive` later to resume | **Auto-continue** into Phase 2→5 |
+
+**Parse**: if any token is exactly `pause` (case-insensitive), treat as the `pause` flag; the remaining tokens (joined) are the `direction` hint. `/iteration-start pause` = pause with empty direction.
 
 ## PM invariants（本命令全程有效 — 读完再动手）
 
@@ -72,11 +75,9 @@ Command-unique 补充（bridge 未枚举）：
 
 Survey structured harness dirs（`{HARNESS_DIR}/status.json`、`{ITERATION_DIR}/`、`{KNOWLEDGE_DIR}/`、`{SPECS_DIR}/`）+ glob for planning artifacts（`**/roadmap*.md`、`**/deferred*.md`、`**/features*.md`、`**/backlog*.md`、`**/TODO*.md`、`**/*.plan.md`）；read matches with iteration-level / deferred-scope information；read `STRATEGY.md`（if exists）。Prioritize deferred / incomplete items from prior iterations。
 
-**Optional — codebase audit**: if a prior `/codebase-audit` run exists under `{PLAN_DIR}/audit-<date>/`, read its findings index as evidence-grounded direction candidates for §2（not mandatory；one source among many）。
-
 ## 2. Explore Directions
 
-Scope **2–4** candidates targeting **product completeness**（default to deferred items from previous iterations；allow substantive refactoring where it accelerates product maturity）。**非 Plan 路径**（Plan mode 已由 §P 处理）。
+Scope **2–4** candidates targeting **product completeness**（default to deferred items from previous iterations；allow substantive refactoring where it accelerates product maturity）。**If `direction` arg given** — narrow candidates to that hint (still scope 2–4 unless the hint is explicitly singular); record the hint in grill-me context。**非 Plan 路径**（Plan mode 已由 §P 处理）。
 
 ## 3. Lock Direction — bundled `grill-me`
 
@@ -84,9 +85,7 @@ Scope **2–4** candidates targeting **product completeness**（default to defer
 
 **Direction lock mode: `interactive`**（`mstar-iteration` §1.2 默认；本命令不使用 `autonomous`）。
 
-This command bundles a **non-`mstar-*`** skill at `skills/grill-me/SKILL.md`. **Only this command step**（及 §P.3.5 deferred grill）references it — **do not** load it from `mstar-harness-core` or other `mstar-*` skills.
-
-**Before this step:** Read `skills/grill-me/SKILL.md`. Run **grill-me** to stress-test candidate directions with the user: walk through trade-offs, converge on a **single iteration direction** with shared understanding, document locked direction + success criteria + non-goals。Confirm delivery branch policy（`iteration_base_branch`、`target_branch`）per **`mstar-iteration` §1.2** — **Do not default to `main` / `master` just because those names exist.**
+**Before this step:** Read `skills/grill-me/SKILL.md`. Run **grill-me** to stress-test candidate directions with the user: walk through trade-offs, converge on a **single iteration direction** with shared understanding, document locked direction + success criteria + non-goals。**If `direction` arg given** — seed grill-me with it as the recommended direction (still interactive: user may correct/refine; the hint does **not** skip grill-me)。Confirm delivery branch policy（`iteration_base_branch`、`target_branch`）per **`mstar-iteration` §1.2** — **Do not default to `main` / `master` just because those names exist.**
 
 ## 4. Write Compass & Plans
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -46,7 +46,7 @@ The plugin registers a non-blocking `tool.execute.before` lint for the `task` to
 
 1. Install the plugin (above).
 2. In OpenCode, start with the **Project Manager** agent (`project-manager`).
-3. For a full iteration: run **`/iteration-start`** then **`/iteration-drive`**, or one-shot **`/iteration-loop`** (autonomous Phase 1→5).
+3. For a full iteration: run **`/iteration-start`** (Phase 1 grill-me → auto-continues Phase 2→5; add `pause` to stop after Phase 1), or one-shot **`/iteration-loop`** (autonomous Phase 1→5). Use **`/iteration-drive`** to resume an interrupted iteration.
 
 Entry skill: **`mstar-harness-core`** (loaded before other `mstar-*` skills).
 


### PR DESCRIPTION
## Why

After Phase 1 (grill-me + lock + integration branch), users had to manually run `/iteration-drive` to continue — a redundant step. `/iteration-start` now continues into Phase 2→5 by default.

## Change

- **`/iteration-start`** — default: after Phase 1 lock + integration branch, auto-continue Phase 2→5 (execute → close → PR → merge-ready), delegating to the `iteration-drive` Phase 2→5 flow with Continuous execution discipline.
- **`/iteration-start pause`** — new arg: stop after Phase 1 (old behavior). Run `/iteration-drive` to resume.
- **`/iteration-drive`** — **unchanged**. Remains the standalone re-entry/resume command (interrupted iterations, cross-session continuation) and the delegation target of `/iteration-loop`.
- **`/iteration-loop`** — unchanged behavior; only its vs-commands table updated.

## Why keep `iteration-drive` separate

Merging drive into start would:
1. Bloat start from ~136 to ~270 lines while forcing `loop` (which delegates to drive at L117) to either duplicate Phase 2→5 or reference start internals.
2. Destroy drive's primary value: **re-entry** (resume interrupted iterations, restart after blocker clears, recover from session crash mid-Phase-5).
3. Add a name-only `pause` toggle that, when off, just renames drive.
4. Touch ~14 routing-eval cases, CLI adapters, tests, install metadata — large blast radius for cosmetic gain.

Keeping drive standalone + making start auto-continue into it eliminates the duplicate-command UX pain with minimal change.

## Files

| File | Change |
|------|--------|
| `commands/iteration-start.md` | `pause` arg + Args table; §7 auto-continue (Phase 2 boot → delegate to drive, Continuous execution HARD, Done = Phase 5 §5.5 exit); description updated |
| `commands/iteration-loop.md` | vs-commands table (start: auto-continue; drive: re-entry/resume) |
| `README.md` / `README_CN.md` | command table 2→3 rows; workflow diagram F/H nodes |
| `INSTALL.md` | post-install usage (start auto-continue, drive re-entry, loop) |
| `packages/opencode/README.md` | quick start |
| `.cursor/skills/.../routing-evals.json` | new `iteration-start-auto-continue-phase2` case |
| `.changes/unreleased/iteration-start-auto-continue.md` | changelog fragment (root + opencode) |

## Verification

- ✅ 19/19 dispatch-preflight tests pass (`bun test test/dispatch-preflight-commands.test.ts`)
- ✅ routing-evals.json valid JSON
- ✅ preflight snippets preserved in §5 (L104/L110); §7 references "同 §5" — no duplication
- ✅ No CLI adapter / test / install mechanism changes (command names unchanged; all three remain)

## Decision context

User proposed merging `iteration-drive` into `iteration-start` with a `pause` param. Analysis showed the actual pain was "having to issue a second command," not "drive is redundant." The minimal fix — auto-continue default + `pause` opt-out + drive kept for re-entry — resolves the pain without the blast radius of deletion.