### PR TITLE
fix(gitignore): default-ignore harness dir with explicit tracked re-includes

### DIFF
--- a/.changes/unreleased/gitignore-default-ignore.md
+++ b/.changes/unreleased/gitignore-default-ignore.md
@@ -1,0 +1,8 @@
+---
+category: Harness
+packages: root, opencode, cli, engine
+---
+- Canonical `.gitignore` snippet now default-ignores the whole harness dir (`<dir>/**`) and re-includes only the tracked results (AGENTS.md, knowledge/, specs/) — new process subdirectories are ignored automatically.
+
+<!-- CN -->
+- canonical `.gitignore` 片段改为默认忽略整个 harness 目录（`<dir>/**`），仅白名单跟踪结果（AGENTS.md、knowledge/、specs/）—— 新增进程子目录自动被忽略。

--- a/packages/cli/src/adapters/shared-install.ts
+++ b/packages/cli/src/adapters/shared-install.ts
@@ -174,20 +174,20 @@ export function validateSymlink(target: string, linkPath: string) {
   return errors;
 }
 
-/** Harness process artifacts (not results: knowledge/, specs/, AGENTS.md). */
+/** Harness .gitignore fence entries: default-ignore the harness dir, re-include tracked results. */
 export const HARNESS_PROCESS_GITIGNORE = [
-  ".mstar/archived/",
-  ".mstar/iterations/",
-  ".mstar/plans/",
-  ".mstar/sdd/",
-  ".mstar/notes.json",
-  ".mstar/status.json",
-  ".agents/archived/",
-  ".agents/iterations/",
-  ".agents/plans/",
-  ".agents/sdd/",
-  ".agents/notes.json",
-  ".agents/status.json",
+  ".mstar/**",
+  "!.mstar/AGENTS.md",
+  "!.mstar/knowledge/",
+  "!.mstar/knowledge/**",
+  "!.mstar/specs/",
+  "!.mstar/specs/**",
+  ".agents/**",
+  "!.agents/AGENTS.md",
+  "!.agents/knowledge/",
+  "!.agents/knowledge/**",
+  "!.agents/specs/",
+  "!.agents/specs/**",
 ];
 
 export function missingHarnessProcessGitignoreEntries(gitignoreContent: string): string[] {

--- a/packages/engine/src/path.ts
+++ b/packages/engine/src/path.ts
@@ -249,7 +249,9 @@ export function emitGitignoreSnippet(kind?: HarnessKind): string {
 
 /**
  * Validate that `<root>/.gitignore` contains a complete canonical
- * process-artifact ignore set (plan-conventions § Git 跟踪策略). Rule
+ * harness ignore set — default-ignore `<dir>/**` plus the tracked
+ * re-includes (AGENTS.md, knowledge/, specs/) per plan-conventions
+ * § Git 跟踪策略. Rule
  * (chosen alignment): the gate passes when the repo's .gitignore holds ONE
  * complete set for the DETECTED harness kind — `.mstar/` for a `.mstar`
  * harness, `.agents/` for a legacy `.agents` harness; layouts without a
@@ -316,7 +318,7 @@ export function validateGitignore(root: string): ValidationResult {
     ok: true,
     severity: "low",
     code: "gitignore.ok",
-    message: `.gitignore at ${gitignorePath} contains a complete canonical harness process-artifact ignore set (${label})`,
+    message: `.gitignore at ${gitignorePath} contains a complete canonical harness ignore set — default-ignore + tracked re-includes (${label})`,
   };
 }
 

--- a/packages/engine/src/path.ts
+++ b/packages/engine/src/path.ts
@@ -186,21 +186,19 @@ export function scaffoldHarness(root: string): string {
  * Canonical `.mstar/` `.gitignore` snippet — verbatim embedded copy of the
  * skill's canonical snippet (plan-conventions § Git 跟踪策略; the skill is
  * the SSOT, this constant exists so the engine never reads skill files at
- * runtime). NOTE: it is NOT byte-identical to the CLI `init` fence — the
- * CLI currently appends a flat dual-prefix entry list (packages/cli
- * src/adapters/shared-install.ts HARNESS_PROCESS_GITIGNORE). Ends with a
+ * runtime). The CLI `init` fence (packages/cli/src/adapters/shared-install.ts
+ * HARNESS_PROCESS_GITIGNORE) mirrors these entries verbatim. Ends with a
  * trailing newline so it can be appended directly.
  */
 const GITIGNORE_SNIPPET = `# Morning Star harness (.mstar/)
 # Principle: process stays local; results are shared with the team.
-# Ignored (process / coordination):
-.mstar/archived/
-.mstar/iterations/
-.mstar/plans/
-.mstar/sdd/
-.mstar/notes.json
-.mstar/status.json
-# Tracked (results): .mstar/AGENTS.md, .mstar/knowledge/, .mstar/specs/
+# Default-ignore everything under .mstar/, then re-include the tracked results.
+.mstar/**
+!.mstar/AGENTS.md
+!.mstar/knowledge/
+!.mstar/knowledge/**
+!.mstar/specs/
+!.mstar/specs/**
 `;
 
 /**
@@ -210,23 +208,23 @@ const GITIGNORE_SNIPPET = `# Morning Star harness (.mstar/)
  * is `.agents`.
  */
 const GITIGNORE_SNIPPET_AGENTS = `# Morning Star harness (.agents/) — legacy
-.agents/archived/
-.agents/iterations/
-.agents/plans/
-.agents/sdd/
-.agents/notes.json
-.agents/status.json
-# Tracked (results): .agents/AGENTS.md, .agents/knowledge/, .agents/specs/
+# Default-ignore everything under .agents/, then re-include the tracked results.
+.agents/**
+!.agents/AGENTS.md
+!.agents/knowledge/
+!.agents/knowledge/**
+!.agents/specs/
+!.agents/specs/**
 `;
 
-/** Process-artifact ignore entries, derived from the `.mstar/` snippet. */
+/** Harness `.gitignore` fence entries (ignore + re-include), derived from the `.mstar/` snippet. */
 const GITIGNORE_PROCESS_ENTRIES: readonly string[] = GITIGNORE_SNIPPET.split("\n")
-  .filter((line) => line.startsWith(".mstar/"))
+  .filter((line) => line.startsWith(".mstar/") || line.startsWith("!.mstar/"))
   .map((line) => line.trim());
 
-/** Process-artifact ignore entries, derived from the legacy `.agents/` snippet. */
+/** Harness `.gitignore` fence entries (ignore + re-include), derived from the legacy `.agents/` snippet. */
 const GITIGNORE_PROCESS_ENTRIES_AGENTS: readonly string[] = GITIGNORE_SNIPPET_AGENTS.split("\n")
-  .filter((line) => line.startsWith(".agents/"))
+  .filter((line) => line.startsWith(".agents/") || line.startsWith("!.agents/"))
   .map((line) => line.trim());
 
 /**
@@ -238,10 +236,10 @@ export type HarnessKind = "mstar" | "agents";
 
 /**
  * Emit the canonical `.gitignore` snippet for `kind` (plan-conventions
- * § Git 跟踪策略): the process-artifact ignore set (`archived/`,
- * `iterations/`, `plans/`, `sdd/`, `notes.json`, `status.json` under the
- * harness dir) with the tracked/results note. When the kind is unknown
- * (omitted), both snippets are emitted so either fence can be applied.
+ * § Git 跟踪策略): default-ignore the whole harness dir (`<dir>/**`) and
+ * re-include only the tracked results (AGENTS.md, knowledge/, specs/).
+ * When the kind is unknown (omitted), both snippets are emitted so either
+ * fence can be applied.
  */
 export function emitGitignoreSnippet(kind?: HarnessKind): string {
   if (kind === "agents") return GITIGNORE_SNIPPET_AGENTS;

--- a/packages/engine/test/path.test.ts
+++ b/packages/engine/test/path.test.ts
@@ -50,25 +50,24 @@ const ENV_KEY = "MSTAR_HARNESS_DIR";
 /** Canonical snippet text — verbatim from plan-conventions § Git 跟踪策略. */
 const CANONICAL_SNIPPET = `# Morning Star harness (.mstar/)
 # Principle: process stays local; results are shared with the team.
-# Ignored (process / coordination):
-.mstar/archived/
-.mstar/iterations/
-.mstar/plans/
-.mstar/sdd/
-.mstar/notes.json
-.mstar/status.json
-# Tracked (results): .mstar/AGENTS.md, .mstar/knowledge/, .mstar/specs/
+# Default-ignore everything under .mstar/, then re-include the tracked results.
+.mstar/**
+!.mstar/AGENTS.md
+!.mstar/knowledge/
+!.mstar/knowledge/**
+!.mstar/specs/
+!.mstar/specs/**
 `;
 
 /** Legacy snippet text — verbatim from plan-conventions § Git 跟踪策略 ("Legacy `.agents/` 等价"). */
 const CANONICAL_SNIPPET_AGENTS = `# Morning Star harness (.agents/) — legacy
-.agents/archived/
-.agents/iterations/
-.agents/plans/
-.agents/sdd/
-.agents/notes.json
-.agents/status.json
-# Tracked (results): .agents/AGENTS.md, .agents/knowledge/, .agents/specs/
+# Default-ignore everything under .agents/, then re-include the tracked results.
+.agents/**
+!.agents/AGENTS.md
+!.agents/knowledge/
+!.agents/knowledge/**
+!.agents/specs/
+!.agents/specs/**
 `;
 
 function tmpRoot(prefix: string): string {
@@ -537,16 +536,16 @@ describe("emitGitignoreSnippet / validateGitignore (plan-conventions § Git 跟�
     try {
       writeFileSync(
         join(root, ".gitignore"),
-        "# Morning Star harness (.mstar/)\n.mstar/plans/\n.mstar/status.json\n",
+        "# Morning Star harness (.mstar/)\n.mstar/**\n!.mstar/AGENTS.md\n",
       );
       const result = validateGitignore(root);
       expect(result.ok).toBe(false);
       expect(result.code).toBe("gitignore.missing-entries");
       // Unknown kind — reports the set needing the fewest additions (.mstar/ here).
-      expect(result.message).toContain(".mstar/archived/");
-      expect(result.message).toContain(".mstar/iterations/");
-      expect(result.message).toContain(".mstar/sdd/");
-      expect(result.message).toContain(".mstar/notes.json");
+      expect(result.message).toContain("!.mstar/knowledge/");
+      expect(result.message).toContain("!.mstar/knowledge/**");
+      expect(result.message).toContain("!.mstar/specs/");
+      expect(result.message).toContain("!.mstar/specs/**");
       expect(result.severity).toBe("medium");
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/skills/mstar-plan-conventions/SKILL.md
+++ b/skills/mstar-plan-conventions/SKILL.md
@@ -103,27 +103,26 @@ Legacy `.agents/` 项目：将上表路径前缀 `.mstar/` 换为 `.agents/`。
 ```gitignore
 # Morning Star harness (.mstar/)
 # Principle: process stays local; results are shared with the team.
-# Ignored (process / coordination):
-.mstar/archived/
-.mstar/iterations/
-.mstar/plans/
-.mstar/sdd/
-.mstar/notes.json
-.mstar/status.json
-# Tracked (results): .mstar/AGENTS.md, .mstar/knowledge/, .mstar/specs/
+# Default-ignore everything under .mstar/, then re-include the tracked results.
+.mstar/**
+!.mstar/AGENTS.md
+!.mstar/knowledge/
+!.mstar/knowledge/**
+!.mstar/specs/
+!.mstar/specs/**
 ```
 
 Legacy `.agents/` 等价：
 
 ```gitignore
 # Morning Star harness (.agents/) — legacy
-.agents/archived/
-.agents/iterations/
-.agents/plans/
-.agents/sdd/
-.agents/notes.json
-.agents/status.json
-# Tracked (results): .agents/AGENTS.md, .agents/knowledge/, .agents/specs/
+# Default-ignore everything under .agents/, then re-include the tracked results.
+.agents/**
+!.agents/AGENTS.md
+!.agents/knowledge/
+!.agents/knowledge/**
+!.agents/specs/
+!.agents/specs/**
 ```
 
 > **Engine check (when available):** import `emitGitignoreSnippet` / `validateGitignore` from `@mstar-harness/engine` in a host hook to emit or validate the canonical snippet above. On `fail` -> do not proceed; fix and re-run. Skill text below remains authoritative when the runtime is absent.


### PR DESCRIPTION
## 说明

Canonical `.gitignore` snippet 改为**默认全 ignore + 白名单**：`.mstar/**`（及 legacy `.agents/**`）默认忽略整个 harness 目录，仅 re-include 跟踪结果（`AGENTS.md`、`knowledge/`、`specs/`）。未来新增进程子目录自动被忽略，无需逐个追加条目。

### 变更
- `skills/mstar-plan-conventions/SKILL.md` — 两处 canonical fence（`.mstar/` + `.agents/` legacy）
- `packages/engine/src/path.ts` — `GITIGNORE_SNIPPET`/`GITIGNORE_SNIPPET_AGENTS` 常量 + `validateGitignore` 推导过滤器（root-cause 修复：原 `.startsWith("<dir>/")` 过滤会丢掉 `!` 前缀 re-include 行，使「仅 `.mstar/**` 无白名单」的部分 fence 通过校验 — 正是本次要修的 bug 态）
- `packages/engine/test/path.test.ts` — fixture 同步（byte-identical fence 断言自动保证 skill/engine 零漂移）
- `packages/cli/src/adapters/shared-install.ts` — `HARNESS_PROCESS_GITIGNORE` 数组（5 host adapter init 消费）
- `.changes/unreleased/gitignore-default-ignore.md` — fragment（`root, opencode, cli, engine`）

### 语义实证（/tmp fixture `git check-ignore`）
- 白名单 3 项（AGENTS.md/knowledge//specs/）→ **不忽略**（目录 re-include 必须目录行 + `/**` 行成对，单目录行实测无效）
- 进程产物 6 项（archived/iterations/plans/sdd/notes.json/status.json）→ **全忽略**

### 验证
- `bun test packages/engine` → 635 pass（含 byte-identical fence）
- `bunx tsc --pretty false` → exit 0
- QC 单席 Approve（0/0/2；2 建议已处置：JSDoc 措辞同步 + R1 residual 登记自动化语义测试后续项）