### PR TITLE
chore(workspace): use workspace:^ for internal engine devDeps

### DIFF
--- a/.changes/unreleased/workspace-protocol-internal-deps.md
+++ b/.changes/unreleased/workspace-protocol-internal-deps.md
@@ -1,0 +1,9 @@
+---
+category: Harness
+packages: root, cli, opencode, dsh
+---
+
+- Internal `@mstar-harness/engine` devDependencies in cli/opencode/dsh now use the `workspace:^` protocol; the release-prep engine-spec sync step was removed.
+
+<!-- CN -->
+- cli/opencode/dsh 的 `@mstar-harness/engine` devDependency 改用 `workspace:^` 协议；移除 release-prep 中的 engine spec 同步步骤。

--- a/.changes/unreleased/workspace-protocol-internal-deps.md
+++ b/.changes/unreleased/workspace-protocol-internal-deps.md
@@ -3,7 +3,7 @@ category: Harness
 packages: root, cli, opencode, dsh
 ---
 
-- Internal `@mstar-harness/engine` devDependencies in cli/opencode/dsh now use the `workspace:^` protocol; the release-prep engine-spec sync step was removed.
+- Internal `@mstar-harness/engine` devDependencies in cli/opencode/dsh now use the `workspace:*` protocol; the release-prep engine-spec sync step was removed.
 
 <!-- CN -->
-- cli/opencode/dsh 的 `@mstar-harness/engine` devDependency 改用 `workspace:^` 协议；移除 release-prep 中的 engine spec 同步步骤。
+- cli/opencode/dsh 的 `@mstar-harness/engine` devDependency 改用 `workspace:*` 协议；移除 release-prep 中的 engine spec 同步步骤。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
 
       - name: OpenCode dep tree (no commander/inquirer)
         run: |
-          TREE="$(npm ls --workspace @mstar-harness/opencode 2>&1)" || {
+          # --omit=dev: engine is a workspace:* devDependency (bundled at build
+          # time); npm ls cannot validate workspace: edges against a
+          # bun-installed tree, and the guard only covers runtime deps.
+          TREE="$(npm ls --workspace @mstar-harness/opencode --omit=dev 2>&1)" || {
             echo "::error::npm ls failed for @mstar-harness/opencode (unresolved dep tree)"
             echo "$TREE"
             exit 1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mstar-harness/engine": "workspace:^"
+    "@mstar-harness/engine": "workspace:*"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mstar-harness/engine": "2.2.0"
+    "@mstar-harness/engine": "workspace:^"
   }
 }

--- a/packages/dsh/package.json
+++ b/packages/dsh/package.json
@@ -83,7 +83,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mstar-harness/engine": "workspace:^",
+    "@mstar-harness/engine": "workspace:*",
     "@types/node": "^25.6.0",
     "@types/react": "~18.3.1",
     "js-yaml": "^4.1.0",

--- a/packages/dsh/package.json
+++ b/packages/dsh/package.json
@@ -83,7 +83,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mstar-harness/engine": "2.2.0",
+    "@mstar-harness/engine": "workspace:^",
     "@types/node": "^25.6.0",
     "@types/react": "~18.3.1",
     "js-yaml": "^4.1.0",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -36,6 +36,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mstar-harness/engine": "workspace:^"
+    "@mstar-harness/engine": "workspace:*"
   }
 }

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -36,6 +36,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@mstar-harness/engine": "2.2.0"
+    "@mstar-harness/engine": "workspace:^"
   }
 }

--- a/scripts/ci-dep-guard.test.ts
+++ b/scripts/ci-dep-guard.test.ts
@@ -1,11 +1,11 @@
 /**
  * scripts/ci-dep-guard.ts — dep-tree guard semantics (qc2 F-004).
  *
- * The CI workflow pipes `npm ls --workspace @mstar-harness/opencode` into
- * `bun run ci:dep-guard`; this test pins the pattern against realistic
- * `npm ls` output lines — scoped `@inquirer/*` packages MUST match (the
- * roadmap's named anti-pattern), while `@commander-js/…`-style names and
- * bare tokens MUST NOT false-positive.
+ * The CI workflow pipes `npm ls --workspace @mstar-harness/opencode
+ * --omit=dev` into `bun run ci:dep-guard`; this test pins the pattern
+ * against realistic `npm ls` output lines — scoped `@inquirer/*` packages
+ * MUST match (the roadmap's named anti-pattern), while `@commander-js/…`-style
+ * names and bare tokens MUST NOT false-positive.
  */
 import { describe, expect, test } from "bun:test";
 import { findForbiddenDeps } from "./ci-dep-guard.ts";

--- a/scripts/ci-dep-guard.ts
+++ b/scripts/ci-dep-guard.ts
@@ -6,8 +6,11 @@
  * `@inquirer/core`, `@inquirer/type` — the roadmap names exactly
  * `commander` + `@inquirer/prompts` as the anti-pattern).
  *
- * Reads `npm ls --workspace @mstar-harness/opencode` output on stdin and
- * exits 1 when a forbidden package appears. The pattern is word-bounded and
+ * Reads `npm ls --workspace @mstar-harness/opencode --omit=dev` output on
+ * stdin and exits 1 when a forbidden package appears. `--omit=dev` prunes
+ * the engine devDependency edge (`workspace:*` — npm ls cannot validate
+ * workspace: edges against a bun-installed tree), leaving the runtime dep
+ * tree the guard covers. The pattern is word-bounded and
  * tolerates the `@` scope prefix so:
  * - `└── @inquirer/prompts@8.4.2` MATCHES (scoped — the slice-3 guard missed
  *   these because the char before `inquirer` was `@`, never `^`/whitespace);

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -308,7 +308,7 @@ async function main(): Promise<void> {
   }
 
   // Internal consumers (cli/opencode/dsh) bundle the engine at build time; their
-  // devDependency uses `workspace:^`, so no per-release spec sync is needed.
+  // devDependency uses `workspace:*`, so no per-release spec sync is needed.
   await bumpInstall(current, version);
   console.log(`bump: ${INSTALL_REF.path}`);
 

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -257,17 +257,6 @@ async function bumpInstall(oldV: string, newV: string): Promise<void> {
   await Bun.write(INSTALL_REF.path, text.replace(re, `$1${newV}$2`));
 }
 
-/** Internal consumers bundle the engine at build time; keep their devDependency
- *  spec aligned with the bumped engine version (workspace resolution, no 404). */
-async function syncEngineDevDepSpec(newV: string): Promise<void> {
-  for (const p of ["packages/cli/package.json", "packages/opencode/package.json", "packages/dsh/package.json"]) {
-    const text = await Bun.file(p).text();
-    const re = /("@mstar-harness\/engine"\s*:\s*")[^"]+(")/;
-    if (!re.test(text)) throw new Error(`${p}: could not find @mstar-harness/engine devDependency spec`);
-    await Bun.write(p, text.replace(re, `$1${newV}$2`));
-  }
-}
-
 function archiveFragments(version: string, frags: Fragment[]): void {
   if (!frags.length) return;
   const dest = `${ARCHIVE_DIR}/${version}`;
@@ -318,13 +307,8 @@ async function main(): Promise<void> {
     console.log(`bump: ${s.path}`);
   }
 
-  // Internal consumers (cli/opencode/dsh) bundle the engine at build time, so
-  // the engine is a devDependency with a version spec. Keep the spec aligned
-  // with the bumped engine version so bun resolves it from the workspace (a
-  // mismatched spec would fall back to the registry and 404 pre-publish).
-  await syncEngineDevDepSpec(version);
-  console.log(`sync: @mstar-harness/engine devDependency spec -> ${version} (cli + opencode + dsh)`);
-
+  // Internal consumers (cli/opencode/dsh) bundle the engine at build time; their
+  // devDependency uses `workspace:^`, so no per-release spec sync is needed.
   await bumpInstall(current, version);
   console.log(`bump: ${INSTALL_REF.path}`);
 


### PR DESCRIPTION
## Summary

`@mstar-harness/engine` is a build-time devDependency in `cli`/`opencode`/`dsh` (bundled at build; consumers never install it). The exact version pin (`2.2.0`) required `syncEngineDevDepSpec` in `scripts/prepare-release.ts` to rewrite the spec on every release — with a documented registry-404 fallback risk when the spec drifts out of sync.

Switch all three to `workspace:^`: bun resolves the local workspace package regardless of version, eliminating the drift/404 class and making the release-prep sync step obsolete.

## Changes

- `packages/{cli,opencode,dsh}/package.json`: `@mstar-harness/engine` devDep `2.2.0` → `workspace:^`
- `scripts/prepare-release.ts`: remove `syncEngineDevDepSpec` + call + comments
- `.changes/unreleased/workspace-protocol-internal-deps.md`: fragment

## Verification

- `bun install` + `bun install --frozen-lockfile` pass; lockfile unchanged (workspace linking is path-based, entries already resolve `@mstar-harness/engine@workspace:packages/engine`)
- `bun run --cwd packages/cli build` bundles 101 modules incl. engine — workspace resolution works at build time
- `bun run release:validate -- v2.2.0`: all 12 surfaces + INSTALL.md aligned
- `bun test scripts/prepare-release.test.ts`: 6 pass (no test covered the removed function)
- Empirically verified npm 11 pack/publish and bun 1.2.17 publish keep `workspace:^` verbatim in devDeps of the published manifest — inert for consumers (dependency devDeps are never installed)