### PR TITLE
Mechanical verification from skills-adoption learnings: ephemeral-citation lint + drift guards

### DIFF
--- a/.changes/unreleased/engine-ephemeral-citation-lint.md
+++ b/.changes/unreleased/engine-ephemeral-citation-lint.md
@@ -1,0 +1,13 @@
+---
+category: Harness
+packages: root, cli, engine
+---
+
+- **Ephemeral-citation lint (engine)**: new `findEphemeralCitations` scans skill text for short-lived citations — concrete task artifacts (`task-<digits>-(brief|report|fix-report|diff)`, incl. dot form `task-N.diff`) and SDD deeplinks (`.mstar/sdd/` / `.agents/sdd/` + concrete first segment) — while discriminating placeholder forms (`task-N-report`, `<plan-id>`, `{SDD_DIR}/…`, `.mstar/sdd/**` path globs): zero false positives on the current `skills/` corpus.
+- **CLI `skill lint`**: third checklist `skill lint (ephemeral citations)` wired into `mstar skill lint` after the five-question checklist; each citation reports as a `skill.ephemeral.<kind>` violation (line + match + placeholder rewrite fix) and sets exit 1.
+- **drift-lint guards**: docs audit-enum set-equality (docs/cli.md `<category>` row and README category-focus lists vs the engine `AUDIT_CATEGORIES` — catches fabricated tokens like `deps` and omissions like `bug` / `direction`), README.md / README_CN.md same-commit bilingual pairing over the push range, and a skills-corpus ephemeral guard reusing `findEphemeralCitations`; plus a `citesKnowledgeConventions` exemption for harness-local knowledge citations.
+
+<!-- CN -->
+- **短命引用 lint（engine）**：新增 `findEphemeralCitations` 扫描 skill 文本中的短命引用——具体 task 工件（`task-<digits>-(brief|report|fix-report|diff)`，含点号形式 `task-N.diff`）与 SDD 深链（`.mstar/sdd/` / `.agents/sdd/` + 具体首段）——同时判别占位符形式（`task-N-report`、`<plan-id>`、`{SDD_DIR}/…`、`.mstar/sdd/**` 路径 glob）：当前 `skills/` corpus 零误报。
+- **CLI `skill lint`**：`mstar skill lint` 五问 checklist 后接入第三项 `skill lint (ephemeral citations)`；每条引用报为 `skill.ephemeral.<kind>` 违规（行号 + 匹配 + 占位符改写建议）并置 exit 1。
+- **drift-lint 守卫**：docs 审计枚举集合相等（docs/cli.md `<category>` 行与 README 类别聚焦列表对 engine `AUDIT_CATEGORIES`——捕获 `deps` 这类杜撰 token 与 `bug` / `direction` 这类遗漏）、push 范围内 README.md / README_CN.md 同 commit 双语配对、以及复用 `findEphemeralCitations` 的 skills corpus 短命引用守卫；另加 `citesKnowledgeConventions` 豁免 harness 本地 knowledge 引用。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         run: bun run --cwd packages/dsh typecheck:tests
 
       - name: Test scripts
-        run: bun test scripts/prepare-release.test.ts scripts/ci-dep-guard.test.ts
+        run: bun test scripts/prepare-release.test.ts scripts/ci-dep-guard.test.ts scripts/drift-lint.test.ts
 
       - name: Pack CLI tarball
         run: bun run cli:pack
@@ -176,8 +176,14 @@ jobs:
   drift-lint:
     runs-on: ubuntu-latest
     steps:
+      # Full history is required: Guard 2 (README bilingual pairing) resolves
+      # its range via `git merge-base origin/main HEAD` — a shallow
+      # fetch-depth: 1 checkout has no origin/main ref and the guard would
+      # (correctly, per its CI contract) fail loudly instead of running.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import {
   detectHost,
   evaluatePhaseGate,
   executionModeToN,
+  findEphemeralCitations,
   findSimplifyMarkers,
   findTemporaryMarkers,
   isReadOnlyAssignmentRole,
@@ -1293,7 +1294,8 @@ skillCommand
   .command("lint")
   .description(
     "Lint <skill-dir>/SKILL.md: frontmatter contract (name lowercase-hyphen, description trigger contract) " +
-      "+ the five-question body (exit 1 on violations, 2 on usage)",
+      "+ the five-question body + ephemeral-citation scan (task-<digits>-* artifacts and .mstar/sdd/… deeplinks — " +
+      "exit 1 on violations, 2 on usage)",
   )
   .argument("[skill-dir]", "Skill directory containing SKILL.md")
   .action((skillDir?: string) => {
@@ -1309,6 +1311,23 @@ skillCommand
       const fiveQuestion = lintFiveQuestion(stripFrontmatter(text));
       printChecklist("skill lint (five questions)", fiveQuestion);
       violations.push(...fiveQuestion.violations);
+      // findEphemeralCitations is a discovery finder (array, no GateResult);
+      // wrap into a GateResult like the other skill lint checklists — empty
+      // array passes, each citation is one violation (codes
+      // skill.ephemeral.<kind>, knowledge conventions §3).
+      const ephemeral = findEphemeralCitations(text);
+      const ephemeralGate: GateResult = {
+        ok: ephemeral.length === 0,
+        violations: ephemeral.map((citation) => ({
+          ok: false,
+          severity: "medium",
+          code: `skill.ephemeral.${citation.kind}`,
+          message: `ephemeral ${citation.kind} citation at line ${citation.line}: "${citation.match}" — task artifacts and SDD deeplinks survive nothing; durable skill text cites in-repo artifacts only (knowledge conventions/skill-content-porting-discipline.md §3)`,
+          fix: `rewrite "${citation.match}" as a placeholder form (e.g. task-N-report, <plan-id>, {SDD_DIR}/task-N-report.md) or cite a stable in-repo artifact instead`,
+        })),
+      };
+      printChecklist("skill lint (ephemeral citations)", ephemeralGate);
+      violations.push(...ephemeralGate.violations);
       if (violations.length > 0) process.exitCode = 1;
     } catch (error) {
       failScript(error, "skill lint");

--- a/packages/cli/test/slice4-cli.test.ts
+++ b/packages/cli/test/slice4-cli.test.ts
@@ -128,6 +128,65 @@ A green CLI run is the success criterion.
 Open the engine tests when a fixture drifts.
 `;
 
+/** Skill body fixture: concrete ephemeral citations (task artifact +
+ * sdd deeplink) inside an otherwise five-question-complete skill. */
+const SKILL_EPHEMERAL = `---
+name: sample-skill
+description: Validates harness fixtures during CLI smoke tests.
+---
+
+## Load Order
+
+Read this skill when running smoke fixtures.
+
+## Workflow
+
+Create fixtures, run the CLI, assert exit codes. See task-3-report for the
+prior run.
+
+## Decision Rules
+
+Never mutate the control worktree. Check .mstar/sdd/20260815-x/ before edits.
+
+## Evidence
+
+A green CLI run is the success criterion.
+
+## References
+
+Open the engine tests when a fixture drifts.
+`;
+
+/** Skill body fixture: placeholder citation forms only — the
+ * discrimination contract (zero false positives) requires these to pass. */
+const SKILL_PLACEHOLDERS = `---
+name: sample-skill
+description: Validates harness fixtures during CLI smoke tests.
+---
+
+## Load Order
+
+Read this skill when running smoke fixtures.
+
+## Workflow
+
+Create fixtures, run the CLI, assert exit codes. task-N-report and
+{SDD_DIR}/task-N-report.md are templates; .mstar/sdd/<plan-id>/ is a
+deeplink template too.
+
+## Decision Rules
+
+Never mutate the control worktree.
+
+## Evidence
+
+A green CLI run is the success criterion.
+
+## References
+
+Open the engine tests when a fixture drifts.
+`;
+
 /** Knowledge-track doc that passes validateSchemaYaml. */
 const KNOWLEDGE_GOOD = `---
 module: engine
@@ -679,8 +738,8 @@ describe("mstar host detect — tool-shape host matrix", () => {
 // mstar skill lint
 // ---------------------------------------------------------------------------
 
-describe("mstar skill lint — frontmatter + five-question body", () => {
-  test("well-formed skill → both checks OK, exit 0", () => {
+describe("mstar skill lint — frontmatter + five-question body + ephemeral citations", () => {
+  test("well-formed skill → all checks OK, exit 0", () => {
     withTempDir((dir) => {
       mkdirSync(join(dir, "skill"));
       writeFileSync(join(dir, "skill", "SKILL.md"), SKILL_GOOD);
@@ -688,6 +747,7 @@ describe("mstar skill lint — frontmatter + five-question body", () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("skill lint (frontmatter): OK");
       expect(result.stdout).toContain("skill lint (five questions): OK");
+      expect(result.stdout).toContain("skill lint (ephemeral citations): OK");
     });
   });
 
@@ -728,5 +788,40 @@ describe("mstar skill lint — frontmatter + five-question body", () => {
     const result = runCli(["skill", "lint"]);
     expect(result.exitCode).toBe(2);
     expect(result.stderr).toContain("usage: skill lint <skill-dir>");
+  });
+
+  test("concrete task-artifact citation → skill.ephemeral.task-artifact, exit 1", () => {
+    withTempDir((dir) => {
+      mkdirSync(join(dir, "skill"));
+      writeFileSync(join(dir, "skill", "SKILL.md"), SKILL_EPHEMERAL);
+      const result = runCli(["skill", "lint", join(dir, "skill")]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("skill lint (ephemeral citations): FAIL");
+      expect(result.stderr).toContain("skill.ephemeral.task-artifact");
+      expect(result.stderr).toContain('"task-3-report"');
+      expect(result.stderr).toContain("line 12");
+    });
+  });
+
+  test("concrete sdd deeplink → skill.ephemeral.sdd-deeplink, exit 1", () => {
+    withTempDir((dir) => {
+      mkdirSync(join(dir, "skill"));
+      writeFileSync(join(dir, "skill", "SKILL.md"), SKILL_EPHEMERAL);
+      const result = runCli(["skill", "lint", join(dir, "skill")]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("skill.ephemeral.sdd-deeplink");
+      expect(result.stderr).toContain('".mstar/sdd/20260815-x"');
+      expect(result.stderr).toContain("line 17");
+    });
+  });
+
+  test("placeholder citation forms → ephemeral checklist OK, exit 0 (discrimination contract)", () => {
+    withTempDir((dir) => {
+      mkdirSync(join(dir, "skill"));
+      writeFileSync(join(dir, "skill", "SKILL.md"), SKILL_PLACEHOLDERS);
+      const result = runCli(["skill", "lint", join(dir, "skill")]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("skill lint (ephemeral citations): OK");
+    });
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -196,6 +196,7 @@ export {
 } from "./compound.js";
 
 export type {
+  EphemeralCitation,
   PlanQualityFinding,
   PlanQualityResult,
   SimplifyMarker,
@@ -204,6 +205,7 @@ export type {
 } from "./lint.js";
 export {
   assertSddTddTriple,
+  findEphemeralCitations,
   findSimplifyMarkers,
   findTemporaryMarkers,
   lintSkillFrontmatter,

--- a/packages/engine/src/lint.ts
+++ b/packages/engine/src/lint.ts
@@ -27,6 +27,10 @@
  *   contract (not a workflow summary), third person.
  * - STRATEGY.md structure: `mstar-strategy` SKILL.md § STRATEGY.md structure —
  *   six required sections.
+ * - Ephemeral citations: knowledge `conventions/skill-content-porting-discipline.md`
+ *   §3 ("No ephemeral citations in durable skill text") + session evaluation
+ *   2026-08-16 discrimination contract — concrete task-artifact references
+ *   and SDD deeplinks are ephemeral; placeholder forms are not.
  *
  * Enforcement depth: roadmap §8.5 C4 — v1 lints are non-blocking
  * `ValidationResult`s; callers surface them as warnings.
@@ -166,6 +170,78 @@ export function findTemporaryMarkers(fileText: string): TemporaryMarkerResult {
     }
   }
   return { ok: violations.length === 0, violations, markers };
+}
+
+/**
+ * An ephemeral citation found in durable skill text: a concrete reference to
+ * a per-task artifact or an SDD deeplink that survives nothing (knowledge
+ * conventions/skill-content-porting-discipline.md §3 — "No ephemeral
+ * citations in durable skill text": a calibration line citing an SDD task
+ * report violates standalone + survives nothing; instances/examples cite
+ * in-repo artifacts only).
+ */
+export type EphemeralCitation = {
+  /** 1-based line number of the citation. */
+  line: number;
+  /** The matched citation token (artifact name or deeplink prefix). */
+  match: string;
+  /** `task-artifact`: `task-<digits>-(brief|report|fix-report|diff)`;
+   * `sdd-deeplink`: `.mstar/sdd/` / `.agents/sdd/` + a concrete first
+   * segment. */
+  kind: "task-artifact" | "sdd-deeplink";
+};
+
+/** Concrete task-artifact reference — `task-<digits>-(brief|report|fix-report|
+ * diff)`, 1+ digits being a real instance; the dot form `task-<digits>.diff`
+ * (review-package diff naming) is included. Placeholder forms (`task-N-*`,
+ * `task-<...>`, `{...}`) never match: `N` is a letter, and `<`/`{` are not
+ * digits. Word boundaries at both ends keep `task-2-reporting` out. */
+const TASK_ARTIFACT_RE = /\btask-\d+(?:-(?:brief|report|fix-report|diff)|\.diff)\b/g;
+
+/** Concrete SDD deeplink — `.mstar/sdd/` / `.agents/sdd/` followed by a
+ * first path segment that is not a placeholder. Segment chars exclude
+ * whitespace, `/`, quote/backtick, the placeholder brackets `<` `>` `{`
+ * `}` `[` `]`, and the glob wildcards `*` `?`, so `<plan-id>` / `{SDD_DIR}`
+ * / `<...>` segments and allowlist globs (`.mstar/sdd/**`) never match. */
+const SDD_DEEPLINK_RE = /\.(?:mstar|agents)\/sdd\/([^\s/<>{}\[\]"'\*\?]+)/g;
+
+/**
+ * Find ephemeral citations in skill text (knowledge
+ * conventions/skill-content-porting-discipline.md §3 + session evaluation
+ * 2026-08-16 discrimination contract).
+ *
+ * Discrimination (HARD — zero false positives on the skills corpus):
+ * - `task-<digits>-(brief|report|fix-report|diff)` with 1+ digits is a
+ *   concrete instance → reported (`task-2-report`, `task-1.diff`).
+ *   Placeholders (`task-N-brief`, `task-N-report`, `<plan-id>`,
+ *   `{SDD_DIR}/task-N-report.md`) never match.
+ * - `.mstar/sdd/<segment>` / `.agents/sdd/<segment>` with a concrete first
+ *   segment (`20260815-x`) → reported; `<plan-id>` / `{SDD_DIR}` segments
+ *   are template forms → never match.
+ *
+ * Discovery only — a finder returning an array, same shape as
+ * `findSimplifyMarkers`, NOT a GateResult; callers wrap findings into
+ * `ViolationResult`s (codes `skill.ephemeral.task-artifact` /
+ * `skill.ephemeral.sdd-deeplink`). Citations are reported line by line in
+ * 1-based line order, source order within a line.
+ */
+export function findEphemeralCitations(skillText: string): EphemeralCitation[] {
+  const citations: EphemeralCitation[] = [];
+  const lines = skillText.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const found: Array<{ index: number; match: string; kind: EphemeralCitation["kind"] }> = [];
+    for (const m of lines[i].matchAll(TASK_ARTIFACT_RE)) {
+      found.push({ index: m.index, match: m[0], kind: "task-artifact" });
+    }
+    for (const m of lines[i].matchAll(SDD_DEEPLINK_RE)) {
+      found.push({ index: m.index, match: m[0], kind: "sdd-deeplink" });
+    }
+    found.sort((a, b) => a.index - b.index);
+    for (const f of found) {
+      citations.push({ line: i + 1, match: f.match, kind: f.kind });
+    }
+  }
+  return citations;
 }
 
 /** Test-file reference: a path ending in `.test.<ext>` / `.spec.<ext>`

--- a/packages/engine/test/lint.test.ts
+++ b/packages/engine/test/lint.test.ts
@@ -23,12 +23,19 @@
  * - STRATEGY.md structure: `mstar-strategy` SKILL.md § STRATEGY.md structure —
  *   six required sections (Vision, What we build, What we don't build,
  *   Guiding Principles, Technology Direction, Decision Log).
+ * - Ephemeral citations: knowledge `conventions/skill-content-porting-discipline.md`
+ *   §3 ("No ephemeral citations in durable skill text") + session evaluation
+ *   2026-08-16 discrimination contract — placeholder artifact refs
+ *   (`task-N-*`, `<plan-id>`, `{SDD_DIR}`, `.mstar/sdd/<plan-id>/`) pass;
+ *   concrete instances (`task-2-report`, `task-1.diff`,
+ *   `.mstar/sdd/20260815-x/`) are flagged.
  */
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   assertSddTddTriple,
+  findEphemeralCitations,
   findSimplifyMarkers,
   findTemporaryMarkers,
   lintSkillFrontmatter,
@@ -109,6 +116,41 @@ const TEMPORARY_PLAN_PATH = `
 
 const TEMPORARY_REMOVAL_PATH_LABEL = `
 // temporary: fast path. removal path: status.json residual R7.
+`;
+
+/** Concrete ephemeral citations — every line must be flagged: concrete task
+ * artifacts (report / dot-diff / fix-report) and a concrete sdd-deeplink. */
+const EPHEMERAL_CONCRETE = `- write report to task-2-report.md
+- review diff at task-1.diff
+- fix report at task-3-fix-report.md
+- deeplink .mstar/sdd/20260815-x/
+`;
+
+/** Placeholder-shaped references that must NOT be flagged (discrimination
+ * contract: letter `N`, `<...>`, `{...}` are template forms, not citations). */
+const EPHEMERAL_PLACEHOLDERS = `- placeholder brief task-N-brief.md
+- placeholder report task-N-report
+- template <plan-id>
+- report path {SDD_DIR}/task-N-report.md
+- deeplink .mstar/sdd/<plan-id>/review/
+- deeplink .mstar/sdd/{SDD_DIR}/
+`;
+
+/** Real corpus line — `skills/mstar-sdd/references/file-handoffs.md` line 26
+ * ("Implementer writes full report to `task-N-report.md`."). The mstar-sdd
+ * SKILL.md itself carries no `task-N-*` literal, so the corpus regression
+ * uses the same skill's reference file. Placeholder `N` → must pass. */
+const EPHEMERAL_REAL_CORPUS = `Implementer writes full report to \`task-N-report.md\`. Return to PM only:
+`;
+
+/** Real corpus regression — `skills/mstar-plan-artifacts/references/
+ * plan-files-and-reports.md` line 80: a global path-allowlist glob
+ * (`.mstar/sdd/**`) is a pattern, not a concrete deeplink → must pass. */
+const EPHEMERAL_REAL_GLOB = `全局 agent 提示词应允许 \`.mstar/sdd/**\`、\`.agents/sdd/**\` 及 worktree 下对应路径。
+`;
+
+/** One line carrying both citation kinds — source order must be preserved. */
+const EPHEMERAL_MULTI = `both on one line: .mstar/sdd/20260815-x/ contains task-3-report.md
 `;
 
 /** Complete TDD triple per mstar-sdd/references/file-handoffs.md:
@@ -403,6 +445,93 @@ describe("findTemporaryMarkers", () => {
     const result = findTemporaryMarkers('const re = /\\s*temporary\\b/;');
     expect(result.ok).toBe(true);
     expect(result.markers).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findEphemeralCitations — knowledge conventions/
+// skill-content-porting-discipline.md §3 ("no ephemeral citations in durable
+// skill text") + session evaluation 2026-08-16 discrimination contract:
+// placeholders pass, concrete instances fail.
+// ---------------------------------------------------------------------------
+
+describe("findEphemeralCitations", () => {
+  test("flags concrete task artifacts with kind task-artifact and 1-based lines", () => {
+    const citations = findEphemeralCitations(EPHEMERAL_CONCRETE);
+    expect(citations).toHaveLength(4);
+    expect(citations.map((c) => c.line)).toEqual([1, 2, 3, 4]);
+    expect(citations.map((c) => c.kind)).toEqual([
+      "task-artifact",
+      "task-artifact",
+      "task-artifact",
+      "sdd-deeplink",
+    ]);
+    expect(citations.map((c) => c.match)).toEqual([
+      "task-2-report",
+      "task-1.diff",
+      "task-3-fix-report",
+      ".mstar/sdd/20260815-x",
+    ]);
+  });
+
+  test("matches multi-digit task numbers and the bare (extension-less) forms", () => {
+    const citations = findEphemeralCitations(
+      "- task-12-report\n- task-1-brief\n- task-2-diff\n",
+    );
+    expect(citations.map((c) => c.match)).toEqual([
+      "task-12-report",
+      "task-1-brief",
+      "task-2-diff",
+    ]);
+  });
+
+  test("does not treat task-N-* / <...> placeholder references as citations", () => {
+    expect(findEphemeralCitations(EPHEMERAL_PLACEHOLDERS)).toEqual([]);
+  });
+
+  test("word boundary keeps task-2-reporting out of the artifact set", () => {
+    expect(findEphemeralCitations("mentions task-2-reporting")).toEqual([]);
+  });
+
+  test("flags concrete sdd-deeplinks under both .mstar/sdd/ and .agents/sdd/", () => {
+    const citations = findEphemeralCitations(
+      "- .agents/sdd/20260815-x/\n- .mstar/sdd/20260816-mechanical-verification/task-3-report.md\n",
+    );
+    expect(citations).toHaveLength(3);
+    expect(citations[0].kind).toBe("sdd-deeplink");
+    expect(citations[0].match).toBe(".agents/sdd/20260815-x");
+    // concrete first segment → deeplink, plus the concrete task artifact inside
+    expect(citations[1]).toEqual({
+      line: 2,
+      match: ".mstar/sdd/20260816-mechanical-verification",
+      kind: "sdd-deeplink",
+    });
+    expect(citations[2]).toEqual({
+      line: 2,
+      match: "task-3-report",
+      kind: "task-artifact",
+    });
+  });
+
+  test("passes the real mstar-sdd corpus line (placeholder task-N-report.md)", () => {
+    expect(findEphemeralCitations(EPHEMERAL_REAL_CORPUS)).toEqual([]);
+  });
+
+  test("passes the real corpus path-allowlist glob (.mstar/sdd/**)", () => {
+    expect(findEphemeralCitations(EPHEMERAL_REAL_GLOB)).toEqual([]);
+  });
+
+  test("reports all citations on one line in source order", () => {
+    const citations = findEphemeralCitations(EPHEMERAL_MULTI);
+    expect(citations).toHaveLength(2);
+    expect(citations[0].kind).toBe("sdd-deeplink");
+    expect(citations[1].kind).toBe("task-artifact");
+    expect(citations[0].line).toBe(1);
+    expect(citations[1].line).toBe(1);
+  });
+
+  test("returns [] for empty input", () => {
+    expect(findEphemeralCitations("")).toEqual([]);
   });
 });
 

--- a/scripts/drift-lint.test.ts
+++ b/scripts/drift-lint.test.ts
@@ -1,0 +1,164 @@
+/**
+ * scripts/drift-lint.ts — guard semantics (QC fix wave: W-1/F-001, W-2,
+ * S-1/F-002). Pins the committed guard behavior that previously had zero
+ * automated coverage:
+ * - checkBilingualPairing (guard 2 pairing logic) — all four change sets.
+ * - evaluateBilingualGuard — the CI fail-loudly contract (GITHUB_ACTIONS
+ *   env injection): a null range fails in CI, skips locally; an empty range
+ *   (direct-to-main push) skips by design; a non-empty range runs the check.
+ * - extractCategoryRowTokens (guard 1) — the docs/cli.md `<category>` row
+ *   yields exactly AUDIT_CATEGORIES; fabricated tokens are kept for the
+ *   membership check; `Category` / `<category>` placeholders are filtered.
+ * - citesKnowledgeConventions (W-2) — the exemption is anchored to the
+ *   cited token itself (the citation path starts with `conventions/`);
+ *   proximity alone no longer exempts unrelated citations.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { AUDIT_CATEGORIES } from "../packages/engine/src/index.ts";
+import {
+  checkBilingualPairing,
+  citesKnowledgeConventions,
+  evaluateBilingualGuard,
+  extractCategoryRowTokens,
+  isGitHubActions,
+} from "./drift-lint.ts";
+
+describe("checkBilingualPairing — README pairing logic (guard 2)", () => {
+  test("both READMEs changed passes", () => {
+    expect(checkBilingualPairing(["README.md", "README_CN.md", "docs/cli.md"])).toEqual([]);
+  });
+
+  test("neither README changed passes", () => {
+    expect(checkBilingualPairing(["docs/cli.md", "scripts/drift-lint.ts"])).toEqual([]);
+  });
+
+  test("empty change list passes", () => {
+    expect(checkBilingualPairing([])).toEqual([]);
+  });
+
+  test("only README.md changed fails naming the missing CN file", () => {
+    const failures = checkBilingualPairing(["README.md"]);
+    expect(failures.length).toBe(1);
+    expect(failures[0]).toContain("README.md changed but README_CN.md did not");
+  });
+
+  test("only README_CN.md changed fails naming the missing EN file", () => {
+    const failures = checkBilingualPairing(["README_CN.md"]);
+    expect(failures.length).toBe(1);
+    expect(failures[0]).toContain("README_CN.md changed but README.md did not");
+  });
+});
+
+describe("evaluateBilingualGuard — CI fail-loudly vs local skip (W-1/F-001)", () => {
+  test("null range + GITHUB_ACTIONS fails loudly with a fetch-depth hint", () => {
+    const out = evaluateBilingualGuard(null, { ci: true });
+    if (out.status !== "failed") throw new Error(`expected failed, got ${out.status}`);
+    expect(out.failures.length).toBe(1);
+    expect(out.failures[0]).toContain("fetch-depth: 0");
+  });
+
+  test("null range + non-CI skips silently", () => {
+    const out = evaluateBilingualGuard(null, { ci: false });
+    if (out.status !== "skipped") throw new Error(`expected skipped, got ${out.status}`);
+  });
+
+  test("empty range (direct-to-main push) skips by design even in CI", () => {
+    const out = evaluateBilingualGuard([], { ci: true });
+    if (out.status !== "skipped") throw new Error(`expected skipped, got ${out.status}`);
+    expect(out.reason).toContain("empty range");
+  });
+
+  test("non-empty range runs the pairing check in CI", () => {
+    const unpaired = evaluateBilingualGuard(["README.md"], { ci: true });
+    if (unpaired.status !== "checked") throw new Error(`expected checked, got ${unpaired.status}`);
+    expect(unpaired.failures.length).toBe(1);
+    const paired = evaluateBilingualGuard(["README.md", "README_CN.md"], { ci: true });
+    if (paired.status !== "checked") throw new Error(`expected checked, got ${paired.status}`);
+    expect(paired.failures).toEqual([]);
+  });
+
+  test("GITHUB_ACTIONS env var injection flips the guard to fail-loudly", () => {
+    const prev = process.env.GITHUB_ACTIONS;
+    try {
+      process.env.GITHUB_ACTIONS = "true";
+      expect(isGitHubActions()).toBe(true);
+      const ciOut = evaluateBilingualGuard(null);
+      if (ciOut.status !== "failed") throw new Error(`expected failed, got ${ciOut.status}`);
+      process.env.GITHUB_ACTIONS = "false";
+      expect(isGitHubActions()).toBe(false);
+      const localOut = evaluateBilingualGuard(null);
+      if (localOut.status !== "skipped") throw new Error(`expected skipped, got ${localOut.status}`);
+    } finally {
+      if (prev === undefined) delete process.env.GITHUB_ACTIONS;
+      else process.env.GITHUB_ACTIONS = prev;
+    }
+  });
+});
+
+describe("extractCategoryRowTokens — docs/cli.md `<category>` row (guard 1)", () => {
+  test("real docs/cli.md <category> row yields exactly AUDIT_CATEGORIES", () => {
+    const cliMd = readFileSync(join(import.meta.dir, "..", "docs", "cli.md"), "utf8");
+    const row = cliMd.split(/\r?\n/).find((l) => /^\|\s*`<category>`\s*\|/.test(l));
+    expect(row).toBeDefined();
+    expect(extractCategoryRowTokens(row!)).toEqual([...AUDIT_CATEGORIES]);
+  });
+
+  test("fabricated token is kept for the membership check (extraction is faithful)", () => {
+    const row = "| `<category>` | recon then focus: `bug`, `deps` | all nine |";
+    expect(extractCategoryRowTokens(row)).toEqual(["bug", "deps"]);
+  });
+
+  test("plan-field `Category` reference and `<category>` placeholder are filtered", () => {
+    const row = "| `<category>` | plan `Category` field values: `bug` | all nine |";
+    expect(extractCategoryRowTokens(row)).toEqual(["bug"]);
+  });
+});
+
+describe("citesKnowledgeConventions — anchored exemption (W-2)", () => {
+  const idxOf = (text: string, token: string) => text.indexOf(token);
+
+  test("knowledge `conventions/<file>` citation is exempt", () => {
+    const text = "spec: knowledge `conventions/skill-content-porting-discipline.md`";
+    expect(citesKnowledgeConventions(text, idxOf(text, "skill-content-porting-discipline.md"))).toBe(true);
+  });
+
+  test("plain conventions/<file> (no knowledge prefix) is exempt", () => {
+    const text = "spec: conventions/skill-content-porting-discipline.md";
+    expect(citesKnowledgeConventions(text, idxOf(text, "skill-content-porting-discipline.md"))).toBe(true);
+  });
+
+  test("parenthesized conventions/<file> is exempt", () => {
+    const text = "(conventions/skill-content-porting-discipline.md)";
+    expect(citesKnowledgeConventions(text, idxOf(text, "skill-content-porting-discipline.md"))).toBe(true);
+  });
+
+  test("x-conventions/<file> is NOT exempt (citation path must start with conventions/)", () => {
+    const text = "spec: x-conventions/skill-content-porting-discipline.md";
+    expect(citesKnowledgeConventions(text, idxOf(text, "skill-content-porting-discipline.md"))).toBe(false);
+  });
+
+  test("sub/conventions/<file> is NOT exempt (citation path must start with conventions/)", () => {
+    const text = "spec: sub/conventions/skill-content-porting-discipline.md";
+    expect(citesKnowledgeConventions(text, idxOf(text, "skill-content-porting-discipline.md"))).toBe(false);
+  });
+
+  test("unrelated skills/<file> citation is NOT exempt", () => {
+    const text = "spec: skills/mstar-foo.md";
+    expect(citesKnowledgeConventions(text, idxOf(text, "mstar-foo.md"))).toBe(false);
+  });
+
+  test("nearby unrelated token is no longer swallowed by a prior conventions/ mention", () => {
+    // The old 60-char proximity window exempted `missing.md` here because
+    // "conventions/" appeared within 60 chars before it; the anchored check
+    // exempts only the token immediately preceded by "conventions/".
+    const text = "knowledge `conventions/real-doc.md`\n\nspec: typo'd missing.md on an adjacent line";
+    expect(citesKnowledgeConventions(text, idxOf(text, "missing.md"))).toBe(false);
+  });
+
+  test("token on the next line after conventions/ is NOT exempt (path is broken)", () => {
+    const text = "spec: conventions/\nskill-content-porting-discipline.md";
+    expect(citesKnowledgeConventions(text, idxOf(text, "skill-content-porting-discipline.md"))).toBe(false);
+  });
+});

--- a/scripts/drift-lint.ts
+++ b/scripts/drift-lint.ts
@@ -4,25 +4,33 @@
  * skills/ must reference real engine exports and real CLI subcommands, and
  * engine spec-citation comments must resolve to real skill files.
  *
- * Forward (skills → engine / CLI):
- *   - parse every `**Engine check (when available):**` callout in
- *     every markdown file under skills/ (blockquote runs)
- *   - every `import { X } from "@mstar-harness/engine"` name (in callouts or
- *     anywhere else in a skill file) must exist in
- *     packages/engine/src/index.ts exports (value and type exports)
- *   - every `mstar <verb>` / `mstar <verb> <sub>` command form in a callout
- *     must exist in the CLI command tree (packages/cli/src/index.ts
- *     `.command(...)` calls)
- * Reverse (engine → skills):
- *   - spec-citation comments in each packages/engine/src/<module>.ts header
- *     block (`mstar-*` SKILL.md / `references/<file>` citations) must resolve
- *     to an existing file under skills/
+ * Guards added by plan 20260816-mechanical-verification (Task 3):
+ *   1. docs audit enum — `/codebase-audit` category tokens in docs/cli.md
+ *      (the `<category>` keyword-table row) and README.md / README_CN.md
+ *      (the category-focus list) must be real AUDIT_CATEGORIES members;
+ *      docs/cli.md must enumerate the full nine (fabrications like `deps`
+ *      and omissions like a missing `bug` / `direction` both fail).
+ *   2. README bilingual pairing — README.md and README_CN.md must change
+ *      together over the committed range merge-base(origin/main, HEAD)..HEAD
+ *      (AGENTS.md bilingual rule); skipped silently when git has no range.
+ *   3. skills corpus — no ephemeral citations anywhere in the skills/
+ *      markdown tree (engine findEphemeralCitations over the full corpus),
+ *      turning the manual corpus smoke into a permanent CI guard.
+ *
+ * Engine symbols are imported from the source entry (../packages/engine/
+ * src/index.ts), NOT the "@mstar-harness/engine" package specifier: the CI
+ * drift-lint job runs `bun run validation:drift` in a fresh checkout with
+ * no `bun install`, and the package exports map resolves to the gitignored
+ * dist build. The engine source has zero runtime deps, so bun executes it
+ * directly.
  *
  * Usage: bun run scripts/drift-lint.ts
  * Exit 0 = no drift; exit 1 = drift found (one line per violation).
  */
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
+import { AUDIT_CATEGORIES, findEphemeralCitations } from "../packages/engine/src/index.ts";
 
 const root = process.cwd();
 const failures: string[] = [];
@@ -56,214 +64,363 @@ function exists(rel: string): boolean {
 }
 
 /* ------------------------------------------------------------------ */
-/* Engine export inventory (packages/engine/src/index.ts)               */
+/* Guard 2 helpers: README bilingual pairing (AGENTS.md)               */
 /* ------------------------------------------------------------------ */
 
-const engineIndex = readFileSync(join(root, "packages/engine/src/index.ts"), "utf8");
-const engineExports = new Set<string>();
-const exportRe = /export\s+(?:type\s+)?\{([^}]*)\}\s*from\s*["'][^"']+["']/g;
-let m: RegExpExecArray | null;
-while ((m = exportRe.exec(engineIndex))) {
-  for (let name of m[1].split(",")) {
-    name = name.trim().split(/\s+as\s+/)[0].trim();
-    if (name) engineExports.add(name);
+/**
+ * Changed files over the committed range merge-base(origin/main, HEAD)..HEAD
+ * (the push range in CI), or null when git cannot produce a range (no repo,
+ * no origin/main, empty diff). A null result skips the pairing guard — it
+ * must not block non-commit scenarios such as a plain local run while
+ * editing.
+ */
+function changedFilesSinceMergeBase(): string[] | null {
+  let base: string;
+  try {
+    base = execFileSync("git", ["merge-base", "origin/main", "HEAD"], { encoding: "utf8" }).trim();
+  } catch {
+    return null;
   }
-}
-if (engineExports.size === 0) {
-  console.error("drift: could not parse any exports from packages/engine/src/index.ts");
-  process.exit(1);
-}
-
-/* ------------------------------------------------------------------ */
-/* CLI command inventory (packages/cli/src/index.ts `.command(...)`)    */
-/* ------------------------------------------------------------------ */
-
-const cliSrc = readFileSync(join(root, "packages/cli/src/index.ts"), "utf8");
-const cliCommands = new Set<string>();
-const varPaths = new Map<string, string>();
-const commandRe = /(?:const\s+(\w+)\s*=\s*program\s*|(\w+)\s*)\.command\(\s*"([a-z-]+)"\s*\)/g;
-while ((m = commandRe.exec(cliSrc))) {
-  const [, declared, receiver, name] = m;
-  if (declared) {
-    varPaths.set(declared, name);
-    cliCommands.add(name);
-  } else if (receiver === "program") {
-    cliCommands.add(name);
-  } else {
-    const parent = varPaths.get(receiver);
-    if (parent === undefined) {
-      fail(`CLI parent of "${receiver}.command("${name}")" is not a known command var`);
-      continue;
-    }
-    cliCommands.add(parent ? `${parent} ${name}` : name);
+  if (!base) return null;
+  try {
+    const out = execFileSync("git", ["diff", "--name-only", base, "HEAD"], { encoding: "utf8" });
+    return out.split("\n").map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return null;
   }
 }
 
-/* ------------------------------------------------------------------ */
-/* Forward: skill callouts → engine exports + CLI commands              */
-/* ------------------------------------------------------------------ */
+/**
+ * Pure pairing check — AGENTS.md ("README = developer consumer docs"):
+ * README.md and README_CN.md must change together. Both changed or both
+ * unchanged passes; exactly one changed fails. Returns failure lines
+ * ([] = pass) so callers can test it with plain file-name lists.
+ * Exported as a test seam — the script's own main block uses it for guard 2.
+ */
+export function checkBilingualPairing(changedFiles: string[]): string[] {
+  const changed = new Set(changedFiles);
+  const enChanged = changed.has("README.md");
+  const cnChanged = changed.has("README_CN.md");
+  if (enChanged === cnChanged) return [];
+  const updated = enChanged ? "README.md" : "README_CN.md";
+  const missing = enChanged ? "README_CN.md" : "README.md";
+  return [
+    `${updated} changed but ${missing} did not — update the paired README in the same change set (AGENTS.md bilingual rule)`,
+  ];
+}
 
-const skillFiles = collectFiles("skills", ".md");
-for (const file of skillFiles) {
-  const text = readFileSync(file, "utf8");
-  const lines = text.split(/\r?\n/);
-  const rel = relative(root, file);
+if (import.meta.main) {
+  /* ------------------------------------------------------------------ */
+  /* Engine export inventory (packages/engine/src/index.ts)               */
+  /* ------------------------------------------------------------------ */
 
-  // Blockquote runs: consecutive lines starting with `>`.
-  const runs: Array<{ start: number; end: number; text: string }> = [];
-  let runStart = -1;
-  for (let i = 0; i <= lines.length; i++) {
-    const isQuote = i < lines.length && lines[i].trimStart().startsWith(">");
-    if (isQuote && runStart === -1) runStart = i;
-    if (!isQuote && runStart !== -1) {
-      runs.push({ start: runStart, end: i - 1, text: lines.slice(runStart, i).join("\n") });
-      runStart = -1;
+  const engineIndex = readFileSync(join(root, "packages/engine/src/index.ts"), "utf8");
+  const engineExports = new Set<string>();
+  const exportRe = /export\s+(?:type\s+)?\{([^}]*)\}\s*from\s*["'][^"']+["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = exportRe.exec(engineIndex))) {
+    for (let name of m[1].split(",")) {
+      name = name.trim().split(/\s+as\s+/)[0].trim();
+      if (name) engineExports.add(name);
     }
   }
+  if (engineExports.size === 0) {
+    console.error("drift: could not parse any exports from packages/engine/src/index.ts");
+    process.exit(1);
+  }
 
-  for (const run of runs) {
-    if (!run.text.includes("**Engine check (when available):**")) continue;
-    calloutsChecked++;
+  /* ------------------------------------------------------------------ */
+  /* CLI command inventory (packages/cli/src/index.ts `.command(...)`)    */
+  /* ------------------------------------------------------------------ */
 
-    for (const cm of run.text.matchAll(/mstar\s+([a-z-]+(?:\s+[a-z-]+)?)/g)) {
-      const cmd = cm[1];
-      if (!cliCommands.has(cmd)) {
-        fail(`${rel}:${run.start + 1} callout references unknown CLI command "mstar ${cmd}" (known: ${[...cliCommands].sort().join(", ")})`);
+  const cliSrc = readFileSync(join(root, "packages/cli/src/index.ts"), "utf8");
+  const cliCommands = new Set<string>();
+  const varPaths = new Map<string, string>();
+  const commandRe = /(?:const\s+(\w+)\s*=\s*program\s*|(\w+)\s*)\.command\(\s*"([a-z-]+)"\s*\)/g;
+  while ((m = commandRe.exec(cliSrc))) {
+    const [, declared, receiver, name] = m;
+    if (declared) {
+      varPaths.set(declared, name);
+      cliCommands.add(name);
+    } else if (receiver === "program") {
+      cliCommands.add(name);
+    } else {
+      const parent = varPaths.get(receiver);
+      if (parent === undefined) {
+        fail(`CLI parent of "${receiver}.command("${name}")" is not a known command var`);
+        continue;
+      }
+      cliCommands.add(parent ? `${parent} ${name}` : name);
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Forward: skill callouts → engine exports + CLI commands              */
+  /* ------------------------------------------------------------------ */
+
+  const skillFiles = collectFiles("skills", ".md");
+  for (const file of skillFiles) {
+    const text = readFileSync(file, "utf8");
+    const lines = text.split(/\r?\n/);
+    const rel = relative(root, file);
+
+    // Blockquote runs: consecutive lines starting with `>`.
+    const runs: Array<{ start: number; end: number; text: string }> = [];
+    let runStart = -1;
+    for (let i = 0; i <= lines.length; i++) {
+      const isQuote = i < lines.length && lines[i].trimStart().startsWith(">");
+      if (isQuote && runStart === -1) runStart = i;
+      if (!isQuote && runStart !== -1) {
+        runs.push({ start: runStart, end: i - 1, text: lines.slice(runStart, i).join("\n") });
+        runStart = -1;
       }
     }
-    for (const im of run.text.matchAll(/import\s*\{([^}]*)\}\s*from\s*"@mstar-harness\/engine"/g)) {
+
+    for (const run of runs) {
+      if (!run.text.includes("**Engine check (when available):**")) continue;
+      calloutsChecked++;
+
+      for (const cm of run.text.matchAll(/mstar\s+([a-z-]+(?:\s+[a-z-]+)?)/g)) {
+        const cmd = cm[1];
+        if (!cliCommands.has(cmd)) {
+          fail(`${rel}:${run.start + 1} callout references unknown CLI command "mstar ${cmd}" (known: ${[...cliCommands].sort().join(", ")})`);
+        }
+      }
+      for (const im of run.text.matchAll(/import\s*\{([^}]*)\}\s*from\s*"@mstar-harness\/engine"/g)) {
+        for (const raw of im[1].split(",")) {
+          // Strip TS import modifiers so `import { type Foo }` / `import {
+          // Foo as Bar }` resolve to the exported name `Foo`.
+          const name = raw.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0].trim();
+          if (name && !engineExports.has(name)) {
+            fail(`${rel}:${run.start + 1} callout imports unknown engine export "${name}"`);
+          }
+        }
+      }
+    }
+
+    // Import statements anywhere in a skill file must reference real exports.
+    for (const im of text.matchAll(/import\s*\{([^}]*)\}\s*from\s*"@mstar-harness\/engine"/g)) {
       for (const raw of im[1].split(",")) {
-        // Strip TS import modifiers so `import { type Foo }` / `import {
-        // Foo as Bar }` resolve to the exported name `Foo`.
         const name = raw.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0].trim();
         if (name && !engineExports.has(name)) {
-          fail(`${rel}:${run.start + 1} callout imports unknown engine export "${name}"`);
+          fail(`${rel}: import of unknown engine export "${name}"`);
         }
       }
     }
   }
 
-  // Import statements anywhere in a skill file must reference real exports.
-  for (const im of text.matchAll(/import\s*\{([^}]*)\}\s*from\s*"@mstar-harness\/engine"/g)) {
-    for (const raw of im[1].split(",")) {
-      const name = raw.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0].trim();
-      if (name && !engineExports.has(name)) {
-        fail(`${rel}: import of unknown engine export "${name}"`);
+  /* ------------------------------------------------------------------ */
+  /* Reverse: engine module spec citations → skill files                  */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Non-skill spec sources the engine legitimately cites: generated artifact
+   * types (`main.md`, `task-N-report.md`, …), root convention docs
+   * (`STRATEGY.md`, `README.md`, …) and review-bundle files (`qcN.md`). These
+   * are not skill files — existence is not expected under skills/.
+   */
+  const ARTIFACT_SPEC_SOURCES = new Set([
+    "main.md",
+    "task-N-report.md",
+    "STRATEGY.md",
+    "delivery-compass.md",
+    "README.md",
+    "CONCEPTS.md",
+    "DESIGN.md",
+    "DESIGN.dark.md",
+    "qc1.md",
+    "qc2.md",
+    "qc3.md",
+    "qc-consolidated.md",
+    "schema.yaml",
+  ]);
+
+  /** True when the citation at `index` is prefixed by a `.harness/` path
+   * (gitignored roadmap / ADR — not part of the skills tree). */
+  function citesHarnessPath(text: string, index: number): boolean {
+    return text.slice(Math.max(0, index - 40), index).includes(".harness/");
+  }
+
+  /** True when the citation at `index` is a knowledge-conventions reference
+   * ("knowledge \`conventions/<file>\`" / "conventions/<file>") — such docs
+   * resolve under `{KNOWLEDGE_DIR}/conventions/` (`.mstar/knowledge/`,
+   * gitignored), so they are harness-local docs, not skill files, and
+   * existence is not verifiable in CI. Mirrors the `.harness/` exemption. */
+  function citesKnowledgeConventions(text: string, index: number): boolean {
+    return /(?:knowledge\s*)?`?conventions\//.test(text.slice(Math.max(0, index - 60), index));
+  }
+
+  const engineModules = collectFiles("packages/engine/src", ".ts").filter(
+    (f) => !f.endsWith("/index.ts"),
+  );
+  const skillRefFiles = collectFiles("skills", ".md").map((f) => relative(root, f));
+  const yamlRefs = collectFiles("skills", ".yaml").map((f) => relative(root, f));
+  const allSkillFiles = new Set([...skillRefFiles, ...yamlRefs]);
+
+  for (const file of engineModules) {
+    const rel = relative(root, file);
+    const lines = readFileSync(file, "utf8").split(/\r?\n/);
+
+    // Header block: contiguous comment lines at the top of the file.
+    const header: string[] = [];
+    for (const line of lines) {
+      const t = line.trim();
+      if (header.length === 0 && (t === "" || t.startsWith("/*") || t.startsWith("//") || t.startsWith("*"))) {
+        if (t !== "" || header.length > 0) header.push(line);
+        if (t.startsWith("*/")) break;
+      } else if (header.length > 0 && (t === "" || t.startsWith("*"))) {
+        header.push(line);
+        if (t.startsWith("*/")) break;
+      } else if (header.length > 0) {
+        break;
+      } else {
+        break;
+      }
+    }
+    const headerText = header.join("\n");
+    if (!/Spec|spec/.test(headerText)) continue;
+
+    // Explicit skill paths: skills/<skill>/SKILL.md
+    for (const sm of headerText.matchAll(/skills\/(mstar-[\w-]+)\/SKILL\.md/g)) {
+      const p = `skills/${sm[1]}/SKILL.md`;
+      if (!exists(p)) fail(`${rel}: spec citation "${p}" does not exist`);
+    }
+    // "<skill> SKILL.md" / "<skill> SKILL" token forms
+    for (const sm of headerText.matchAll(/`?(mstar-[\w-]+)`?\s+SKILL(?:\.md)?/g)) {
+      const p = `skills/${sm[1]}/SKILL.md`;
+      if (!exists(p)) fail(`${rel}: spec citation "${p}" does not exist`);
+    }
+    // "<skill>/references/<file>" and "<skill> `references/<file>`" forms
+    for (const sm of headerText.matchAll(/`?(mstar-[\w-]+)`?\s*(?:\/|\s+)`?references\/([\w.-]+)/g)) {
+      const p = `skills/${sm[1]}/references/${sm[2]}`;
+      if (!exists(p)) fail(`${rel}: spec citation "${p}" does not exist`);
+    }
+    // Bare "references/<file>" citations (no skill token): must exist under
+    // some skill — unless they are `.harness/` roadmap citations.
+    for (const rm of headerText.matchAll(/references\/([\w.-]+)/g)) {
+      if (citesHarnessPath(headerText, rm.index)) continue;
+      const candidates = [...allSkillFiles].filter((f) => f.endsWith(`/references/${rm[1]}`));
+      if (candidates.length === 0) {
+        fail(`${rel}: spec citation "references/${rm[1]}" does not exist under any skill`);
+      }
+    }
+    // Bare "<file>.md"/"<file>.yaml" next to a spec marker ("spec:" / "§"):
+    // must resolve under skills/, be a `.harness/` doc, or be a known
+    // artifact-type spec source.
+    for (const bm of headerText.matchAll(/(?<![-\w])([a-zA-Z0-9][\w-]*\.(?:md|yaml))/g)) {
+      const name = bm[1];
+      if (name === "SKILL.md") continue;
+      const nearSpec = headerText.slice(Math.max(0, bm.index - 60), (bm.index ?? 0) + name.length + 60);
+      if (!/spec|§/.test(nearSpec)) continue;
+      if (citesHarnessPath(headerText, bm.index)) continue;
+      if (citesKnowledgeConventions(headerText, bm.index)) continue;
+      if ([...allSkillFiles].some((f) => f.endsWith(`/${name}`))) continue;
+      if (ARTIFACT_SPEC_SOURCES.has(name)) continue;
+      fail(`${rel}: spec citation "${name}" does not exist under skills/ and is not a known artifact spec source`);
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Guard 1: `/codebase-audit` docs tokens ↔ engine AUDIT_CATEGORIES     */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Category tokens in docs must be real `AUDIT_CATEGORIES` members, and
+   * docs/cli.md must enumerate the full set:
+   * - docs/cli.md: the `<category>` keyword-table row (set equality — a
+   *   fabricated token like `deps` fails, and so does an omission such as
+   *   a missing `bug` / `direction`).
+   * - README.md / README_CN.md: the category-focus list in the audit usage
+   *   line ("category focus (…)" / "按类别聚焦（…）") — membership only,
+   *   the list is illustrative (`…`).
+   * Only lowercase-kebab tokens are scanned (`^[a-z][a-z-]*$`); the
+   * placeholder `<category>` cell and the plan-field reference `Category`
+   * are not category codes.
+   */
+  const auditCategories = new Set<string>(AUDIT_CATEGORIES);
+  let categoryTokensChecked = 0;
+
+  {
+    const file = "docs/cli.md";
+    const lines = readFileSync(join(root, file), "utf8").split(/\r?\n/);
+    const rowIdx = lines.findIndex((l) => /^\|\s*`<category>`\s*\|/.test(l));
+    if (rowIdx === -1) {
+      fail(`${file}: could not locate the \`<category>\` keyword-table row (expected a row starting with \`| \`<category>\` |\`)`);
+    } else {
+      const cells = lines[rowIdx].split("|");
+      const tokens = [...cells.slice(2).join("|").matchAll(/`([^`]+)`/g)]
+        .map((mm) => mm[1])
+        .filter((t) => /^[a-z][a-z-]*$/.test(t));
+      categoryTokensChecked += tokens.length;
+      for (const t of tokens) {
+        if (!auditCategories.has(t)) {
+          fail(`${file}:${rowIdx + 1} category token "${t}" is not an AUDIT_CATEGORY (valid: ${AUDIT_CATEGORIES.join(", ")})`);
+        }
+      }
+      for (const c of AUDIT_CATEGORIES) {
+        if (!tokens.includes(c)) {
+          fail(`${file}:${rowIdx + 1} category table omits AUDIT_CATEGORY "${c}" — add \`${c}\` to the <category> row`);
+        }
       }
     }
   }
-}
 
-/* ------------------------------------------------------------------ */
-/* Reverse: engine module spec citations → skill files                  */
-/* ------------------------------------------------------------------ */
-
-/**
- * Non-skill spec sources the engine legitimately cites: generated artifact
- * types (`main.md`, `task-N-report.md`, …), root convention docs
- * (`STRATEGY.md`, `README.md`, …) and review-bundle files (`qcN.md`). These
- * are not skill files — existence is not expected under skills/.
- */
-const ARTIFACT_SPEC_SOURCES = new Set([
-  "main.md",
-  "task-N-report.md",
-  "STRATEGY.md",
-  "delivery-compass.md",
-  "README.md",
-  "CONCEPTS.md",
-  "DESIGN.md",
-  "DESIGN.dark.md",
-  "qc1.md",
-  "qc2.md",
-  "qc3.md",
-  "qc-consolidated.md",
-  "schema.yaml",
-]);
-
-/** True when the citation at `index` is prefixed by a `.harness/` path
- * (gitignored roadmap / ADR — not part of the skills tree). */
-function citesHarnessPath(text: string, index: number): boolean {
-  return text.slice(Math.max(0, index - 40), index).includes(".harness/");
-}
-
-const engineModules = collectFiles("packages/engine/src", ".ts").filter(
-  (f) => !f.endsWith("/index.ts"),
-);
-const skillRefFiles = collectFiles("skills", ".md").map((f) => relative(root, f));
-const yamlRefs = collectFiles("skills", ".yaml").map((f) => relative(root, f));
-const allSkillFiles = new Set([...skillRefFiles, ...yamlRefs]);
-
-for (const file of engineModules) {
-  const rel = relative(root, file);
-  const lines = readFileSync(file, "utf8").split(/\r?\n/);
-
-  // Header block: contiguous comment lines at the top of the file.
-  const header: string[] = [];
-  for (const line of lines) {
-    const t = line.trim();
-    if (header.length === 0 && (t === "" || t.startsWith("/*") || t.startsWith("//") || t.startsWith("*"))) {
-      if (t !== "" || header.length > 0) header.push(line);
-      if (t.startsWith("*/")) break;
-    } else if (header.length > 0 && (t === "" || t.startsWith("*"))) {
-      header.push(line);
-      if (t.startsWith("*/")) break;
-    } else if (header.length > 0) {
-      break;
-    } else {
-      break;
+  for (const file of ["README.md", "README_CN.md"]) {
+    const text = readFileSync(join(root, file), "utf8");
+    const fm = text.match(/(?:category\s+focus|按类别聚焦)\s*[（(]([^）)]*)[）)]/i);
+    if (!fm) {
+      fail(`${file}: could not locate the category-focus list (expected "category focus (\`a\`, \`b\`, …)" / "按类别聚焦（…）")`);
+      continue;
+    }
+    const line = text.slice(0, fm.index ?? 0).split(/\r?\n/).length;
+    for (const t of fm[1].matchAll(/`([^`]+)`/g)) {
+      categoryTokensChecked++;
+      if (!auditCategories.has(t[1])) {
+        fail(`${file}:${line} category token "${t[1]}" is not an AUDIT_CATEGORY (valid: ${AUDIT_CATEGORIES.join(", ")})`);
+      }
     }
   }
-  const headerText = header.join("\n");
-  if (!/Spec|spec/.test(headerText)) continue;
 
-  // Explicit skill paths: skills/<skill>/SKILL.md
-  for (const sm of headerText.matchAll(/skills\/(mstar-[\w-]+)\/SKILL\.md/g)) {
-    const p = `skills/${sm[1]}/SKILL.md`;
-    if (!exists(p)) fail(`${rel}: spec citation "${p}" does not exist`);
+  /* ------------------------------------------------------------------ */
+  /* Guard 2: README.md / README_CN.md bilingual pairing (AGENTS.md)      */
+  /* ------------------------------------------------------------------ */
+
+  const changedFiles = changedFilesSinceMergeBase();
+  let bilingualStatus = "skipped (no git range)";
+  if (changedFiles !== null && changedFiles.length > 0) {
+    bilingualStatus = "checked";
+    for (const line of checkBilingualPairing(changedFiles)) fail(line);
   }
-  // "<skill> SKILL.md" / "<skill> SKILL" token forms
-  for (const sm of headerText.matchAll(/`?(mstar-[\w-]+)`?\s+SKILL(?:\.md)?/g)) {
-    const p = `skills/${sm[1]}/SKILL.md`;
-    if (!exists(p)) fail(`${rel}: spec citation "${p}" does not exist`);
-  }
-  // "<skill>/references/<file>" and "<skill> `references/<file>`" forms
-  for (const sm of headerText.matchAll(/`?(mstar-[\w-]+)`?\s*(?:\/|\s+)`?references\/([\w.-]+)/g)) {
-    const p = `skills/${sm[1]}/references/${sm[2]}`;
-    if (!exists(p)) fail(`${rel}: spec citation "${p}" does not exist`);
-  }
-  // Bare "references/<file>" citations (no skill token): must exist under
-  // some skill — unless they are `.harness/` roadmap citations.
-  for (const rm of headerText.matchAll(/references\/([\w.-]+)/g)) {
-    if (citesHarnessPath(headerText, rm.index)) continue;
-    const candidates = [...allSkillFiles].filter((f) => f.endsWith(`/references/${rm[1]}`));
-    if (candidates.length === 0) {
-      fail(`${rel}: spec citation "references/${rm[1]}" does not exist under any skill`);
+
+  /* ------------------------------------------------------------------ */
+  /* Guard 3: skills corpus — ephemeral citations (engine lint)          */
+  /* ------------------------------------------------------------------ */
+
+  let ephemeralFilesScanned = 0;
+  let ephemeralCitationsFound = 0;
+  for (const file of skillFiles) {
+    ephemeralFilesScanned++;
+    const citations = findEphemeralCitations(readFileSync(file, "utf8"));
+    if (citations.length === 0) continue;
+    ephemeralCitationsFound += citations.length;
+    const rel = relative(root, file);
+    for (const c of citations) {
+      fail(`${rel}:${c.line} ephemeral citation "${c.match}" (${c.kind}) — concrete task artifacts / SDD deeplinks must not appear in durable skill text`);
     }
   }
-  // Bare "<file>.md"/"<file>.yaml" next to a spec marker ("spec:" / "§"):
-  // must resolve under skills/, be a `.harness/` doc, or be a known
-  // artifact-type spec source.
-  for (const bm of headerText.matchAll(/(?<![-\w])([a-zA-Z0-9][\w-]*\.(?:md|yaml))/g)) {
-    const name = bm[1];
-    if (name === "SKILL.md") continue;
-    const nearSpec = headerText.slice(Math.max(0, bm.index - 60), (bm.index ?? 0) + name.length + 60);
-    if (!/spec|§/.test(nearSpec)) continue;
-    if (citesHarnessPath(headerText, bm.index)) continue;
-    if ([...allSkillFiles].some((f) => f.endsWith(`/${name}`))) continue;
-    if (ARTIFACT_SPEC_SOURCES.has(name)) continue;
-    fail(`${rel}: spec citation "${name}" does not exist under skills/ and is not a known artifact spec source`);
+
+  /* ------------------------------------------------------------------ */
+
+  if (failures.length > 0) {
+    console.error(`drift-lint: ${failures.length} violation(s) found\n`);
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    console.error(
+      `\nchecked ${calloutsChecked} Engine-check callouts against ${engineExports.size} engine exports and ${cliCommands.size} CLI commands; ${categoryTokensChecked} audit category tokens; README bilingual pairing ${bilingualStatus}; ${ephemeralFilesScanned} skill files (${ephemeralCitationsFound} ephemeral citations)`,
+    );
+    process.exit(1);
   }
+
+  console.log(
+    `drift-lint: OK — ${calloutsChecked} Engine-check callouts reference real exports (${engineExports.size}) and CLI commands (${cliCommands.size}); engine spec citations resolve; ${categoryTokensChecked} audit category tokens match AUDIT_CATEGORIES; README bilingual pairing ${bilingualStatus}; ${ephemeralFilesScanned} skill files clean of ephemeral citations`,
+  );
 }
-
-/* ------------------------------------------------------------------ */
-
-if (failures.length > 0) {
-  console.error(`drift-lint: ${failures.length} violation(s) found\n`);
-  for (const f of failures) console.error(`  ✗ ${f}`);
-  console.error(`\nchecked ${calloutsChecked} Engine-check callouts against ${engineExports.size} engine exports and ${cliCommands.size} CLI commands`);
-  process.exit(1);
-}
-
-console.log(
-  `drift-lint: OK — ${calloutsChecked} Engine-check callouts reference real exports (${engineExports.size}) and CLI commands (${cliCommands.size}); engine spec citations resolve`,
-);

--- a/scripts/drift-lint.ts
+++ b/scripts/drift-lint.ts
@@ -12,7 +12,10 @@
  *      and omissions like a missing `bug` / `direction` both fail).
  *   2. README bilingual pairing — README.md and README_CN.md must change
  *      together over the committed range merge-base(origin/main, HEAD)..HEAD
- *      (AGENTS.md bilingual rule); skipped silently when git has no range.
+ *      (AGENTS.md bilingual rule); skipped silently when git has no range
+ *      (local non-commit runs), but a missing range under GITHUB_ACTIONS
+ *      fails loudly — the drift-lint CI job checks out with fetch-depth: 0
+ *      so origin/main exists and PR runs are the enforcement surface.
  *   3. skills corpus — no ephemeral citations anywhere in the skills/
  *      markdown tree (engine findEphemeralCitations over the full corpus),
  *      turning the manual corpus smoke into a permanent CI guard.
@@ -107,6 +110,83 @@ export function checkBilingualPairing(changedFiles: string[]): string[] {
   return [
     `${updated} changed but ${missing} did not — update the paired README in the same change set (AGENTS.md bilingual rule)`,
   ];
+}
+
+export function isGitHubActions(): boolean {
+  return process.env.GITHUB_ACTIONS === "true";
+}
+
+export type BilingualGuardResult =
+  | { status: "checked"; failures: string[] }
+  | { status: "skipped"; reason: string }
+  | { status: "failed"; failures: string[] };
+
+/**
+ * Guard 2 decision given the git range result and CI context:
+ * - `changedFiles === null` — git could not resolve the range (no repo /
+ *   no origin/main). Locally this is a legitimate non-commit run and skips
+ *   silently; under GITHUB_ACTIONS it is a wiring failure (the drift-lint
+ *   job must checkout with fetch-depth: 0 so origin/main exists) and fails
+ *   loudly instead of silently skipping.
+ * - `changedFiles === []` — range resolved but empty (direct-to-main push
+ *   where origin/main == HEAD). Uncovered by design; PR runs are the
+ *   enforcement surface, so this skips in CI too.
+ * - non-empty — run the pairing check.
+ * Exported as a test seam; `opts.ci` defaults to the GITHUB_ACTIONS env var
+ * (the main block passes nothing, tests inject the env explicitly).
+ */
+export function evaluateBilingualGuard(
+  changedFiles: string[] | null,
+  opts: { ci?: boolean } = {},
+): BilingualGuardResult {
+  const ci = opts.ci ?? isGitHubActions();
+  if (changedFiles === null) {
+    if (ci) {
+      return {
+        status: "failed",
+        failures: [
+          "README bilingual pairing guard: no git range in CI (merge-base failed or origin/main missing) — the drift-lint job must checkout with fetch-depth: 0 so the pairing check can run (PR runs are the enforcement surface)",
+        ],
+      };
+    }
+    return { status: "skipped", reason: "no git range (non-CI run)" };
+  }
+  if (changedFiles.length === 0) {
+    return { status: "skipped", reason: "empty range (direct-to-main push)" };
+  }
+  return { status: "checked", failures: checkBilingualPairing(changedFiles) };
+}
+
+/**
+ * Category tokens from the `<category>` keyword-table row: the backticked
+ * cell values after the keyword cell, filtered to lowercase-kebab codes
+ * (`^[a-z][a-z-]*$`). The filter drops the `<category>` placeholder cell and
+ * the plan-field reference "plan `Category` field values" (capitalized) —
+ * neither is a category code. Exported as a test seam for guard 1.
+ */
+export function extractCategoryRowTokens(row: string): string[] {
+  return [...row.split("|").slice(2).join("|").matchAll(/`([^`]+)`/g)]
+    .map((mm) => mm[1])
+    .filter((t) => /^[a-z][a-z-]*$/.test(t));
+}
+
+/** True when the citation at `index` is prefixed by a `.harness/` path
+ * (gitignored roadmap / ADR — not part of the skills tree). */
+export function citesHarnessPath(text: string, index: number): boolean {
+  return text.slice(Math.max(0, index - 40), index).includes(".harness/");
+}
+
+/** True when the bare token at `index` is itself the file name of a
+ * knowledge-conventions citation — the citation path starts with
+ * `conventions/` ("conventions/<file>" / "knowledge \`conventions/<file>\`").
+ * Such docs resolve under `{KNOWLEDGE_DIR}/conventions/` (`.mstar/knowledge/`,
+ * gitignored), so existence is not verifiable in CI. The exemption is
+ * anchored to the cited token itself: `conventions/` must immediately
+ * precede it and start a path segment (`x-conventions/<file>` and
+ * `sub/conventions/<file>` are NOT exempt), so nearby unrelated citations
+ * are still existence-checked. Mirrors the `.harness/` exemption. */
+export function citesKnowledgeConventions(text: string, index: number): boolean {
+  return /(?:^|[^\w./-])conventions\/$/.test(text.slice(Math.max(0, index - 200), index));
 }
 
 if (import.meta.main) {
@@ -235,21 +315,6 @@ if (import.meta.main) {
     "schema.yaml",
   ]);
 
-  /** True when the citation at `index` is prefixed by a `.harness/` path
-   * (gitignored roadmap / ADR — not part of the skills tree). */
-  function citesHarnessPath(text: string, index: number): boolean {
-    return text.slice(Math.max(0, index - 40), index).includes(".harness/");
-  }
-
-  /** True when the citation at `index` is a knowledge-conventions reference
-   * ("knowledge \`conventions/<file>\`" / "conventions/<file>") — such docs
-   * resolve under `{KNOWLEDGE_DIR}/conventions/` (`.mstar/knowledge/`,
-   * gitignored), so they are harness-local docs, not skill files, and
-   * existence is not verifiable in CI. Mirrors the `.harness/` exemption. */
-  function citesKnowledgeConventions(text: string, index: number): boolean {
-    return /(?:knowledge\s*)?`?conventions\//.test(text.slice(Math.max(0, index - 60), index));
-  }
-
   const engineModules = collectFiles("packages/engine/src", ".ts").filter(
     (f) => !f.endsWith("/index.ts"),
   );
@@ -347,10 +412,7 @@ if (import.meta.main) {
     if (rowIdx === -1) {
       fail(`${file}: could not locate the \`<category>\` keyword-table row (expected a row starting with \`| \`<category>\` |\`)`);
     } else {
-      const cells = lines[rowIdx].split("|");
-      const tokens = [...cells.slice(2).join("|").matchAll(/`([^`]+)`/g)]
-        .map((mm) => mm[1])
-        .filter((t) => /^[a-z][a-z-]*$/.test(t));
+      const tokens = extractCategoryRowTokens(lines[rowIdx]);
       categoryTokensChecked += tokens.length;
       for (const t of tokens) {
         if (!auditCategories.has(t)) {
@@ -385,11 +447,16 @@ if (import.meta.main) {
   /* Guard 2: README.md / README_CN.md bilingual pairing (AGENTS.md)      */
   /* ------------------------------------------------------------------ */
 
-  const changedFiles = changedFilesSinceMergeBase();
+  const outcome = evaluateBilingualGuard(changedFilesSinceMergeBase());
   let bilingualStatus = "skipped (no git range)";
-  if (changedFiles !== null && changedFiles.length > 0) {
+  if (outcome.status === "checked") {
     bilingualStatus = "checked";
-    for (const line of checkBilingualPairing(changedFiles)) fail(line);
+    for (const line of outcome.failures) fail(line);
+  } else if (outcome.status === "failed") {
+    bilingualStatus = "failed (no git range in CI)";
+    for (const line of outcome.failures) fail(line);
+  } else {
+    bilingualStatus = `skipped (${outcome.reason})`;
   }
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Plan: 20260816-mechanical-verification (single-plan round, no iteration)

Converts the mechanically-checkable subset of the iter-20260815-dsh-skills-adoption learnings into engine lint + CI drift checks. Follow-up to #95; triage: 1 engine-worthy item, 2 repo-local items, rest rejected as semantic-by-design.

### Engine — `findEphemeralCitations` (+76, `packages/engine/src/lint.ts`)
Skill-text lint for **concrete** citations to ephemeral SDD artifacts: `task-<digits>-(brief|report|fix-report|diff)` and `.mstar/sdd/` / `.agents/sdd/` deep links with concrete plan-id segments. Placeholder forms pass (`task-N-*`, `<plan-id>`, `{SDD_DIR}`, glob `**`). Finder shape (array, like `findSimplifyMarkers`); `EphemeralCitation { line, match, kind }` exported. 9 new tests incl. a glob-boundary false-positive found and fixed during corpus smoke (94 files, zero hits).

### CLI — third `skill lint` checklist (+21, `packages/cli/src/index.ts`)
`mstar skill lint` now runs `skill lint (ephemeral citations)` after frontmatter + five-question: empty ⇒ OK; each citation ⇒ medium `skill.ephemeral.<kind>` with line+match and placeholder-rewrite fix. 3 new subprocess tests (task-artifact exit 1 / sdd-deeplink exit 1 / placeholders exit 0).

### CI — drift-lint guards (`scripts/drift-lint.ts`, +521/−182 incl. structural refactor)
1. **Docs audit-enum set-equality** — `docs/cli.md` category row checked bidirectionally against engine-exported `AUDIT_CATEGORIES` (catches fabricated tokens like `deps` and omissions like `bug`/`direction`); README.md/README_CN.md category-focus lists membership-checked.
2. **README bilingual pairing** — README.md/README_CN.md must change together over `merge-base(origin/main,HEAD)..HEAD`; **fails loudly under `GITHUB_ACTIONS`** when the range is unresolvable (ci.yml drift-lint checkout now `fetch-depth: 0`); silent-skip only for local no-git runs.
3. **Skills corpus ephemeral guard** — engine finder over `skills/**/*.md`; one failure per hit (94 files clean).

Plus: `citesKnowledgeConventions` exemption **anchored** to `conventions/` path-segment root (was proximity-based); `scripts/drift-lint.test.ts` with 21 behavioral tests wired into CI.

### Quality gates
- QC tri (L3 N=3): initial 1×Approve + 2×Request Changes → fix wave `511c518` (CI-visible bilingual guard + anchored exemption + committed guard tests) → targeted re-review **Approve 3/3**, zero-residual.
- **QA gate: mandatory — PASS** (full mode): engine 655/0, cli 172/0, drift-lint tests 21/0, `validation:drift` clean-tree exit 0, CLI spot checks positive (authoring skill, 3 checklists OK) + negative (fixture exit 1, both violation kinds visible); all plan ACs MET; no open residuals.

### Changelog
`.changes/unreleased/engine-ephemeral-citation-lint.md` (packages: root, cli, engine).

### Not in scope (recorded)
Semantic skill content (lenses/methodology — delivered in #95), push-time runtime gates (host-plugin domain), rewrite-evidence probes (no machine-readable binding yet). Durable follow-up recorded in plan: mirror `skill-content-porting-discipline` knowledge to a tracked path + update the engine lint.ts spec citation (exemption stays as safety net).