### PR TITLE
iter-20260817-dsh-cli-roles: CLI dsh install target + roles presence e2e closure

### DIFF
--- a/.changes/unreleased/cli-dsh-install-target.md
+++ b/.changes/unreleased/cli-dsh-install-target.md
@@ -1,0 +1,9 @@
+---
+category: Changed
+packages: cli, root
+---
+
+- **dsh install target**: `npx @mstar-harness/cli init --target dsh` now installs the full dsh capability in one command — it runs **two independent** `dsh plugin --profile web add` calls (`@mstar-harness/dsh` first, then `dsh-llm-fallbacks`; never folded into a patch file). `doctor --target dsh` reports each plugin row as `uninstalled` / `disabled` / `mounted` and exits non-zero on any uninstalled or disabled row. `--no-fallbacks` (dsh target only) skips the `dsh-llm-fallbacks` row; `--dry-run` previews without probing or executing; re-runs are idempotent (already-installed rows skipped). README pair, `INSTALL.md`, and `docs/cli.md` updated.
+
+<!-- CN -->
+- **dsh 安装目标**：`npx @mstar-harness/cli init --target dsh` 现可一条命令装齐 dsh 全量能力——它运行**两条独立** `dsh plugin --profile web add` 调用（先 `@mstar-harness/dsh`，再 `dsh-llm-fallbacks`；绝不折叠进 patch 文件）。`doctor --target dsh` 逐行报告 `uninstalled` / `disabled` / `mounted`，存在未安装或禁用行时以非 0 退出。`--no-fallbacks`（仅 dsh target 生效）跳过 `dsh-llm-fallbacks` 行；`--dry-run` 纯预览，不探测不执行；重复执行幂等（已装行跳过）。README 双语对、`INSTALL.md`、`docs/cli.md` 已同步。

--- a/.changes/unreleased/dsh-roles-e2e-closure.md
+++ b/.changes/unreleased/dsh-roles-e2e-closure.md
@@ -1,0 +1,8 @@
+---
+packages: dsh, root
+---
+
+- **dsh full support (docs)**: the `packages/dsh` README triple's Install section now documents the one-command CLI entry (`init --target dsh` — the two `dsh plugin --profile web add` installs, orchestrated) and what a user gets zero-config once both rows are installed: the 13 `mode: subagent` mstar role seeds with mirror-default personas (revertible in settings; runtime advisory reports overrides), plus a fresh-publish `minimumReleaseAge` window note (re-run init or pin the version). The installed-deployment e2e closes the loop: a real CLI install into a temp `DSH_HOME`, booted from the installed artifacts, asserts all 13 roles seeded with non-empty personas. Root README pair adds the dsh full-support one-liner.
+
+<!-- CN -->
+- **dsh 全量支持（文档）**：`packages/dsh` README 三联的 Install 节现写明一条命令的 CLI 入口（`init --target dsh`——编排两条 `dsh plugin --profile web add` 安装）以及两条行装齐后零配置获得什么：13 个 `mode: subagent` mstar 角色种子、persona 取镜像默认（settings 可 revert、运行时 advisory 报告覆盖），并附 fresh publish 的 `minimumReleaseAge` 窗口提示（重跑 init 或显式 pin 版本）。installed-deployment e2e 闭环：真实 CLI 安装进临时 `DSH_HOME`、从安装产物 boot，断言 13 角色全部 seeded 且 persona 非空。根 README 双语对补充 dsh 全量支持一句。

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,7 @@
   - [Kimi Code CLI](https://www.kimi.com/code/docs/kimi-code-cli/) (for `/plugins install`)
   - [ZCode](https://zcode.z.ai) (for Plugin Management install)
   - [omp (Oh My Pi)](https://omp.sh) (for `omp plugin install` / `omp plugin link`)
+  - [dsh (DeepSeek Harness)](https://www.npmjs.com/package/@deepseek-ai/dsh) (for the `dsh` plugin manager; e.g. `npm install -g @deepseek-ai/dsh`)
 
 ## Recommended: CLI install
 
@@ -151,11 +152,42 @@ Project scope: `npx @mstar-harness/cli init --target omp --scope project`.
 - Enter PM with `/skill:pm`. Iteration commands: `/iteration-start`, `/iteration-drive`, `/iteration-loop`.
 - Host adapter: **`mstar-host`** → `references/omp.md` (`skill://mstar-host/references/omp.md`).
 
+### dsh
+
+One CLI command installs the full dsh capability — the `@mstar-harness/dsh` plugin **plus** the optional `dsh-llm-fallbacks` role-configuration plugin:
+
+```bash
+npx @mstar-harness/cli init --target dsh
+npx @mstar-harness/cli doctor --target dsh
+```
+
+The CLI runs **two independent** `dsh plugin --profile web add` calls (mstar first, then `dsh-llm-fallbacks`) — the two-command install contract, never folded into a patch file. Re-running is idempotent: already-installed rows are skipped (`skipped-existing`), exit 0.
+
+Skip the `dsh-llm-fallbacks` row (`--no-fallbacks` is a dsh-target-only flag — ignored for other targets):
+
+```bash
+npx @mstar-harness/cli init --target dsh --no-fallbacks
+```
+
+Or run the two plugin-manager commands directly (the same contract the CLI executes):
+
+```bash
+dsh plugin --profile web add @mstar-harness/dsh
+dsh plugin --profile web add dsh-llm-fallbacks
+```
+
+**Notes:**
+
+- `--dry-run` previews the would-run commands without probing installed state or executing anything.
+- dsh profiles are machine-global; `--scope` is accepted by the shared interface but has no dsh surface.
+- `doctor --target dsh` reports each plugin row as `uninstalled` / `disabled` / `mounted` and exits non-zero when any row is uninstalled or disabled.
+- Enter PM with the `pm` skill. Host adapter: **`mstar-host`** → `references/dsh.md` (`skill://mstar-host/references/dsh.md`).
+
 ## Manual install
 
 Use when you cannot run the CLI or need to mirror the same layout by hand.
 
-Supported targets: `opencode`, `cursor`, `codex`, `zcode`, `omp`. Kimi uses Kimi TUI `/plugins install` (see [Kimi](#kimi) above).
+Supported targets: `opencode`, `cursor`, `codex`, `zcode`, `omp`, `dsh` (via the two `dsh plugin --profile web add` commands — see [dsh](#dsh) above). Kimi uses Kimi TUI `/plugins install` (see [Kimi](#kimi) above).
 
 ### OpenCode
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)
 | Codex | `npx @mstar-harness/cli init --target codex` then `codex plugin add morning-star-harness --marketplace personal` |
 | Generic (Agent Plugins v1) | point any Agent Plugins v1.0.0 conformant client at this repo root (`plugin.json` + `skills/` are the portable package) |
 
-**dsh full support** — a single CLI command (default) installs both plugin rows and seeds all 13 `mode: subagent` mstar roles with mirror-default personas: zero-config, revertible in settings (details in `packages/dsh/README.md`).
-
 ### Engine gate checks (optional)
 
 `npm i -g @mstar-harness/cli` puts the `mstar-harness` binary (short alias `mstar`) on PATH, so the engine-check commands the skills cite (`mstar status validate`, `mstar dispatch validate`, `mstar iteration gate`, …) actually run — without a global install the harness still works and those checks stay advisory. Set `enforcement: hard` in an iteration compass to make dispatch preflights fail-fast.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)
 | Codex | `npx @mstar-harness/cli init --target codex` then `codex plugin add morning-star-harness --marketplace personal` |
 | Generic (Agent Plugins v1) | point any Agent Plugins v1.0.0 conformant client at this repo root (`plugin.json` + `skills/` are the portable package) |
 
+**dsh full support** — a single CLI command (default) installs both plugin rows and seeds all 13 `mode: subagent` mstar roles with mirror-default personas: zero-config, revertible in settings (details in `packages/dsh/README.md`).
+
 ### Engine gate checks (optional)
 
 `npm i -g @mstar-harness/cli` puts the `mstar-harness` binary (short alias `mstar`) on PATH, so the engine-check commands the skills cite (`mstar status validate`, `mstar dispatch validate`, `mstar iteration gate`, …) actually run — without a global install the harness still works and those checks stay advisory. Set `enforcement: hard` in an iteration compass to make dispatch preflights fail-fast.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)
 
 | Host | Command |
 |------|---------|
-| dsh (DeepSeek Harness) | `dsh plugin --profile web add @mstar-harness/dsh` (the dsh plugin manager — not the CLI) |
+| dsh (DeepSeek Harness) | `npx @mstar-harness/cli init --target dsh` (one CLI command that runs two **independent** `dsh plugin --profile web add` installs: `@mstar-harness/dsh` + `dsh-llm-fallbacks`; `--no-fallbacks` skips the latter) or `dsh plugin --profile web add @mstar-harness/dsh` + `dsh plugin --profile web add dsh-llm-fallbacks` |
 | omp | `npx @mstar-harness/cli init --target omp` (links `~/.mstar/harness`) or `omp plugin install github:btspoony/mstar-harness` |
 | OpenCode | `npx @mstar-harness/cli init --target opencode` |
 | Cursor | `npx @mstar-harness/cli init --target cursor` |
@@ -59,7 +59,7 @@ Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)
 
 ### Verify
 
-`npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp>`.
+`npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp\|dsh>`.
 
 The repo ships a portable **Agent Plugins v1.0.0** manifest (`plugin.json`) at its root; `skills/` is the Agent Skills component — verify it with `npx @mstar-harness/cli plugin validate`.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,6 +51,8 @@ Harness Workflow Engine · Agent Plugin
 | Codex | `npx @mstar-harness/cli init --target codex`，然后 `codex plugin add morning-star-harness --marketplace personal` |
 | Generic（Agent Plugins v1） | 任意 Agent Plugins v1.0.0 兼容客户端直接指向本仓库根（`plugin.json` + `skills/` 即便携包） |
 
+**dsh 全量支持**——一条 CLI 命令（默认）装齐两条插件行并 seed 全部 13 个 `mode: subagent` mstar 角色（persona 取镜像默认）：零配置、settings 可 revert（详见 `packages/dsh/README.md`）。
+
 ### 引擎门禁校验（可选）
 
 `npm i -g @mstar-harness/cli` 将 `mstar-harness` 二进制（短别名 `mstar`）装上 PATH，技能文本引用的引擎校验命令（`mstar status validate`、`mstar dispatch validate`、`mstar iteration gate` 等）才真正可运行——不全局安装时 harness 照常工作，这些校验保持 advisory。在迭代 compass 里设 `enforcement: hard` 可让派发预检 fail-fast。

--- a/README_CN.md
+++ b/README_CN.md
@@ -42,7 +42,7 @@ Harness Workflow Engine · Agent Plugin
 
 | 宿主 | 命令 |
 |------|------|
-| dsh（DeepSeek Harness） | `dsh plugin --profile web add @mstar-harness/dsh`（dsh 自带插件管理器——不走 CLI） |
+| dsh（DeepSeek Harness） | `npx @mstar-harness/cli init --target dsh`（一条 CLI 命令编排两条**独立** `dsh plugin --profile web add` 安装：`@mstar-harness/dsh` + `dsh-llm-fallbacks`；`--no-fallbacks` 可跳过后者）或 `dsh plugin --profile web add @mstar-harness/dsh` + `dsh plugin --profile web add dsh-llm-fallbacks` |
 | omp | `npx @mstar-harness/cli init --target omp`（链接 `~/.mstar/harness`）或 `omp plugin install github:btspoony/mstar-harness` |
 | OpenCode | `npx @mstar-harness/cli init --target opencode` |
 | Cursor | `npx @mstar-harness/cli init --target cursor` |
@@ -59,7 +59,7 @@ Harness Workflow Engine · Agent Plugin
 
 ### 校验
 
-`npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp>`。
+`npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp\|dsh>`。
 
 仓库根提供便携式 **Agent Plugins v1.0.0** manifest（`plugin.json`），`skills/` 为 Agent Skills 组件——可用 `npx @mstar-harness/cli plugin validate` 校验。
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,8 +51,6 @@ Harness Workflow Engine · Agent Plugin
 | Codex | `npx @mstar-harness/cli init --target codex`，然后 `codex plugin add morning-star-harness --marketplace personal` |
 | Generic（Agent Plugins v1） | 任意 Agent Plugins v1.0.0 兼容客户端直接指向本仓库根（`plugin.json` + `skills/` 即便携包） |
 
-**dsh 全量支持**——一条 CLI 命令（默认）装齐两条插件行并 seed 全部 13 个 `mode: subagent` mstar 角色（persona 取镜像默认）：零配置、settings 可 revert（详见 `packages/dsh/README.md`）。
-
 ### 引擎门禁校验（可选）
 
 `npm i -g @mstar-harness/cli` 将 `mstar-harness` 二进制（短别名 `mstar`）装上 PATH，技能文本引用的引擎校验命令（`mstar status validate`、`mstar dispatch validate`、`mstar iteration gate` 等）才真正可运行——不全局安装时 harness 照常工作，这些校验保持 advisory。在迭代 compass 里设 `enforcement: hard` 可让派发预检 fail-fast。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -317,7 +317,7 @@ Codex `init` writes or updates marketplace metadata with a local-source entry:
 
 Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope also links `.codex/plugins/mstar-harness -> ~/.mstar/harness`, adds `.codex/plugins/mstar-harness` plus `.codex/agents/*.toml` to `.gitignore`, appends the same harness **process** gitignore set as Cursor project `init` (see above), and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
 
-dsh `init` runs the two `dsh plugin --profile web add` calls (`@mstar-harness/dsh` then `dsh-llm-fallbacks`) in the resolved profile (default `web`) — idempotent (already-installed rows skipped), fail-loud when the `dsh` binary is missing, and `--no-fallbacks` skips the fallbacks row.
+dsh `init` runs the two `dsh plugin --profile web add` calls (`@mstar-harness/dsh` then `dsh-llm-fallbacks`) in the fixed `web` profile — idempotent (already-installed rows skipped), fail-loud when the `dsh` binary is missing, and `--no-fallbacks` skips the fallbacks row.
 
 ## What `doctor` Checks
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # mstar-harness CLI Guide
 
-This guide documents the standalone `@mstar-harness/cli` package (command: `mstar-harness`) for OpenCode, Cursor, Codex, ZCode, and omp bootstrap. Kimi Code uses Kimi TUI `/plugins install` — see [INSTALL.md](../INSTALL.md#kimi). dsh (DeepSeek Harness) is **not** a CLI target — see the [dsh section](#dsh-deepseek-harness) below.
+This guide documents the standalone `@mstar-harness/cli` package (command: `mstar-harness`) for OpenCode, Cursor, Codex, ZCode, omp, and dsh bootstrap. Kimi Code uses Kimi TUI `/plugins install` — see [INSTALL.md](../INSTALL.md#kimi).
 
 The package installs two interchangeable binaries: `mstar-harness` (canonical) and the `mstar` short alias — both invoke the same CLI.
 
@@ -138,10 +138,22 @@ Kimi: not a CLI target — use `/plugins install` in Kimi TUI (see [INSTALL.md](
 
 ### dsh (DeepSeek Harness)
 
-dsh is **not** a CLI target — the harness is not installed via `npx @mstar-harness/cli init`. dsh consumes Morning Star through the **profile bundle** of the `@mstar-harness/dsh` package, added to the shipped `web` profile with the host's own plugin manager:
+`init --target dsh` installs the full dsh capability in one command — the `@mstar-harness/dsh` plugin **plus** the optional `dsh-llm-fallbacks` role-configuration plugin:
+
+- `npx @mstar-harness/cli init --target dsh`
+- `npx @mstar-harness/cli doctor --target dsh`
+
+The CLI runs **two independent** `dsh plugin --profile web add` calls (mstar first, then `dsh-llm-fallbacks`) — the two-command install contract, never folded into a patch file. Re-running is idempotent (already-installed rows are skipped, exit 0); `--dry-run` previews the would-run commands without probing installed state or executing anything.
+
+Skip the `dsh-llm-fallbacks` row (`--no-fallbacks` is a dsh-target-only flag — ignored for other targets):
+
+- `npx @mstar-harness/cli init --target dsh --no-fallbacks`
+
+Or run the two plugin-manager commands directly (the same contract the CLI executes):
 
 ```sh
 dsh plugin --profile web add @mstar-harness/dsh
+dsh plugin --profile web add dsh-llm-fallbacks
 # or, from a local checkout:
 cd <repo>/packages/dsh && dsh plugin --profile web add .
 ```
@@ -157,8 +169,9 @@ Check an existing config:
 - `npx @mstar-harness/cli doctor --target cursor --scope global`
 - `npx @mstar-harness/cli doctor --target cursor --scope project`
 - `npx @mstar-harness/cli doctor --target codex`
+- `npx @mstar-harness/cli doctor --target dsh`
 
-If validation fails, `doctor` exits with a non-zero status code.
+If validation fails, `doctor` exits with a non-zero status code. For the dsh target, each plugin row is reported as `uninstalled` / `disabled` / `mounted`; rows that are uninstalled or disabled are issues (exit 1), `mounted` is healthy.
 
 ### `mstar-harness plugin validate`
 
@@ -304,6 +317,8 @@ Codex `init` writes or updates marketplace metadata with a local-source entry:
 
 Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope also links `.codex/plugins/mstar-harness -> ~/.mstar/harness`, adds `.codex/plugins/mstar-harness` plus `.codex/agents/*.toml` to `.gitignore`, appends the same harness **process** gitignore set as Cursor project `init` (see above), and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
 
+dsh `init` runs the two `dsh plugin --profile web add` calls (`@mstar-harness/dsh` then `dsh-llm-fallbacks`) in the resolved profile (default `web`) — idempotent (already-installed rows skipped), fail-loud when the `dsh` binary is missing, and `--no-fallbacks` skips the fallbacks row.
+
 ## What `doctor` Checks
 
 - Same schema and presence of **either** `@mstar-harness/opencode…` **or** a recognized legacy `morning-star@git+…` line (so existing git-based configs still pass).
@@ -341,9 +356,10 @@ Or re-run `npx @mstar-harness/cli init --target cursor --scope global`.
 ### `init` options
 
 - `--yes`: non-interactive mode
-- `--target <opencode|cursor|codex>`
+- `--target <opencode|cursor|codex|zcode|omp|dsh>`
 - `--scope <global|project>` (default: `project`)
 - `--dry-run`
+- `--no-fallbacks`: skip installing the `dsh-llm-fallbacks` plugin row (dsh target only; ignored for other targets)
 - `--pm-model <model>` (optional advanced override)
 - `--strategic-models <a,b,c>` (optional)
 - `--dev-models <a,b,c>` (optional)

--- a/packages/cli/src/adapters/dsh.ts
+++ b/packages/cli/src/adapters/dsh.ts
@@ -65,26 +65,45 @@ function resolveProfileDir(): string {
   return path.join(dshHome, DSH_PROFILES_DIR, DSH_PROFILE);
 }
 
-/** Loader entry names from a `dsh --profile <name> --dump-config` dump: a
- * flat list of loader entries (`- id: <id>` followed by indented keys), each
- * carrying exactly one `name: <spec>` line right after the id. */
-function loaderEntryNames(dump: string): string[] {
-  const names: string[] = [];
-  let inEntry = false;
+/** One loader entry from a `--dump-config` dump. `enabled` is false when the
+ * entry carries a literal `disabled: true` or `enabled: false` line (the
+ * patch-applied disable shape observed on dsh 0.1.0-rc.6: cordis.patch.yml
+ * with `- id: <id>` / `enabled: false` prints `enabled: false` on the row).
+ * `!!js` expressions (e.g. `disabled: !!js process.platform === 'win32'`) are
+ * not statically decidable and count as enabled. */
+type LoaderEntry = { name: string; enabled: boolean };
+
+/** Parse loader entries from a `dsh --profile <name> --dump-config` dump: a
+ * flat list of `- id: <id>` entries, each carrying a `name: <spec>` line plus
+ * optional keys at the same 2-space indent. Returns null when the dump is
+ * non-empty but yields no named entry (or an entry without a `name:` line) —
+ * format drift — so callers degrade loudly instead of misreporting the
+ * installed state. */
+function parseLoaderEntries(dump: string): LoaderEntry[] | null {
+  const entries: LoaderEntry[] = [];
+  let current: LoaderEntry | null = null;
   for (const line of dump.split("\n")) {
     if (/^- id: /.test(line)) {
-      inEntry = true;
-    } else if (inEntry) {
-      const match = /^  name: (.+)$/.exec(line);
-      if (match) {
-        names.push(match[1].trim().replace(/^['"]|['"]$/g, ""));
-        inEntry = false;
+      if (current) entries.push(current);
+      current = { name: "", enabled: true };
+    } else if (current) {
+      const nameMatch = /^  name: (.+)$/.exec(line);
+      if (nameMatch) {
+        current.name = nameMatch[1].trim().replace(/^['"]|['"]$/g, "");
+      } else if (/^  disabled: true$/.test(line) || /^  enabled: false$/.test(line)) {
+        current.enabled = false;
       } else if (line.trim() !== "" && !line.startsWith("  ")) {
-        inEntry = false;
+        // Top-level line outside the entry block: close the current entry.
+        entries.push(current);
+        current = null;
       }
     }
   }
-  return names;
+  if (current) entries.push(current);
+  if (dump.trim() !== "" && (entries.length === 0 || entries.some((entry) => !entry.name))) {
+    return null;
+  }
+  return entries;
 }
 
 /** Install orchestration for the dsh target. `scope` is accepted for the
@@ -98,6 +117,11 @@ function runInit(scope: Scope, dryRun: boolean, initFlags?: InstallInitFlags) {
   // Fail-loud when the dsh bin is absent: without it there is nothing an
   // init can complete (deliberate divergence from omp's note-and-continue,
   // whose local repo clone/link side effects still make progress).
+  //
+  // Dry-run is a pure preview contract (PM ruling on T1 review M1/M2): it
+  // never probes installed state, never fails on a missing bin, and always
+  // previews the full add list — the output is identical regardless of the
+  // machine's install state. (Task 3 documents this.)
   if (!dryRun && !dshAvailable()) {
     throw new Error(`${DSH_BIN} CLI not found on PATH. ${DSH_INSTALL_HINT}`);
   }
@@ -107,8 +131,14 @@ function runInit(scope: Scope, dryRun: boolean, initFlags?: InstallInitFlags) {
   const installed = new Set<string>();
   if (!dryRun) {
     try {
-      for (const name of loaderEntryNames(runDsh([DSH_PROFILE_FLAG, DSH_PROFILE, DSH_DUMP_FLAG], dryRun))) {
-        installed.add(name);
+      const entries = parseLoaderEntries(runDsh([DSH_PROFILE_FLAG, DSH_PROFILE, DSH_DUMP_FLAG], dryRun));
+      if (entries === null) {
+        // Format drift in the dump: degrade loudly instead of misreporting
+        // everything as uninstalled. Duplicate `add` is a pinned no-op
+        // (probe 2026-08-17), so the install stays idempotent.
+        notes.push("Warning: could not parse installed plugins from dump (unexpected format); proceeding with add (idempotent).");
+      } else {
+        for (const entry of entries) installed.add(entry.name);
       }
     } catch (error) {
       // Probe unavailable: degrade to unconditional adds. Duplicate `add` is
@@ -152,8 +182,59 @@ function runInit(scope: Scope, dryRun: boolean, initFlags?: InstallInitFlags) {
   return { location: profileDir, notes };
 }
 
+/** Doctor for the dsh install surface: reports each plugin row's capability
+ * state with the AC-2 words `uninstalled` / `disabled` / `mounted`
+ * (`mounted` = loader row present and not disabled; doctor probes the
+ * install surface, it does not boot a live fiber). Issue states
+ * (uninstalled/disabled) go to `errors` (the CLI exits 1); every state also
+ * gets a worded `notes` line so `mounted` is visible on a healthy run —
+ * never implied only by exit code 0. An unusable probe degrades into an
+ * explicit error line instead of a silent pass. `scope` is accepted for the
+ * shared AgentAdapter contract but has no dsh surface (machine-global
+ * profiles), mirroring runInit. */
+function runDoctor(scope: Scope): { location: string; errors: string[]; notes: string[] } {
+  const errors: string[] = [];
+  const notes: string[] = [];
+  const profileDir = resolveProfileDir();
+
+  if (!dshAvailable()) {
+    errors.push(`${DSH_BIN} CLI not found on PATH. ${DSH_INSTALL_HINT}`);
+    return { location: profileDir, errors, notes };
+  }
+
+  let dump: string;
+  try {
+    dump = runDsh([DSH_PROFILE_FLAG, DSH_PROFILE, DSH_DUMP_FLAG], false);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push(`Warning: could not probe installed plugins (${message}); cannot verify install state.`);
+    return { location: profileDir, errors, notes };
+  }
+
+  const entries = parseLoaderEntries(dump);
+  if (entries === null) {
+    errors.push("Warning: could not parse installed plugins from dump (unexpected format); cannot verify install state.");
+    return { location: profileDir, errors, notes };
+  }
+
+  const byName = new Map(entries.map((entry) => [entry.name, entry]));
+  for (const spec of DSH_PLUGIN_SPECS) {
+    const entry = byName.get(spec);
+    const state = !entry ? "uninstalled" : entry.enabled ? "mounted" : "disabled";
+    notes.push(`${spec}: ${state}`);
+    if (state === "mounted") continue;
+    const hint =
+      state === "uninstalled"
+        ? "Run: mstar-harness init --target dsh"
+        : "Enable it (e.g. remove the disable entry from cordis.patch.yml) and re-run doctor.";
+    errors.push(`${spec} is ${state}. ${hint}`);
+  }
+  return { location: profileDir, errors, notes };
+}
+
 export const dshAdapter: AgentAdapter = {
   target: "dsh",
   mode: "install",
   runInstallInit: (scope, dryRun, initFlags) => runInit(scope, dryRun, initFlags),
+  runInstallDoctor: (scope) => runDoctor(scope),
 };

--- a/packages/cli/src/adapters/dsh.ts
+++ b/packages/cli/src/adapters/dsh.ts
@@ -214,8 +214,8 @@ function runInit(scope: Scope, dryRun: boolean, initFlags?: InstallInitFlags) {
   notes.push(`Profile: ${DSH_PROFILE} at ${profileDir}`);
   notes.push("Verify with: mstar-harness doctor --target dsh");
   notes.push(
-    `Alternate manual install: ${DSH_BIN} ${DSH_PROFILE_FLAG} ${DSH_PROFILE} add ${DSH_PLUGIN_SPECS.join(
-      ` && ${DSH_BIN} ${DSH_PROFILE_FLAG} ${DSH_PROFILE} add `,
+    `Alternate manual install: ${DSH_BIN} plugin ${DSH_PROFILE_FLAG} ${DSH_PROFILE} add ${DSH_PLUGIN_SPECS.join(
+      ` && ${DSH_BIN} plugin ${DSH_PROFILE_FLAG} ${DSH_PROFILE} add `,
     )}`,
   );
 

--- a/packages/cli/src/adapters/dsh.ts
+++ b/packages/cli/src/adapters/dsh.ts
@@ -28,6 +28,25 @@ const DSH_HOME_ENV = "DSH_HOME";
 const DSH_HOME_SUBDIR = ".dsh";
 const DSH_PROFILES_DIR = "profiles";
 
+/** Subprocess timeouts (ms). The `add` call forwards to pnpm over the
+ * network, so it gets a conservative ceiling: a stalled registry must
+ * surface as an error instead of hanging the CLI without output. Local
+ * probe calls (`--version`, `--dump-config`) are bounded tighter. The add
+ * timeout is overridable via `MSTAR_DSH_SUBPROCESS_TIMEOUT_MS` (mirrors the
+ * engine's MSTAR_GIT_PROBE_TIMEOUT_MS convention; tests shrink it to
+ * exercise the kill path). */
+const DSH_LOCAL_TIMEOUT_MS = 10_000;
+const DSH_ADD_TIMEOUT_MS = 300_000;
+const DSH_ADD_TIMEOUT_ENV = "MSTAR_DSH_SUBPROCESS_TIMEOUT_MS";
+
+/** Add-path timeout: env override wins, else the conservative default. */
+function addTimeoutMs(): number {
+  const raw = process.env[DSH_ADD_TIMEOUT_ENV];
+  if (raw === undefined || raw.trim() === "") return DSH_ADD_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DSH_ADD_TIMEOUT_MS;
+}
+
 /** Install order is the F4 double-command contract: mstar first, fallbacks
  * second (reconcile append order — the fallbacks row lands after the
  * dsh-base/llm-retry layers). The lines are never folded into any patch.
@@ -39,18 +58,25 @@ const DSH_FALLBACKS_SPEC = DSH_PLUGIN_SPECS[1];
 const DSH_INSTALL_HINT =
   "Install the DeepSeek Harness CLI (@deepseek-ai/dsh), e.g. `pnpm add -g @deepseek-ai/dsh` or `npm install -g @deepseek-ai/dsh`, then re-run init.";
 
-/** Run dsh with args; dry-run never spawns a subprocess (preview only). */
-function runDsh(args: string[], dryRun: boolean): string {
+/** Run dsh with args; dry-run never spawns a subprocess (preview only).
+ * `timeoutMs` bounds the child so a hung dsh/pnpm surfaces as an error
+ * instead of blocking the CLI forever. */
+function runDsh(args: string[], dryRun: boolean, timeoutMs: number): string {
   if (dryRun) return "";
   // Explicit `env` snapshot: Bun resolves the command against the env's PATH
   // only when `env` is passed (otherwise it uses the startup PATH), which is
   // what lets tests inject a fake dsh via PATH.
-  return execFileSync(DSH_BIN, args, { stdio: "pipe", encoding: "utf8", env: process.env });
+  return execFileSync(DSH_BIN, args, {
+    stdio: "pipe",
+    encoding: "utf8",
+    env: process.env,
+    timeout: timeoutMs,
+  });
 }
 
 function dshAvailable(): boolean {
   try {
-    runDsh(["--version"], false);
+    runDsh(["--version"], false, DSH_LOCAL_TIMEOUT_MS);
     return true;
   } catch {
     return false;
@@ -66,12 +92,16 @@ function resolveProfileDir(): string {
 }
 
 /** One loader entry from a `--dump-config` dump. `enabled` is false when the
- * entry carries a literal `disabled: true` or `enabled: false` line (the
- * patch-applied disable shape observed on dsh 0.1.0-rc.6: cordis.patch.yml
- * with `- id: <id>` / `enabled: false` prints `enabled: false` on the row).
- * `!!js` expressions (e.g. `disabled: !!js process.platform === 'win32'`) are
- * not statically decidable and count as enabled. */
+ * entry carries a literal `disabled: true` or `enabled: false` marker: as a
+ * standalone 2-space line (the real shapes observed on dsh 0.1.0-rc.6 — the
+ * patch-applied `enabled: false` row and the built-in `disabled: true` row)
+ * or inline on the `- id:` / `name:` line. `!!js` expressions (e.g.
+ * `disabled: !!js process.platform === 'win32'`) are not statically
+ * decidable and count as enabled. */
 type LoaderEntry = { name: string; enabled: boolean };
+
+/** Literal disable markers that make a loader row statically disabled. */
+const DISABLED_MARKERS = /\b(?:disabled: true|enabled: false)\b/;
 
 /** Parse loader entries from a `dsh --profile <name> --dump-config` dump: a
  * flat list of `- id: <id>` entries, each carrying a `name: <spec>` line plus
@@ -85,11 +115,19 @@ function parseLoaderEntries(dump: string): LoaderEntry[] | null {
   for (const line of dump.split("\n")) {
     if (/^- id: /.test(line)) {
       if (current) entries.push(current);
-      current = { name: "", enabled: true };
+      current = { name: "", enabled: !DISABLED_MARKERS.test(line) };
     } else if (current) {
       const nameMatch = /^  name: (.+)$/.exec(line);
       if (nameMatch) {
-        current.name = nameMatch[1].trim().replace(/^['"]|['"]$/g, "");
+        let name = nameMatch[1].trim();
+        if (DISABLED_MARKERS.test(line)) {
+          current.enabled = false;
+          // Inline marker on the name line (drift shape): strip a trailing
+          // `, disabled: true` / ` disabled: true` suffix before quote
+          // removal so the row still matches its spec.
+          name = name.replace(/\s*,?\s*(?:disabled: true|enabled: false)\s*$/, "");
+        }
+        current.name = name.replace(/^['"]|['"]$/g, "");
       } else if (/^  disabled: true$/.test(line) || /^  enabled: false$/.test(line)) {
         current.enabled = false;
       } else if (line.trim() !== "" && !line.startsWith("  ")) {
@@ -131,7 +169,9 @@ function runInit(scope: Scope, dryRun: boolean, initFlags?: InstallInitFlags) {
   const installed = new Set<string>();
   if (!dryRun) {
     try {
-      const entries = parseLoaderEntries(runDsh([DSH_PROFILE_FLAG, DSH_PROFILE, DSH_DUMP_FLAG], dryRun));
+      const entries = parseLoaderEntries(
+        runDsh([DSH_PROFILE_FLAG, DSH_PROFILE, DSH_DUMP_FLAG], dryRun, DSH_LOCAL_TIMEOUT_MS),
+      );
       if (entries === null) {
         // Format drift in the dump: degrade loudly instead of misreporting
         // everything as uninstalled. Duplicate `add` is a pinned no-op
@@ -163,7 +203,7 @@ function runInit(scope: Scope, dryRun: boolean, initFlags?: InstallInitFlags) {
       continue;
     }
     try {
-      runDsh(addArgs, dryRun);
+      runDsh(addArgs, dryRun, addTimeoutMs());
       notes.push(`installed: ${spec} (${DSH_BIN} ${addArgs.join(" ")})`);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -204,7 +244,7 @@ function runDoctor(scope: Scope): { location: string; errors: string[]; notes: s
 
   let dump: string;
   try {
-    dump = runDsh([DSH_PROFILE_FLAG, DSH_PROFILE, DSH_DUMP_FLAG], false);
+    dump = runDsh([DSH_PROFILE_FLAG, DSH_PROFILE, DSH_DUMP_FLAG], false, DSH_LOCAL_TIMEOUT_MS);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     errors.push(`Warning: could not probe installed plugins (${message}); cannot verify install state.`);

--- a/packages/cli/src/adapters/dsh.ts
+++ b/packages/cli/src/adapters/dsh.ts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import type { AgentAdapter, InstallInitFlags, Scope } from "../types";
+
+// --- dsh CLI surface (probe-pinned 2026-08-17 on dsh 0.1.0-rc.6) ---
+// - `--profile <name>` is required and must precede the subcommand:
+//   `dsh plugin --help` without it exits 1 with
+//   "required option '--profile <name>' not specified".
+// - `dsh plugin --profile <name> add <spec>` forwards <spec> to pnpm in the
+//   profile dir (writes package.json dependencies, materializes node_modules)
+//   and reconciles `dsh.profile.bundles` from the installed state: any
+//   dependency whose manifest declares `dsh.bundle` joins the layer stack
+//   (appended in dependency order).
+// - Duplicate `add` of an already-installed spec is a no-op: pnpm prints
+//   "Already up to date", exits 0, and the bundle list is unchanged.
+// - Enumeration surface: `dsh --profile <name> --dump-config` prints the
+//   composed loader tree and exits 0 without booting a live fiber; each
+//   installed bundle shows up as loader entries (`- id: <id>` then a
+//   `name: <spec>` line), disabled rows included.
+// - There is no `dsh plugin list` subcommand; enumeration goes through
+//   --dump-config (or the profile manifest under $DSH_HOME/profiles/<name>).
+const DSH_BIN = "dsh";
+const DSH_PROFILE = "web";
+const DSH_PROFILE_FLAG = "--profile";
+const DSH_DUMP_FLAG = "--dump-config";
+const DSH_HOME_ENV = "DSH_HOME";
+const DSH_HOME_SUBDIR = ".dsh";
+const DSH_PROFILES_DIR = "profiles";
+
+/** Install order is the F4 double-command contract: mstar first, fallbacks
+ * second (reconcile append order — the fallbacks row lands after the
+ * dsh-base/llm-retry layers). The lines are never folded into any patch.
+ * Default profile is fixed to `web` (dsh-tui not verified); centralized so a
+ * future profile flag changes exactly one place. */
+const DSH_PLUGIN_SPECS: readonly string[] = ["@mstar-harness/dsh", "dsh-llm-fallbacks"];
+const DSH_FALLBACKS_SPEC = DSH_PLUGIN_SPECS[1];
+
+const DSH_INSTALL_HINT =
+  "Install the DeepSeek Harness CLI (@deepseek-ai/dsh), e.g. `pnpm add -g @deepseek-ai/dsh` or `npm install -g @deepseek-ai/dsh`, then re-run init.";
+
+/** Run dsh with args; dry-run never spawns a subprocess (preview only). */
+function runDsh(args: string[], dryRun: boolean): string {
+  if (dryRun) return "";
+  // Explicit `env` snapshot: Bun resolves the command against the env's PATH
+  // only when `env` is passed (otherwise it uses the startup PATH), which is
+  // what lets tests inject a fake dsh via PATH.
+  return execFileSync(DSH_BIN, args, { stdio: "pipe", encoding: "utf8", env: process.env });
+}
+
+function dshAvailable(): boolean {
+  try {
+    runDsh(["--version"], false);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The `web` profile directory. dsh resolves its home from $DSH_HOME, else
+ * `~/.dsh` (observed on this machine). Only used for the reported location;
+ * installed-state detection goes through the dsh binary itself. */
+function resolveProfileDir(): string {
+  const dshHome = process.env[DSH_HOME_ENV] ?? path.join(os.homedir(), DSH_HOME_SUBDIR);
+  return path.join(dshHome, DSH_PROFILES_DIR, DSH_PROFILE);
+}
+
+/** Loader entry names from a `dsh --profile <name> --dump-config` dump: a
+ * flat list of loader entries (`- id: <id>` followed by indented keys), each
+ * carrying exactly one `name: <spec>` line right after the id. */
+function loaderEntryNames(dump: string): string[] {
+  const names: string[] = [];
+  let inEntry = false;
+  for (const line of dump.split("\n")) {
+    if (/^- id: /.test(line)) {
+      inEntry = true;
+    } else if (inEntry) {
+      const match = /^  name: (.+)$/.exec(line);
+      if (match) {
+        names.push(match[1].trim().replace(/^['"]|['"]$/g, ""));
+        inEntry = false;
+      } else if (line.trim() !== "" && !line.startsWith("  ")) {
+        inEntry = false;
+      }
+    }
+  }
+  return names;
+}
+
+/** Install orchestration for the dsh target. `scope` is accepted for the
+ * shared AgentAdapter contract but has no dsh surface: dsh profiles live
+ * machine-globally under $DSH_HOME/profiles, so the flow is identical for
+ * global and project scopes. */
+function runInit(scope: Scope, dryRun: boolean, initFlags?: InstallInitFlags) {
+  const notes: string[] = [];
+  const profileDir = resolveProfileDir();
+
+  // Fail-loud when the dsh bin is absent: without it there is nothing an
+  // init can complete (deliberate divergence from omp's note-and-continue,
+  // whose local repo clone/link side effects still make progress).
+  if (!dryRun && !dshAvailable()) {
+    throw new Error(`${DSH_BIN} CLI not found on PATH. ${DSH_INSTALL_HINT}`);
+  }
+
+  // Probe installed state from the composed loader tree: same binary, same
+  // home resolution as `add`, so the probe can never disagree with install.
+  const installed = new Set<string>();
+  if (!dryRun) {
+    try {
+      for (const name of loaderEntryNames(runDsh([DSH_PROFILE_FLAG, DSH_PROFILE, DSH_DUMP_FLAG], dryRun))) {
+        installed.add(name);
+      }
+    } catch (error) {
+      // Probe unavailable: degrade to unconditional adds. Duplicate `add` is
+      // a pinned no-op (probe 2026-08-17), so the install stays idempotent.
+      const message = error instanceof Error ? error.message : String(error);
+      notes.push(`Warning: could not probe installed plugins (${message}); proceeding with add (idempotent).`);
+    }
+  }
+
+  for (const spec of DSH_PLUGIN_SPECS) {
+    if (spec === DSH_FALLBACKS_SPEC && initFlags?.noFallbacks) {
+      notes.push(`skipped-by-flag: ${spec} (--no-fallbacks)`);
+      continue;
+    }
+    if (!dryRun && installed.has(spec)) {
+      notes.push(`skipped-existing: ${spec} (already installed in profile ${DSH_PROFILE})`);
+      continue;
+    }
+    const addArgs = ["plugin", DSH_PROFILE_FLAG, DSH_PROFILE, "add", spec];
+    if (dryRun) {
+      notes.push(`Would run: ${DSH_BIN} ${addArgs.join(" ")}`);
+      continue;
+    }
+    try {
+      runDsh(addArgs, dryRun);
+      notes.push(`installed: ${spec} (${DSH_BIN} ${addArgs.join(" ")})`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to install ${spec} via ${DSH_BIN}: ${message}`);
+    }
+  }
+
+  notes.push(`Profile: ${DSH_PROFILE} at ${profileDir}`);
+  notes.push("Verify with: mstar-harness doctor --target dsh");
+  notes.push(
+    `Alternate manual install: ${DSH_BIN} ${DSH_PROFILE_FLAG} ${DSH_PROFILE} add ${DSH_PLUGIN_SPECS.join(
+      ` && ${DSH_BIN} ${DSH_PROFILE_FLAG} ${DSH_PROFILE} add `,
+    )}`,
+  );
+
+  return { location: profileDir, notes };
+}
+
+export const dshAdapter: AgentAdapter = {
+  target: "dsh",
+  mode: "install",
+  runInstallInit: (scope, dryRun, initFlags) => runInit(scope, dryRun, initFlags),
+};

--- a/packages/cli/src/adapters/index.ts
+++ b/packages/cli/src/adapters/index.ts
@@ -1,6 +1,7 @@
 import type { AgentAdapter, Target } from "../types";
 import { codexAdapter } from "./codex";
 import { cursorAdapter } from "./cursor";
+import { dshAdapter } from "./dsh";
 import { ompAdapter } from "./omp";
 import { opencodeAdapter } from "./opencode";
 import { zcodeAdapter } from "./zcode";
@@ -11,6 +12,7 @@ const adapters: Record<Target, AgentAdapter> = {
   codex: codexAdapter,
   zcode: zcodeAdapter,
   omp: ompAdapter,
+  dsh: dshAdapter,
 };
 
 export function getAdapter(target: Target) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -204,6 +204,12 @@ function runDoctor(options: DoctorOptions) {
       throw new Error(`Adapter ${target} does not implement install doctor flow.`);
     }
     console.log(`Install location: ${result.location}`);
+    // Capability word lines (install-mode doctor notes, e.g. dsh
+    // uninstalled/disabled/mounted) print on every run, healthy included —
+    // a `mounted` state must not be implied only by exit code 0 (AC-2).
+    for (const note of result.notes ?? []) {
+      console.log(`  - ${note}`);
+    }
     if (!result.errors.length) {
       console.log(pc.green("Doctor result: healthy"));
       return;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -136,7 +136,7 @@ async function runInit(options: InitOptions) {
 
   if (adapter.mode === "install") {
     logStep("Step 2/2 - Run target install flow");
-    const installResult = adapter.runInstallInit?.(scope, !!options.dryRun);
+    const installResult = adapter.runInstallInit?.(scope, !!options.dryRun, { noFallbacks: options.noFallbacks });
     if (!installResult) {
       throw new Error(`Adapter ${target} does not implement install init flow.`);
     }
@@ -281,13 +281,16 @@ program
   .option("--scope <scope>", "Config scope: global|project (default: project)")
   .option("--output <path>", "Config file path override, relative to project root")
   .option("--dry-run", "Preview result without writing config")
+  .option("--no-fallbacks", "Skip installing the dsh-llm-fallbacks plugin (dsh target only)")
   .option("--pm-model <model>", "Optional: model for project-manager (advanced override)")
   .option("--strategic-models <a,b,c>", "Optional: models for architect/product-manager/prompt-engineer")
   .option("--dev-models <a,b,c>", "Optional: models for fullstack-dev/fullstack-dev-2/frontend-dev")
   .option("--qc-models <a,b,c>", "Optional: models for qc trio")
   .option("--other-models <a,b,c>", "Optional: models for remaining roles")
-  .action(async (options: InitOptions) => {
-    await runInit(options);
+  .action(async (options: InitOptions & { fallbacks?: boolean }) => {
+    // commander's negation `--no-fallbacks` parses as `fallbacks: false`
+    // (default true); map to the canonical `noFallbacks` name at the boundary.
+    await runInit({ ...options, noFallbacks: options.fallbacks === false });
   });
 
 program

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_TARGETS = ["opencode", "cursor", "codex", "zcode", "omp"] as const;
+export const SUPPORTED_TARGETS = ["opencode", "cursor", "codex", "zcode", "omp", "dsh"] as const;
 export type Target = (typeof SUPPORTED_TARGETS)[number];
 export type Scope = "global" | "project";
 
@@ -8,6 +8,8 @@ export type InitOptions = {
   scope?: Scope;
   output?: string;
   dryRun?: boolean;
+  /** Skip installing the dsh-llm-fallbacks plugin row (dsh target only). */
+  noFallbacks?: boolean;
   pmModel?: string;
   strategicModels?: string;
   devModels?: string;
@@ -33,6 +35,11 @@ export type ModelSelections = {
   others: string[];
 };
 
+/** Flags forwarded to an install-mode adapter's runInstallInit. */
+export type InstallInitFlags = {
+  noFallbacks?: boolean;
+};
+
 export type AgentAdapter = {
   target: Target;
   mode: "config" | "install";
@@ -45,7 +52,11 @@ export type AgentAdapter = {
   validateConfig?: (config: Record<string, unknown>) => string[];
   /** Non-fatal notices printed after doctor validation passes (e.g. migration hints). */
   getDoctorWarnings?: (config: Record<string, unknown>) => string[];
-  runInstallInit?: (scope: Scope, dryRun: boolean) => { location: string; notes: string[] };
+  runInstallInit?: (
+    scope: Scope,
+    dryRun: boolean,
+    initFlags?: InstallInitFlags,
+  ) => { location: string; notes: string[] };
   runInstallDoctor?: (scope: Scope) => { location: string; errors: string[] };
   printPostSetupSummary?: (config: Record<string, unknown>) => void;
 };

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -57,6 +57,6 @@ export type AgentAdapter = {
     dryRun: boolean,
     initFlags?: InstallInitFlags,
   ) => { location: string; notes: string[] };
-  runInstallDoctor?: (scope: Scope) => { location: string; errors: string[] };
+  runInstallDoctor?: (scope: Scope) => { location: string; errors: string[]; notes?: string[] };
   printPostSetupSummary?: (config: Record<string, unknown>) => void;
 };

--- a/packages/cli/test/dsh-adapter.test.ts
+++ b/packages/cli/test/dsh-adapter.test.ts
@@ -708,6 +708,19 @@ describe("CLI doctor --target dsh (fake dsh on PATH)", () => {
     }
   });
 
+  test("fallbacks uninstalled: exit 1 and the uninstalled issue is printed", () => {
+    const fake = makeFakeDsh(DUMP_FALLBACKS_MISSING);
+    try {
+      const result = runCli(["doctor", "--target", "dsh"], { env: fakePathEnv(fake) });
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain(`${MSTAR_SPEC}: mounted`);
+      expect(result.stdout).toContain(`${FALLBACKS_SPEC}: uninstalled`);
+      expect(result.stdout).toContain(`${FALLBACKS_SPEC} is uninstalled`);
+    } finally {
+      fake.remove();
+    }
+  });
+
   test("probe failure: exit 1 with the explicit degradation line (no silent pass)", () => {
     const fake = makeFakeDsh(DUMP_BOTH, { dumpExit: 1 });
     try {

--- a/packages/cli/test/dsh-adapter.test.ts
+++ b/packages/cli/test/dsh-adapter.test.ts
@@ -1,0 +1,272 @@
+/**
+ * dsh target adapter — install orchestration (`runInstallInit`).
+ *
+ * Drives the adapter with a fake `dsh` executable injected on PATH (a shell
+ * script that records argv to a log file and serves a `--dump-config`
+ * fixture), so the exact subprocess surface is asserted without a real dsh
+ * install:
+ *   - default install: two `dsh plugin --profile web add <spec>` calls,
+ *     mstar first then dsh-llm-fallbacks (F4 double-command contract, AC-6);
+ *   - `--no-fallbacks`: one add (mstar only), fallbacks noted skipped-by-flag;
+ *   - missing dsh bin: fail-loud throw carrying an install hint;
+ *   - dry-run: no subprocess at all, notes preview the would-run commands;
+ *   - idempotency: lines already present in the composed loader tree are
+ *     skipped (`skipped-existing` notes, zero add calls).
+ * Plus end-to-end wiring through the real CLI entry (`init --target dsh` /
+ * `--no-fallbacks` / missing bin) with the fake bin injected via PATH.
+ */
+import { describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { dshAdapter } from "../src/adapters/dsh";
+
+const CLI_ROOT = resolve(import.meta.dir, "..");
+const SRC_ENTRY = join(CLI_ROOT, "src/index.ts");
+
+/** Spawn env with ambient harness env vars pinned out (same convention as
+ * the other cli suites): the CLI would otherwise resolve harness dirs from
+ * MSTAR_HARNESS_DIR and redirect fixtures. */
+function cliEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key === "MSTAR_HARNESS_DIR" || key === "MSTAR_CONTROL_ROOT" || key === "SDD_DIR" || key === "MSTAR_WORKING_BRANCH") {
+      continue;
+    }
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+interface RunResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run the real CLI entry as a subprocess; cwd + env overrides per test. */
+function runCli(args: string[], opts: { env?: Record<string, string> } = {}): RunResult {
+  const proc = Bun.spawnSync([process.execPath, "run", SRC_ENTRY, ...args], {
+    cwd: CLI_ROOT,
+    env: { ...cliEnv(), ...opts.env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { exitCode: proc.exitCode, stdout: proc.stdout.toString(), stderr: proc.stderr.toString() };
+}
+
+interface FakeDsh {
+  binDir: string;
+  logFile: string;
+  remove: () => void;
+}
+
+/** Create a fake `dsh` executable in a temp dir: records argv (space-joined)
+ * to logFile, answers `--version` (exit 0), prints the `--dump-config`
+ * fixture, and exits 0 for `plugin ... add ...`. The script uses shell
+ * builtins only so it works under a PATH restricted to the fake dir. */
+function makeFakeDsh(dumpFixture: string): FakeDsh {
+  const binDir = mkdtempSync(join(tmpdir(), "dsh-fake-"));
+  const logFile = join(binDir, "argv.log");
+  const dumpFile = join(binDir, "dump.yml");
+  writeFileSync(dumpFile, dumpFixture);
+  const binPath = join(binDir, "dsh");
+  writeFileSync(
+    binPath,
+    [
+      "#!/bin/sh",
+      `echo "$@" >> "${logFile}"`,
+      'if [ "$1" = "--version" ]; then exit 0; fi',
+      `if [ "$1" = "--profile" ] && [ "$3" = "--dump-config" ]; then`,
+      `  while IFS= read -r line; do printf '%s\\n' "$line"; done < "${dumpFile}"`,
+      "  exit 0",
+      "fi",
+      "exit 0",
+    ].join("\n") + "\n",
+  );
+  chmodSync(binPath, 0o755);
+  return { binDir, logFile, remove: () => rmSync(binDir, { recursive: true, force: true }) };
+}
+
+/** Run fn with PATH restricted to `pathEntry` (snapshot/restore). */
+function withPath(pathEntry: string, fn: () => void): void {
+  const prev = process.env.PATH;
+  process.env.PATH = pathEntry;
+  try {
+    fn();
+  } finally {
+    process.env.PATH = prev;
+  }
+}
+
+/** All recorded invocations, one line per argv (space-joined). A missing
+ * log means no subprocess ever ran (e.g. dry-run). */
+function argvLines(fake: FakeDsh): string[] {
+  if (!existsSync(fake.logFile)) return [];
+  const raw = readFileSync(fake.logFile, "utf8").trim();
+  return raw ? raw.split("\n") : [];
+}
+
+/** Only the `plugin --profile web add <spec>` invocations (the F4 contract). */
+function addLines(fake: FakeDsh): string[] {
+  return argvLines(fake).filter((line) => line.startsWith("plugin --profile web add "));
+}
+
+/** Assert one notes line carries the marker prefix (notes append trailing
+ * detail after the marker, so exact element match would be wrong). */
+function expectNote(notes: string[], marker: string): void {
+  expect(notes.some((note) => note.startsWith(marker))).toBe(true);
+}
+
+const MSTAR_SPEC = "@mstar-harness/dsh";
+const FALLBACKS_SPEC = "dsh-llm-fallbacks";
+
+/** Empty loader tree: nothing installed. */
+const DUMP_EMPTY = "";
+
+/** Loader tree with both plugin lines present (real dump-config shape:
+ * `# == <bundle>` header, then `- id: <id>` / `name: <spec>` loader entries). */
+const DUMP_BOTH = [
+  "# == @mstar-harness/dsh",
+  "- id: mstar",
+  "  name: '@mstar-harness/dsh'",
+  "  config: {}",
+  "# == dsh-llm-fallbacks",
+  "- id: llm-fallbacks",
+  "  name: dsh-llm-fallbacks",
+  "  config: {}",
+  "",
+].join("\n");
+
+describe("dshAdapter.runInstallInit", () => {
+  test("default install: two adds, mstar first then fallbacks (AC-6)", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY);
+    try {
+      let result: { location: string; notes: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallInit?.("global", false);
+      });
+      expect(result).toBeDefined();
+      expect(addLines(fake)).toEqual([
+        `plugin --profile web add ${MSTAR_SPEC}`,
+        `plugin --profile web add ${FALLBACKS_SPEC}`,
+      ]);
+      expectNote(result!.notes, `installed: ${MSTAR_SPEC}`);
+      expectNote(result!.notes, `installed: ${FALLBACKS_SPEC}`);
+      expect(result!.location).toContain(join("profiles", "web"));    } finally {
+      fake.remove();
+    }
+  });
+
+  test("--no-fallbacks: only the mstar add runs; fallbacks noted skipped-by-flag", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY);
+    try {
+      let result: { location: string; notes: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallInit?.("global", false, { noFallbacks: true });
+      });
+      expect(result).toBeDefined();
+      expect(addLines(fake)).toEqual([`plugin --profile web add ${MSTAR_SPEC}`]);
+      expectNote(result!.notes, `skipped-by-flag: ${FALLBACKS_SPEC}`);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("missing dsh bin: fail-loud throw carrying an install hint", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "dsh-nobin-"));
+    try {
+      let error: unknown;
+      withPath(emptyDir, () => {
+        try {
+          dshAdapter.runInstallInit?.("global", false);
+        } catch (e) {
+          error = e;
+        }
+      });
+      expect(String(error)).toContain("dsh CLI not found on PATH");
+      expect(String(error)).toContain("@deepseek-ai/dsh");
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  test("dry-run: no subprocess at all; notes preview the would-run adds", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY);
+    try {
+      let result: { location: string; notes: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallInit?.("global", true);
+      });
+      expect(result).toBeDefined();
+      expect(argvLines(fake)).toEqual([]);
+      expectNote(result!.notes, `Would run: dsh plugin --profile web add ${MSTAR_SPEC}`);
+      expectNote(result!.notes, `Would run: dsh plugin --profile web add ${FALLBACKS_SPEC}`);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("idempotent: already-installed lines are skipped (skipped-existing)", () => {
+    const fake = makeFakeDsh(DUMP_BOTH);
+    try {
+      let result: { location: string; notes: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallInit?.("global", false);
+      });
+      expect(result).toBeDefined();
+      expect(addLines(fake)).toEqual([]);
+      // The only subprocesses are the availability check + installed-state probe.
+      expect(argvLines(fake)).toEqual(["--version", "--profile web --dump-config"]);
+      expectNote(result!.notes, `skipped-existing: ${MSTAR_SPEC}`);
+      expectNote(result!.notes, `skipped-existing: ${FALLBACKS_SPEC}`);
+    } finally {
+      fake.remove();
+    }
+  });
+});
+
+describe("CLI init --target dsh (fake dsh on PATH)", () => {
+  const fakePathEnv = (fake: FakeDsh): { PATH: string } => ({
+    PATH: `${fake.binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+  });
+
+  test("wires --target dsh through the adapter (two adds, exit 0)", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY);
+    try {
+      const result = runCli(["init", "--target", "dsh"], { env: fakePathEnv(fake) });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`installed: ${MSTAR_SPEC}`);
+      expect(result.stdout).toContain(`installed: ${FALLBACKS_SPEC}`);
+      expect(addLines(fake)).toEqual([
+        `plugin --profile web add ${MSTAR_SPEC}`,
+        `plugin --profile web add ${FALLBACKS_SPEC}`,
+      ]);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("--no-fallbacks maps to a single mstar add", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY);
+    try {
+      const result = runCli(["init", "--target", "dsh", "--no-fallbacks"], { env: fakePathEnv(fake) });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`skipped-by-flag: ${FALLBACKS_SPEC}`);
+      expect(addLines(fake)).toEqual([`plugin --profile web add ${MSTAR_SPEC}`]);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("missing dsh bin: Setup failed + exit 1 (fail-loud, no silent skip)", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "dsh-nobin-"));
+    try {
+      const result = runCli(["init", "--target", "dsh"], { env: { PATH: emptyDir } });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Setup failed: dsh CLI not found on PATH");
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/test/dsh-adapter.test.ts
+++ b/packages/cli/test/dsh-adapter.test.ts
@@ -16,12 +16,19 @@
  *   - probe degradation: a failing `--dump-config` probe or a malformed
  *     (format-drifted) dump yields an explicit warning note while the adds
  *     still run (pinned no-op keeps it idempotent);
- *   - add failure: a non-zero `add` exit throws `Failed to install <spec>`.
+ *   - add failure: a non-zero `add` exit throws `Failed to install <spec>`;
+ *   - stalled add: a hung pnpm forward is killed by the bounded subprocess
+ *     timeout (ETIMEDOUT) instead of blocking the CLI forever;
+ *   - `--dry-run` + `--no-fallbacks`: previews a single add with zero
+ *     subprocesses.
  * Doctor (`runInstallDoctor`): reports each plugin row's capability state
  * with the AC-2 words `uninstalled` / `disabled` / `mounted` — issue states
  * (uninstalled/disabled) land in `errors` (CLI exits 1), every state also
  * gets a worded notes line (healthy runs show `mounted`), and an unusable
- * probe degrades into an explicit error rather than a silent pass.
+ * probe degrades into an explicit error rather than a silent pass. Disabled
+ * rows are pinned in all literal marker shapes: standalone `enabled: false`,
+ * standalone `disabled: true`, and inline `disabled: true` on the `- id:` /
+ * `name:` lines.
  * Plus end-to-end wiring through the real CLI entry (`init --target dsh` /
  * `--no-fallbacks` / missing bin / `doctor --target dsh`) with the fake bin
  * injected via PATH.
@@ -78,14 +85,19 @@ interface FakeDsh {
  * builtins only so it works under a PATH restricted to the fake dir.
  * `opts.dumpExit` / `opts.addExit` force a non-zero exit on the
  * `--dump-config` / `plugin ... add` branches to simulate probe and add
- * failures. */
-function makeFakeDsh(dumpFixture: string, opts: { dumpExit?: number; addExit?: number } = {}): FakeDsh {
+ * failures; `opts.addSleepSec` makes the add branch sleep first (via
+ * /bin/sleep, PATH-independent) to simulate a stalled pnpm forward. */
+function makeFakeDsh(
+  dumpFixture: string,
+  opts: { dumpExit?: number; addExit?: number; addSleepSec?: number } = {},
+): FakeDsh {
   const binDir = mkdtempSync(join(tmpdir(), "dsh-fake-"));
   const logFile = join(binDir, "argv.log");
   const dumpFile = join(binDir, "dump.yml");
   writeFileSync(dumpFile, dumpFixture);
   const dumpExit = opts.dumpExit ?? 0;
   const addExit = opts.addExit ?? 0;
+  const addSleep = opts.addSleepSec ? `  /bin/sleep ${opts.addSleepSec}\n` : "";
   const binPath = join(binDir, "dsh");
   writeFileSync(
     binPath,
@@ -97,7 +109,10 @@ function makeFakeDsh(dumpFixture: string, opts: { dumpExit?: number; addExit?: n
       `  while IFS= read -r line; do printf '%s\\n' "$line"; done < "${dumpFile}"`,
       `  exit ${dumpExit}`,
       "fi",
-      `if [ "$1" = "plugin" ]; then exit ${addExit}; fi`,
+      'if [ "$1" = "plugin" ]; then',
+      addSleep,
+      `  exit ${addExit}`,
+      "fi",
       "exit 0",
     ].join("\n") + "\n",
   );
@@ -113,6 +128,19 @@ function withPath(pathEntry: string, fn: () => void): void {
     fn();
   } finally {
     process.env.PATH = prev;
+  }
+}
+
+/** Run fn with an env var set (snapshot/restore). */
+function withEnv(key: string, value: string | undefined, fn: () => void): void {
+  const prev = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
   }
 }
 
@@ -170,6 +198,49 @@ const DUMP_FALLBACKS_DISABLED = [
   "",
 ].join("\n");
 
+/** Fallbacks row disabled via a literal `disabled: true` line — the built-in
+ * shape observed on dsh 0.1.0-rc.6 (fresh-profile dump: the `hmr` row carries
+ * a standalone 2-space `disabled: true` under a `patched by ...` header). */
+const DUMP_FALLBACKS_DISABLED_TRUE = [
+  "# == @mstar-harness/dsh",
+  "- id: mstar",
+  "  name: '@mstar-harness/dsh'",
+  "  config: {}",
+  "# == dsh-llm-fallbacks, patched by .../cordis.patch.yml",
+  "- id: llm-fallbacks",
+  "  name: dsh-llm-fallbacks",
+  "  config: {}",
+  "  disabled: true",
+  "",
+].join("\n");
+
+/** Fallbacks row disabled inline on the `- id:` line (hypothetical dump-shape
+ * drift; the parser must still report the row as disabled, never mounted). */
+const DUMP_FALLBACKS_DISABLED_INLINE_ID = [
+  "# == @mstar-harness/dsh",
+  "- id: mstar",
+  "  name: '@mstar-harness/dsh'",
+  "  config: {}",
+  "# == dsh-llm-fallbacks, patched by .../cordis.patch.yml",
+  "- id: llm-fallbacks, disabled: true",
+  "  name: dsh-llm-fallbacks",
+  "  config: {}",
+  "",
+].join("\n");
+
+/** Fallbacks row disabled inline on the `name:` line (same drift class). */
+const DUMP_FALLBACKS_DISABLED_INLINE_NAME = [
+  "# == @mstar-harness/dsh",
+  "- id: mstar",
+  "  name: '@mstar-harness/dsh'",
+  "  config: {}",
+  "# == dsh-llm-fallbacks, patched by .../cordis.patch.yml",
+  "- id: llm-fallbacks",
+  "  name: dsh-llm-fallbacks, disabled: true",
+  "  config: {}",
+  "",
+].join("\n");
+
 /** Only the mstar row present; fallbacks uninstalled. */
 const DUMP_FALLBACKS_MISSING = [
   "# == @mstar-harness/dsh",
@@ -224,7 +295,8 @@ describe("dshAdapter.runInstallInit", () => {
       ]);
       expectNote(result!.notes, `installed: ${MSTAR_SPEC}`);
       expectNote(result!.notes, `installed: ${FALLBACKS_SPEC}`);
-      expect(result!.location).toContain(join("profiles", "web"));    } finally {
+      expect(result!.location).toContain(join("profiles", "web"));
+    } finally {
       fake.remove();
     }
   });
@@ -273,6 +345,23 @@ describe("dshAdapter.runInstallInit", () => {
       expect(argvLines(fake)).toEqual([]);
       expectNote(result!.notes, `Would run: dsh plugin --profile web add ${MSTAR_SPEC}`);
       expectNote(result!.notes, `Would run: dsh plugin --profile web add ${FALLBACKS_SPEC}`);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("dry-run + --no-fallbacks: previews a single add, zero subprocesses", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY);
+    try {
+      let result: { location: string; notes: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallInit?.("global", true, { noFallbacks: true });
+      });
+      expect(result).toBeDefined();
+      expect(argvLines(fake)).toEqual([]);
+      expectNote(result!.notes, `Would run: dsh plugin --profile web add ${MSTAR_SPEC}`);
+      expectNote(result!.notes, `skipped-by-flag: ${FALLBACKS_SPEC}`);
+      expect(result!.notes.filter((note) => note.startsWith("Would run:")).length).toBe(1);
     } finally {
       fake.remove();
     }
@@ -366,6 +455,33 @@ describe("dshAdapter.runInstallInit", () => {
       fake.remove();
     }
   });
+
+  test("stalled add (hung pnpm forward) is killed by the subprocess timeout (S-001)", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY, { addSleepSec: 30 });
+    try {
+      let error: unknown;
+      withPath(fake.binDir, () => {
+        // Shrink the conservative 300s network ceiling so the kill path is
+        // exercised fast: the fake add branch sleeps 30s, the timeout fires
+        // in 300ms, execFileSync kills the child and throws.
+        withEnv("MSTAR_DSH_SUBPROCESS_TIMEOUT_MS", "300", () => {
+          try {
+            dshAdapter.runInstallInit?.("global", false);
+          } catch (e) {
+            error = e;
+          }
+        });
+      });
+      expect(String(error)).toContain(`Failed to install ${MSTAR_SPEC}`);
+      // The timeout fired (execFileSync kills the child with SIGTERM and
+      // reports ETIMEDOUT), it did not simply exit non-zero.
+      expect(String(error)).toContain("ETIMEDOUT");
+      // The add was attempted and killed (argv recorded before the sleep).
+      expect(addLines(fake)).toEqual([`plugin --profile web add ${MSTAR_SPEC}`]);
+    } finally {
+      fake.remove();
+    }
+  });
 });
 
 describe("dshAdapter.runInstallDoctor", () => {
@@ -385,21 +501,28 @@ describe("dshAdapter.runInstallDoctor", () => {
     }
   });
 
-  test("fallbacks disabled: notes say disabled, errors carry the issue", () => {
-    const fake = makeFakeDsh(DUMP_FALLBACKS_DISABLED);
-    try {
-      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
-      withPath(fake.binDir, () => {
-        result = dshAdapter.runInstallDoctor?.("global");
-      });
-      expect(result).toBeDefined();
-      expectNote(result!.notes ?? [], `${MSTAR_SPEC}: mounted`);
-      expectNote(result!.notes ?? [], `${FALLBACKS_SPEC}: disabled`);
-      expect(result!.errors.some((line) => line.includes(`${FALLBACKS_SPEC} is disabled`))).toBe(true);
-    } finally {
-      fake.remove();
-    }
-  });
+  for (const [label, dump] of [
+    ["enabled: false standalone", DUMP_FALLBACKS_DISABLED],
+    ["disabled: true standalone", DUMP_FALLBACKS_DISABLED_TRUE],
+    ["disabled: true inline on the - id: line", DUMP_FALLBACKS_DISABLED_INLINE_ID],
+    ["disabled: true inline on the name: line", DUMP_FALLBACKS_DISABLED_INLINE_NAME],
+  ] as const) {
+    test(`fallbacks disabled (${label}): notes say disabled, errors carry the issue`, () => {
+      const fake = makeFakeDsh(dump);
+      try {
+        let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+        withPath(fake.binDir, () => {
+          result = dshAdapter.runInstallDoctor?.("global");
+        });
+        expect(result).toBeDefined();
+        expectNote(result!.notes ?? [], `${MSTAR_SPEC}: mounted`);
+        expectNote(result!.notes ?? [], `${FALLBACKS_SPEC}: disabled`);
+        expect(result!.errors.some((line) => line.includes(`${FALLBACKS_SPEC} is disabled`))).toBe(true);
+      } finally {
+        fake.remove();
+      }
+    });
+  }
 
   test("fallbacks missing: notes say uninstalled, errors carry the issue", () => {
     const fake = makeFakeDsh(DUMP_FALLBACKS_MISSING);
@@ -475,6 +598,9 @@ describe("dshAdapter.runInstallDoctor", () => {
       expect(result!.errors.some((line) => line.includes("could not parse installed plugins from dump"))).toBe(
         true,
       );
+      // Same granularity as the probe-failure test: the degradation line must
+      // keep its "cannot verify install state" tail (wording-drift guard).
+      expect(result!.errors.some((line) => line.includes("cannot verify install state"))).toBe(true);
     } finally {
       fake.remove();
     }
@@ -560,6 +686,18 @@ describe("CLI doctor --target dsh (fake dsh on PATH)", () => {
 
   test("fallbacks disabled: exit 1 and the disabled issue is printed", () => {
     const fake = makeFakeDsh(DUMP_FALLBACKS_DISABLED);
+    try {
+      const result = runCli(["doctor", "--target", "dsh"], { env: fakePathEnv(fake) });
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain(`${FALLBACKS_SPEC}: disabled`);
+      expect(result.stdout).toContain(`${FALLBACKS_SPEC} is disabled`);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("disabled: true standalone row: exit 1 and the disabled issue is printed", () => {
+    const fake = makeFakeDsh(DUMP_FALLBACKS_DISABLED_TRUE);
     try {
       const result = runCli(["doctor", "--target", "dsh"], { env: fakePathEnv(fake) });
       expect(result.exitCode).toBe(1);

--- a/packages/cli/test/dsh-adapter.test.ts
+++ b/packages/cli/test/dsh-adapter.test.ts
@@ -345,6 +345,10 @@ describe("dshAdapter.runInstallInit", () => {
       expect(argvLines(fake)).toEqual([]);
       expectNote(result!.notes, `Would run: dsh plugin --profile web add ${MSTAR_SPEC}`);
       expectNote(result!.notes, `Would run: dsh plugin --profile web add ${FALLBACKS_SPEC}`);
+      expectNote(
+        result!.notes,
+        `Alternate manual install: dsh plugin --profile web add ${MSTAR_SPEC} && dsh plugin --profile web add ${FALLBACKS_SPEC}`,
+      );
     } finally {
       fake.remove();
     }

--- a/packages/cli/test/dsh-adapter.test.ts
+++ b/packages/cli/test/dsh-adapter.test.ts
@@ -11,9 +11,20 @@
  *   - missing dsh bin: fail-loud throw carrying an install hint;
  *   - dry-run: no subprocess at all, notes preview the would-run commands;
  *   - idempotency: lines already present in the composed loader tree are
- *     skipped (`skipped-existing` notes, zero add calls).
+ *     skipped (`skipped-existing` notes, zero add calls) — including rows
+ *     that are present but disabled;
+ *   - probe degradation: a failing `--dump-config` probe or a malformed
+ *     (format-drifted) dump yields an explicit warning note while the adds
+ *     still run (pinned no-op keeps it idempotent);
+ *   - add failure: a non-zero `add` exit throws `Failed to install <spec>`.
+ * Doctor (`runInstallDoctor`): reports each plugin row's capability state
+ * with the AC-2 words `uninstalled` / `disabled` / `mounted` — issue states
+ * (uninstalled/disabled) land in `errors` (CLI exits 1), every state also
+ * gets a worded notes line (healthy runs show `mounted`), and an unusable
+ * probe degrades into an explicit error rather than a silent pass.
  * Plus end-to-end wiring through the real CLI entry (`init --target dsh` /
- * `--no-fallbacks` / missing bin) with the fake bin injected via PATH.
+ * `--no-fallbacks` / missing bin / `doctor --target dsh`) with the fake bin
+ * injected via PATH.
  */
 import { describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -64,12 +75,17 @@ interface FakeDsh {
 /** Create a fake `dsh` executable in a temp dir: records argv (space-joined)
  * to logFile, answers `--version` (exit 0), prints the `--dump-config`
  * fixture, and exits 0 for `plugin ... add ...`. The script uses shell
- * builtins only so it works under a PATH restricted to the fake dir. */
-function makeFakeDsh(dumpFixture: string): FakeDsh {
+ * builtins only so it works under a PATH restricted to the fake dir.
+ * `opts.dumpExit` / `opts.addExit` force a non-zero exit on the
+ * `--dump-config` / `plugin ... add` branches to simulate probe and add
+ * failures. */
+function makeFakeDsh(dumpFixture: string, opts: { dumpExit?: number; addExit?: number } = {}): FakeDsh {
   const binDir = mkdtempSync(join(tmpdir(), "dsh-fake-"));
   const logFile = join(binDir, "argv.log");
   const dumpFile = join(binDir, "dump.yml");
   writeFileSync(dumpFile, dumpFixture);
+  const dumpExit = opts.dumpExit ?? 0;
+  const addExit = opts.addExit ?? 0;
   const binPath = join(binDir, "dsh");
   writeFileSync(
     binPath,
@@ -79,8 +95,9 @@ function makeFakeDsh(dumpFixture: string): FakeDsh {
       'if [ "$1" = "--version" ]; then exit 0; fi',
       `if [ "$1" = "--profile" ] && [ "$3" = "--dump-config" ]; then`,
       `  while IFS= read -r line; do printf '%s\\n' "$line"; done < "${dumpFile}"`,
-      "  exit 0",
+      `  exit ${dumpExit}`,
       "fi",
+      `if [ "$1" = "plugin" ]; then exit ${addExit}; fi`,
       "exit 0",
     ].join("\n") + "\n",
   );
@@ -135,6 +152,60 @@ const DUMP_BOTH = [
   "- id: llm-fallbacks",
   "  name: dsh-llm-fallbacks",
   "  config: {}",
+  "",
+].join("\n");
+
+/** Fallbacks row present but disabled via patch — `enabled: false` is the
+ * shape observed on dsh 0.1.0-rc.6 when cordis.patch.yml disables a row. */
+const DUMP_FALLBACKS_DISABLED = [
+  "# == @mstar-harness/dsh",
+  "- id: mstar",
+  "  name: '@mstar-harness/dsh'",
+  "  config: {}",
+  "# == dsh-llm-fallbacks, patched by .../cordis.patch.yml",
+  "- id: llm-fallbacks",
+  "  name: dsh-llm-fallbacks",
+  "  config: {}",
+  "  enabled: false",
+  "",
+].join("\n");
+
+/** Only the mstar row present; fallbacks uninstalled. */
+const DUMP_FALLBACKS_MISSING = [
+  "# == @mstar-harness/dsh",
+  "- id: mstar",
+  "  name: '@mstar-harness/dsh'",
+  "  config: {}",
+  "",
+].join("\n");
+
+/** Only the fallbacks row present; mstar uninstalled. */
+const DUMP_MSTAR_MISSING = [
+  "# == dsh-llm-fallbacks",
+  "- id: llm-fallbacks",
+  "  name: dsh-llm-fallbacks",
+  "  config: {}",
+  "",
+].join("\n");
+
+/** mstar row present but disabled; fallbacks mounted. */
+const DUMP_MSTAR_DISABLED = [
+  "# == @mstar-harness/dsh",
+  "- id: mstar",
+  "  name: '@mstar-harness/dsh'",
+  "  config: {}",
+  "  enabled: false",
+  "# == dsh-llm-fallbacks",
+  "- id: llm-fallbacks",
+  "  name: dsh-llm-fallbacks",
+  "  config: {}",
+  "",
+].join("\n");
+
+/** Non-empty output with no parseable loader entries (format drift). */
+const DUMP_MALFORMED = [
+  "not a loader dump",
+  "some: other: thing",
   "",
 ].join("\n");
 
@@ -224,6 +295,204 @@ describe("dshAdapter.runInstallInit", () => {
       fake.remove();
     }
   });
+
+  test("idempotent: a present-but-disabled row still counts as installed (skipped-existing)", () => {
+    const fake = makeFakeDsh(DUMP_FALLBACKS_DISABLED);
+    try {
+      let result: { location: string; notes: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallInit?.("global", false);
+      });
+      expect(result).toBeDefined();
+      expect(addLines(fake)).toEqual([]);
+      expectNote(result!.notes, `skipped-existing: ${MSTAR_SPEC}`);
+      expectNote(result!.notes, `skipped-existing: ${FALLBACKS_SPEC}`);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("probe failure (dump non-zero exit): warning note + still adds both (M4)", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY, { dumpExit: 1 });
+    try {
+      let result: { location: string; notes: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallInit?.("global", false);
+      });
+      expect(result).toBeDefined();
+      expectNote(result!.notes, "Warning: could not probe installed plugins");
+      expect(addLines(fake)).toEqual([
+        `plugin --profile web add ${MSTAR_SPEC}`,
+        `plugin --profile web add ${FALLBACKS_SPEC}`,
+      ]);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("malformed dump (format drift): parse-degradation warning + still adds both (M3)", () => {
+    const fake = makeFakeDsh(DUMP_MALFORMED);
+    try {
+      let result: { location: string; notes: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallInit?.("global", false);
+      });
+      expect(result).toBeDefined();
+      expectNote(result!.notes, "Warning: could not parse installed plugins from dump");
+      expect(addLines(fake)).toEqual([
+        `plugin --profile web add ${MSTAR_SPEC}`,
+        `plugin --profile web add ${FALLBACKS_SPEC}`,
+      ]);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("add non-zero exit: throws Failed to install <spec> (M6)", () => {
+    const fake = makeFakeDsh(DUMP_EMPTY, { addExit: 1 });
+    try {
+      let error: unknown;
+      withPath(fake.binDir, () => {
+        try {
+          dshAdapter.runInstallInit?.("global", false);
+        } catch (e) {
+          error = e;
+        }
+      });
+      expect(String(error)).toContain(`Failed to install ${MSTAR_SPEC}`);
+      // The failing add was still attempted (argv recorded before the exit).
+      expect(addLines(fake)).toEqual([`plugin --profile web add ${MSTAR_SPEC}`]);
+    } finally {
+      fake.remove();
+    }
+  });
+});
+
+describe("dshAdapter.runInstallDoctor", () => {
+  test("both rows mounted: healthy, capability words present in notes", () => {
+    const fake = makeFakeDsh(DUMP_BOTH);
+    try {
+      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallDoctor?.("global");
+      });
+      expect(result).toBeDefined();
+      expect(result!.errors).toEqual([]);
+      expectNote(result!.notes ?? [], `${MSTAR_SPEC}: mounted`);
+      expectNote(result!.notes ?? [], `${FALLBACKS_SPEC}: mounted`);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("fallbacks disabled: notes say disabled, errors carry the issue", () => {
+    const fake = makeFakeDsh(DUMP_FALLBACKS_DISABLED);
+    try {
+      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallDoctor?.("global");
+      });
+      expect(result).toBeDefined();
+      expectNote(result!.notes ?? [], `${MSTAR_SPEC}: mounted`);
+      expectNote(result!.notes ?? [], `${FALLBACKS_SPEC}: disabled`);
+      expect(result!.errors.some((line) => line.includes(`${FALLBACKS_SPEC} is disabled`))).toBe(true);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("fallbacks missing: notes say uninstalled, errors carry the issue", () => {
+    const fake = makeFakeDsh(DUMP_FALLBACKS_MISSING);
+    try {
+      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallDoctor?.("global");
+      });
+      expect(result).toBeDefined();
+      expectNote(result!.notes ?? [], `${MSTAR_SPEC}: mounted`);
+      expectNote(result!.notes ?? [], `${FALLBACKS_SPEC}: uninstalled`);
+      expect(result!.errors.some((line) => line.includes(`${FALLBACKS_SPEC} is uninstalled`))).toBe(true);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("mstar missing: errors carry the uninstalled issue", () => {
+    const fake = makeFakeDsh(DUMP_MSTAR_MISSING);
+    try {
+      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallDoctor?.("global");
+      });
+      expect(result).toBeDefined();
+      expectNote(result!.notes ?? [], `${MSTAR_SPEC}: uninstalled`);
+      expectNote(result!.notes ?? [], `${FALLBACKS_SPEC}: mounted`);
+      expect(result!.errors.some((line) => line.includes(`${MSTAR_SPEC} is uninstalled`))).toBe(true);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("mstar disabled: errors carry the disabled issue", () => {
+    const fake = makeFakeDsh(DUMP_MSTAR_DISABLED);
+    try {
+      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallDoctor?.("global");
+      });
+      expect(result).toBeDefined();
+      expectNote(result!.notes ?? [], `${MSTAR_SPEC}: disabled`);
+      expectNote(result!.notes ?? [], `${FALLBACKS_SPEC}: mounted`);
+      expect(result!.errors.some((line) => line.includes(`${MSTAR_SPEC} is disabled`))).toBe(true);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("probe failure: explicit degradation error, not a silent pass", () => {
+    const fake = makeFakeDsh(DUMP_BOTH, { dumpExit: 1 });
+    try {
+      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallDoctor?.("global");
+      });
+      expect(result).toBeDefined();
+      expect(result!.errors.some((line) => line.includes("could not probe installed plugins"))).toBe(true);
+      expect(result!.errors.some((line) => line.includes("cannot verify install state"))).toBe(true);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("malformed dump: explicit parse-degradation error, not a silent pass", () => {
+    const fake = makeFakeDsh(DUMP_MALFORMED);
+    try {
+      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+      withPath(fake.binDir, () => {
+        result = dshAdapter.runInstallDoctor?.("global");
+      });
+      expect(result).toBeDefined();
+      expect(result!.errors.some((line) => line.includes("could not parse installed plugins from dump"))).toBe(
+        true,
+      );
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("missing dsh bin: doctor reports the fail-loud error", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "dsh-nobin-"));
+    try {
+      let result: { location: string; errors: string[]; notes?: string[] } | undefined;
+      withPath(emptyDir, () => {
+        result = dshAdapter.runInstallDoctor?.("global");
+      });
+      expect(result).toBeDefined();
+      expect(result!.errors.some((line) => line.includes("dsh CLI not found on PATH"))).toBe(true);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("CLI init --target dsh (fake dsh on PATH)", () => {
@@ -267,6 +536,49 @@ describe("CLI init --target dsh (fake dsh on PATH)", () => {
       expect(result.stderr).toContain("Setup failed: dsh CLI not found on PATH");
     } finally {
       rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("CLI doctor --target dsh (fake dsh on PATH)", () => {
+  const fakePathEnv = (fake: FakeDsh): { PATH: string } => ({
+    PATH: `${fake.binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+  });
+
+  test("both mounted: exit 0 and capability words are printed on the healthy run (AC-2)", () => {
+    const fake = makeFakeDsh(DUMP_BOTH);
+    try {
+      const result = runCli(["doctor", "--target", "dsh"], { env: fakePathEnv(fake) });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`${MSTAR_SPEC}: mounted`);
+      expect(result.stdout).toContain(`${FALLBACKS_SPEC}: mounted`);
+      expect(result.stdout).toContain("Doctor result: healthy");
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("fallbacks disabled: exit 1 and the disabled issue is printed", () => {
+    const fake = makeFakeDsh(DUMP_FALLBACKS_DISABLED);
+    try {
+      const result = runCli(["doctor", "--target", "dsh"], { env: fakePathEnv(fake) });
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain(`${FALLBACKS_SPEC}: disabled`);
+      expect(result.stdout).toContain(`${FALLBACKS_SPEC} is disabled`);
+    } finally {
+      fake.remove();
+    }
+  });
+
+  test("probe failure: exit 1 with the explicit degradation line (no silent pass)", () => {
+    const fake = makeFakeDsh(DUMP_BOTH, { dumpExit: 1 });
+    try {
+      const result = runCli(["doctor", "--target", "dsh"], { env: fakePathEnv(fake) });
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain("could not probe installed plugins");
+      expect(result.stdout).toContain("cannot verify install state");
+    } finally {
+      fake.remove();
     }
   });
 });

--- a/packages/dsh/README.i18n.yaml
+++ b/packages/dsh/README.i18n.yaml
@@ -2,5 +2,5 @@
 # Blob hashes (git hash-object) of each side as of the last confirmation that
 # both languages say the same thing (dsh i18n contract: a pair is three
 # sibling files; editing either side obligates re-confirming and re-recording).
-README.md: ebaf2a22fa9965e40e006ff311fafdc3971c6376
-README.zh.md: a520154b43d50ef20c2fcf300af74571ff1b0f85
+README.md: d942e880bbc5c8dc34940251df7666cf81345042
+README.zh.md: 7a3e913084e5d79271828b5f3f5f27e41aca85fe

--- a/packages/dsh/README.md
+++ b/packages/dsh/README.md
@@ -12,6 +12,8 @@ How a dsh app consumes the plugin — install paths, configuration, what mounts 
 
 The package ships as a workspace package (`workspaces: ["packages/*"]`) with the engine bundled into `dist/` at build time (`bun run build`; dist is gitignored). The install path is the **profile bundle**, added to the shipped `web` profile (`dsh --profile web` — the ready-made web app profile, `dsh web`), through the `dsh.bundle.patch` manifest — a patch layer mounted over the dsh-base defaults:
 
+**One-command CLI entry (recommended)** — `npx @mstar-harness/cli init --target dsh` installs the full capability in one go: it runs the two `dsh plugin --profile web add` installs below in order (the mstar bundle first, then `dsh-llm-fallbacks`), and `npx @mstar-harness/cli doctor --target dsh` reports each plugin row as `uninstalled` / `disabled` / `mounted`. It is the same two-command install, orchestrated; `--no-fallbacks` skips the second row (and with it the seeded roles — see What you get below).
+
 **(a) Registry install (published form)** — the npm package carries the built `dist/` (no build step on install):
 
 ```sh
@@ -34,6 +36,10 @@ dsh plugin --profile web add dsh-llm-fallbacks
 ```
 
 The **two-command install is the contract** — folding a `dsh-llm-fallbacks` row into this bundle's patch is explicitly rejected (roadmap §8.3 F4): the loader has no insert-if-absent semantics, so a same-`id` insert is a `duplicate loader entry id` boot failure (the whole dsh session fails to start), and a different-`id` insert mounts the plugin twice — two `apply()` runs with split fallback state (per-context state stores, double listeners, config-override lottery) for anyone who also installs the package directly. Layer order is the reconcile append order: `dsh-llm-fallbacks` lands **after `dsh-base`/`llm-retry`** (its hard ordering requirement) and after the mstar row. Single-command multi-activation is an upstream feature gap (reconcile dedup or insert-if-absent patch semantics), not actionable from this repo.
+
+**What you get with zero configuration** — with BOTH rows installed (via the CLI entry or the two commands above), the mstar plugin declares the 13 `mode: subagent` mstar role seeds (derived from the bundled `harness-agents/` mirror, `project-manager` excluded) into the fallbacks taxonomy at boot: each seeded role's persona defaults to its mirror `description` plus the mandatory role-loading guidance line, the seeded state stays revertible (the `fallbacks/revert-seed` gateway / the settings rollback button), and the runtime advisory reports missing ids and persona overrides. The seeds mechanism is B4 (delivered iter-20260816-dsh-seeds-bridges) — the installed-deployment e2e (`tests/install-e2e.spec.ts`) closes the verification loop: a real `init --target dsh` install into a temp `DSH_HOME`, booted from the installed artifacts, asserts all 13 ids present in the effective taxonomy with non-empty personas. Not included: model routing, automatch dispatch, or the dsh TUI.
+
+> **Fresh-publish age window**: pnpm's `minimumReleaseAge` gate can make a `dsh plugin add <spec>` range resolution pick an older published version (without the seeds surface) for up to ~24h after a fresh publish — re-run `npx @mstar-harness/cli init --target dsh` after the window (or pin the version) to converge on the latest surface.
 
 ### Configuration
 

--- a/packages/dsh/README.zh.md
+++ b/packages/dsh/README.zh.md
@@ -12,6 +12,8 @@ dsh 应用如何使用本插件——安装路径、配置、挂载时发生什�
 
 本包以 workspace 包形式发布（`workspaces: ["packages/*"]`），构建时把 engine 打进 `dist/`（`bun run build`；dist 已被 gitignore）。安装途径是 **profile bundle**，装进现成的 `web` profile（`dsh --profile web`——开箱即用的 web 应用 profile，即 `dsh web`），经 `dsh.bundle.patch` 清单——一个叠在 dsh-base 默认层之上的补丁层：
 
+**一条命令的 CLI 入口（推荐）**——`npx @mstar-harness/cli init --target dsh` 一次性装齐全量能力：它按序运行下面两条 `dsh plugin --profile web add` 安装（先 mstar bundle，再 `dsh-llm-fallbacks`），并可用 `npx @mstar-harness/cli doctor --target dsh` 逐行报告 `uninstalled` / `disabled` / `mounted`。它编排的仍是同一条双命令安装；`--no-fallbacks` 跳过第二行（连带跳过 seeded 角色——见下文「零配置获得什么」）。
+
 **（a）registry 安装（发布形态）**——npm 包自带构建好的 `dist/`（安装时无需构建）：
 
 ```sh
@@ -34,6 +36,10 @@ dsh plugin --profile web add dsh-llm-fallbacks
 ```
 
 **双命令安装即契约**——把 `dsh-llm-fallbacks` 行折叠进本 bundle 的补丁**明确否决**（roadmap §8.3 F4）：loader 没有 insert-if-absent 语义，因此同 `id` 插入是 `duplicate loader entry id` 启动失败（整个 dsh 会话无法启动）；异 `id` 插入则插件被挂载两次——对同时直接安装该包的人，会出现两次 `apply()` 与分裂的 fallback 状态（各自独立的 state store、双份监听器、配置覆盖抽签）。层序为 reconcile 追加序：`dsh-llm-fallbacks` 落在 **`dsh-base`/`llm-retry` 之后**（其硬性排序要求）并位于 mstar 行之后。单命令多激活是上游功能缺口（reconcile 去重或 insert-if-absent 补丁语义），本仓库无法实施。
+
+**零配置获得什么**——两条行都装上后（经 CLI 入口或上面两条命令），mstar 插件在 boot 时把 13 个 `mode: subagent` 的 mstar 角色种子（从打包的 `harness-agents/` 镜像派生，排除 `project-manager`）声明进 fallbacks taxonomy：每个 seeded 角色的 persona 默认取其镜像 `description` 外加一行强制角色加载引导；seeded 状态保持可 revert（`fallbacks/revert-seed` 网关 / settings 回滚按钮）；运行时 advisory 报告缺失 id 与 persona 覆盖。该 seeds 机制即 B4（iter-20260816-dsh-seeds-bridges 已交付）——installed-deployment e2e（`tests/install-e2e.spec.ts`）本轮把验证闭环：真实 `init --target dsh` 安装进临时 `DSH_HOME`、从安装产物 boot，断言 13 个 id 全部出现在 effective taxonomy 且 persona 非空。不含模型路由、不含 automatch 派发、不含 dsh-tui。
+
+> **fresh publish 年龄窗口提示**：pnpm 的 `minimumReleaseAge` 门禁可能让 `dsh plugin add <spec>` 的 range 解析在全新发布后约 24h 内选中旧版本（不含 seeds surface）——窗口过后重跑 `npx @mstar-harness/cli init --target dsh`（或显式 pin 版本）即可收敛到最新 surface。
 
 ### Configuration
 

--- a/packages/dsh/tests/harness.ts
+++ b/packages/dsh/tests/harness.ts
@@ -358,11 +358,11 @@ export interface BootOptions {
   pluginModule?: unknown
   /**
    * REAL `dsh-llm-fallbacks` row (plan `20260817-dsh-roles-e2e` Task 1):
-   * when set, a `dsh-llm-fallbacks` row is mounted BEFORE the mstar row
-   * with this module as its source (the real app composes the fallbacks
-   * layer before the mstar plugin row; the seeds inject child then fires
-   * at mstar apply). Absent by default — existing compositions are
-   * untouched.
+   * when set, a `dsh-llm-fallbacks` row is mounted AFTER the mstar row
+   * with this module as its source (the real profile entry-list order is
+   * mstar first, fallbacks second — the seeds inject child is armed at
+   * mstar apply and fires when the fallbacks service appears). Absent by
+   * default — existing compositions are untouched.
    */
   fallbacksModule?: unknown
   /**

--- a/packages/dsh/tests/harness.ts
+++ b/packages/dsh/tests/harness.ts
@@ -18,7 +18,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { Context, Service } from '@deepseek-ai/cordis'
+import { Context, Service, type Fiber } from '@deepseek-ai/cordis'
 import { load as parseYaml } from 'js-yaml'
 import { createScope } from '@deepseek-ai/dsh-scope'
 import { Session, SessionId } from '@deepseek-ai/dsh-session'
@@ -197,6 +197,38 @@ export class FakeSessionsRegistry extends Service {
   }
 }
 
+/**
+ * Minimal in-memory `settings` service for the REAL-fallbacks composition
+ * (plan `20260817-dsh-roles-e2e` Task 1 — installed-deployment e2e): the
+ * upstream `dsh-llm-fallbacks` plugin writes its seed registry through the
+ * `settings` service (`seedsIo.writeRoles` → `sctx.settings.update(...)`),
+ * which the real dsh app always provides (`dsh-settings-file` row). Without
+ * it the fallbacks `declareSeeds` rejects with
+ * `seedsSettingsUnavailable` and no mstar seed can land. This fake
+ * implements the ONE consumed contract — `update(namespace, data)` (+ a
+ * `get` readback for the spec) — mounted as the `@deepseek-ai/dsh-settings-fake`
+ * module row (`bootApp({ settingsService: 'fake' })`), the same
+ * structural-fake philosophy as the loader/jobs/agents/sessions fakes.
+ */
+export class FakeSettingsRegistry extends Service {
+  private readonly store = new Map<string, unknown>()
+
+  constructor(ctx: Context) {
+    super(ctx, 'settings')
+  }
+
+  /** Persist one namespace payload (the fallbacks `update` contract). */
+  update(namespace: string, data: unknown): Promise<void> {
+    this.store.set(namespace, data)
+    return Promise.resolve()
+  }
+
+  /** Read one namespace payload (spec readback). */
+  get(namespace: string): unknown {
+    return this.store.get(namespace)
+  }
+}
+
 let fakeChildSeq = 0
 
 /**
@@ -316,6 +348,34 @@ export interface BootOptions {
    * temp `root/harness` dir.
    */
   harnessDir?: string | null
+  /**
+   * Module-source override for the `@mstar-harness/dsh` row (plan
+   * `20260817-dsh-roles-e2e` Task 1 — installed-deployment e2e): the
+   * default is the src plugin (`../src/index.ts`); an installed-artifact
+   * test passes the dist namespace imported from the real install. The
+   * default behavior is unchanged when omitted.
+   */
+  pluginModule?: unknown
+  /**
+   * REAL `dsh-llm-fallbacks` row (plan `20260817-dsh-roles-e2e` Task 1):
+   * when set, a `dsh-llm-fallbacks` row is mounted BEFORE the mstar row
+   * with this module as its source (the real app composes the fallbacks
+   * layer before the mstar plugin row; the seeds inject child then fires
+   * at mstar apply). Absent by default — existing compositions are
+   * untouched.
+   */
+  fallbacksModule?: unknown
+  /**
+   * Mount the {@link FakeSettingsRegistry} as the `settings` service (the
+   * `@deepseek-ai/dsh-settings-fake` row + module map): the REAL
+   * `dsh-llm-fallbacks` plugin writes its seed registry through
+   * `sctx.settings.update` (the real dsh app always composes the
+   * `dsh-settings-file` row), so a fallbacks composition without a
+   * settings seam cannot persist seed declarations. Mounted BEFORE the
+   * fallbacks row so `writeRoles` binds at fallbacks apply. Absent by
+   * default — existing compositions are untouched.
+   */
+  settingsService?: 'fake'
 }
 
 /** A booted app: context, temp root, resolved harness dir, and disposal. */
@@ -323,6 +383,13 @@ export interface BootResult {
   ctx: Context
   root: string
   harnessDir: string
+  /**
+   * The fallbacks row fiber (plan `20260817-dsh-roles-e2e` Task 1 — set
+   * when `fallbacksModule` was mounted): the host may dispose it and
+   * re-apply the row with a settings-derived config to model the real
+   * app's config-stack re-composition (settings write → HMR re-apply).
+   */
+  fallbacksFiber?: Fiber
   /** Dispose the app fiber and remove the temp root. */
   dispose(): Promise<void>
 }
@@ -409,8 +476,21 @@ export async function bootApp(options: BootOptions = {}): Promise<BootResult> {
     // so the plugin's `registerWorkflowLedger` consumer registers (W-B2 run
     // rows + the P-c answer observation e2e).
     ...(options.sessionsService !== undefined ? [{ name: '@deepseek-ai/dsh-session-fake' }] : []),
-    // Last row: the mstar plugin (carries the boot-time Config below).
+    // The fake settings service row (only when requested — plan
+    // `20260817-dsh-roles-e2e` Task 1): mounted BEFORE the plugin layers
+    // so the real fallbacks plugin's `ctx.inject(['settings'])` child
+    // binds `writeRoles` at its own apply (the real dsh app composes the
+    // `dsh-settings-file` row before the plugin layers).
+    ...(options.settingsService !== undefined ? [{ name: '@deepseek-ai/dsh-settings-fake' }] : []),
+    // The mstar plugin row (carries the boot-time Config below).
     { name: '@mstar-harness/dsh' },
+    // The REAL fallbacks layer (only when requested — plan
+    // `20260817-dsh-roles-e2e` Task 1 installed-deployment e2e): the real
+    // dsh app's profile entry list puts `@mstar-harness/dsh` BEFORE
+    // `dsh-llm-fallbacks` (probed on dsh 0.1.0-rc.6), so the seeds inject
+    // child arms at mstar apply and fires when the fallbacks service
+    // appears — the same sequence the seeds wiring test pins.
+    ...(options.fallbacksModule !== undefined ? [{ name: 'dsh-llm-fallbacks' }] : []),
   ]
   let rows: ReadonlyArray<{ name: string; config?: Record<string, unknown> }> = inlineRows
   if (options.cordisYml !== undefined) {
@@ -449,7 +529,16 @@ export async function bootApp(options: BootOptions = {}): Promise<BootResult> {
   // Module seams, keyed by row name. The seam packages export their plugin
   // function as `default` (CJS-style); the mstar plugin is named-only.
   const modules = new Map<string, unknown>([
-    ['@mstar-harness/dsh', plugin],
+    // `pluginModule` overrides the src default with an installed-artifact
+    // module (plan `20260817-dsh-roles-e2e` Task 1).
+    ['@mstar-harness/dsh', options.pluginModule ?? plugin],
+    // The REAL fallbacks row module (plan `20260817-dsh-roles-e2e` Task 1;
+    // only mounted when the option is set, see the row list above). The
+    // seam unwrap handles the named-export plugin shape (`name`/`apply`/
+    // `provide` namespace — same path as the mstar dist).
+    ...(options.fallbacksModule !== undefined
+      ? [['dsh-llm-fallbacks', options.fallbacksModule] as const]
+      : []),
     // The `ctx.skills` registry seam — the REAL package, installed from the
     // npm registry; the host app provides it at runtime via peerDependencies.
     ['@deepseek-ai/dsh-skill', await import('@deepseek-ai/dsh-skill')],
@@ -482,19 +571,29 @@ export async function bootApp(options: BootOptions = {}): Promise<BootResult> {
     ...(options.sessionsService !== undefined
       ? [['@deepseek-ai/dsh-session-fake', { default: FakeSessionsRegistry }] as const]
       : []),
+    // The fake `settings` service (plan `20260817-dsh-roles-e2e` Task 1):
+    // a `{ default }` module so the seam unwrap resolves the class.
+    ...(options.settingsService !== undefined
+      ? [['@deepseek-ai/dsh-settings-fake', { default: FakeSettingsRegistry }] as const]
+      : []),
   ])
+  let fallbacksFiber: Fiber | undefined
   for (const row of rows) {
     const mod = modules.get(row.name)
     if (mod === undefined) throw new Error(`unexpected boot row: ${row.name}`)
     const mountable = (mod as { default?: unknown }).default ?? mod
     // `ctx.plugin` validates a plain config object against the plugin's
     // schemastery `Config` (the same validation the loader applied to rows).
-    await ctx.plugin(mountable as Parameters<Context['plugin']>[0], row.name === '@mstar-harness/dsh' && Object.keys(config).length > 0 ? config : undefined)
+    const fiber = await ctx.plugin(mountable as Parameters<Context['plugin']>[0], row.name === '@mstar-harness/dsh' && Object.keys(config).length > 0 ? config : undefined)
+    // The fallbacks row handle (plan `20260817-dsh-roles-e2e` Task 1): the
+    // e2e disposes it to model the host config-stack re-composition.
+    if (row.name === 'dsh-llm-fallbacks') fallbacksFiber = fiber
   }
   return {
     ctx,
     root,
     harnessDir,
+    fallbacksFiber,
     async dispose() {
       await ctx.fiber.dispose()
       await rm(root, { recursive: true, force: true })

--- a/packages/dsh/tests/install-doctor-e2e.spec.ts
+++ b/packages/dsh/tests/install-doctor-e2e.spec.ts
@@ -1,0 +1,333 @@
+/**
+ * Task 2 — capability three-state closure e2e (plan `20260817-dsh-roles-e2e`):
+ * the REAL CLI install/doctor loop across the three install-surface states —
+ * `uninstalled` / `disabled` / `mounted` — plus the dsh-plugin degradation
+ * semantics per cell. Reuses the Task 1 patterns: skip-guard, temp
+ * `DSH_HOME`, real CLI subprocesses, the `--no-fallbacks` install form, the
+ * `--dump-config` probe, the single-instance host copy, and
+ * installed-artifact boots.
+ *
+ * The two three-state vocabularies are deliberately NOT conflated:
+ *   - CLI doctor (install surface): uninstalled / disabled / mounted
+ *   - dsh plugin advisory (runtime): missing / seeded / overridden
+ * This spec closes the first end to end; the second is pinned by the
+ * src-level specs (fallbacks-advisory.spec.ts (f)/(f2),
+ * fallbacks-decoration.spec.ts (c)) and Task 1's installed-deployment e2e
+ * (13 mstar roles seeded — the cell-3 runtime half, cited here).
+ *
+ * Matrix:
+ *   Cell 1 (uninstalled): `init --target dsh --no-fallbacks` → doctor exit 1
+ *     `dsh-llm-fallbacks: uninstalled`; dsh side — installed artifact boots
+ *     WITHOUT the fallbacks row: fallbacksMounted false, advisory not
+ *     invoked (false, zero logs), decoration still injects the persona from
+ *     Config (degradation path does not crash).
+ *   Cell 2 (disabled): fallbacks row added, disabled via the REAL
+ *     `cordis.patch.yml` mechanism → doctor exit 1 `dsh-llm-fallbacks:
+ *     disabled`; dsh side — loader entry present (dump carries the disabled
+ *     row) but capability off: fallbacksMounted false, advisory false.
+ *   Cell 3 (mounted): patch reverted → doctor exit 0, both rows `mounted`,
+ *     healthy; runtime seeds = Task 1 e2e (13 roles, cited).
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { bootApp, fakeChild, startInfo, type BootResult, type FakeLoaderRegistry } from './harness.ts'
+import { FALLBACKS_ENTRY_NAME, fallbacksMounted } from '../src/gates/fallbacks-probe.ts'
+import { setAdvisoryLogger, runFallbacksAdvisory, type AdvisoryLogLevel } from '../src/gates/fallbacks-advisory.ts'
+import { PERSONA_SECTION_NAME } from '../src/gates/fallbacks-decoration.ts'
+import { packageRoot } from '../scripts/bundle-harness-assets.ts'
+
+/** Repo root (packages/dsh/tests → up three levels). */
+const REPO_ROOT = resolve(import.meta.dir, '../../..')
+/** The real CLI entry (plan 001 surface) run as a subprocess. */
+const CLI_ENTRY = join(REPO_ROOT, 'packages/cli/src/index.ts')
+/** The profile the dsh CLI fixes for installs (dsh adapter `web`). */
+const DSH_PROFILE = 'web'
+/** The mstar plugin spec (doctor capability words). */
+const MSTAR_SPEC = '@mstar-harness/dsh'
+/** The fallbacks plugin spec (doctor capability words). */
+const FALLBACKS_SPEC = 'dsh-llm-fallbacks'
+
+/** Skip-guard probe (Task 1 pattern): `dsh` bin on PATH + registry
+ * reachability. A missing prerequisite SKIPS with the reason printed —
+ * never a silent green; a skip is not three-state evidence. */
+const skipReason = await (async (): Promise<string | undefined> => {
+  const dshProbe = Bun.spawnSync(['dsh', '--version'], { stdout: 'pipe', stderr: 'pipe' })
+  if (dshProbe.exitCode !== 0) return 'dsh CLI not found on PATH (install @deepseek-ai/dsh first)'
+  try {
+    const response = await fetch('https://registry.npmjs.org/@mstar-harness%2Fdsh/latest', {
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!response.ok) return `npm registry probe failed (HTTP ${response.status})`
+  } catch (error) {
+    return `npm registry unreachable (${error instanceof Error ? error.message : String(error)})`
+  }
+  return undefined
+})()
+
+/** Spawn env with ambient harness env vars pinned out (CLI-test convention)
+ * and `DSH_HOME` forced to the temp profile root. */
+function dshEnv(dshHome: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key === 'MSTAR_HARNESS_DIR' || key === 'MSTAR_CONTROL_ROOT' || key === 'SDD_DIR' || key === 'MSTAR_WORKING_BRANCH') continue
+    if (value !== undefined) env[key] = value
+  }
+  env.DSH_HOME = dshHome
+  return env
+}
+
+/** Run one dsh CLI command under the temp home; returns stdout on exit 0. */
+function runDsh(dshHome: string, args: string[], timeoutMs = 120_000): string {
+  const proc = Bun.spawnSync(['dsh', ...args], {
+    env: dshEnv(dshHome),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const stdout = proc.stdout.toString()
+  if (proc.exitCode !== 0) {
+    throw new Error(`dsh ${args.join(' ')} failed (${proc.exitCode}): ${stdout}\n${proc.stderr.toString()}`)
+  }
+  return stdout
+}
+
+/** Run the REAL CLI `init --target dsh` (plan 001 surface) as a subprocess. */
+function runCliInit(dshHome: string, extraArgs: string[] = [], timeoutMs = 300_000): string {
+  const proc = Bun.spawnSync([process.execPath, 'run', CLI_ENTRY, 'init', '--target', 'dsh', ...extraArgs], {
+    cwd: join(REPO_ROOT, 'packages/cli'),
+    env: dshEnv(dshHome),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const stdout = proc.stdout.toString()
+  if (proc.exitCode !== 0) {
+    throw new Error(`mstar-harness init --target dsh failed (${proc.exitCode}): ${stdout}\n${proc.stderr.toString()}`)
+  }
+  return stdout
+}
+
+/** Run the REAL CLI `doctor --target dsh` as a subprocess; returns the exit
+ * code AND stdout (issue states exit 1 — the code is part of the evidence). */
+function runCliDoctor(dshHome: string): { exitCode: number | null; stdout: string } {
+  const proc = Bun.spawnSync([process.execPath, 'run', CLI_ENTRY, 'doctor', '--target', 'dsh'], {
+    cwd: join(REPO_ROOT, 'packages/cli'),
+    env: dshEnv(dshHome),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  return { exitCode: proc.exitCode, stdout: proc.stdout.toString() }
+}
+
+const profileDir = (dshHome: string) => join(dshHome, 'profiles', DSH_PROFILE)
+/** The installed mstar package dir under the hoisted profile node_modules. */
+const installedMstarDir = (dshHome: string) => join(profileDir(dshHome), 'node_modules/@mstar-harness/dsh')
+
+/** The seeds surface marker (Task 1 pattern): the bundled seeds wiring in
+ * `dist/index.js` + the packaged `harness-agents` mirror. The doctor itself
+ * reads only loader rows, but the dsh-side boots exercise the bundled
+ * probe/advisory/decoration gates — pin the FULL shipped surface so the
+ * boot evidence never runs against a seeds-less stale version. */
+function hasSeedsSurface(mstarPkgDir: string): boolean {
+  const distIndex = join(mstarPkgDir, 'dist/index.js')
+  if (!existsSync(distIndex) || !existsSync(join(mstarPkgDir, 'harness-agents'))) return false
+  return readFileSync(distIndex, 'utf8').includes('mstar seeds declared')
+}
+
+/** Read the `version` field of a package.json (Task 1 pattern). */
+async function readVersion(pkgJsonPath: string): Promise<string> {
+  const parsed: unknown = JSON.parse(await readFile(pkgJsonPath, 'utf8'))
+  if (typeof parsed !== 'object' || parsed === null || !('version' in parsed) || typeof parsed.version !== 'string') {
+    throw new Error(`package.json at ${pkgJsonPath} carries no string version field`)
+  }
+  return parsed.version
+}
+
+/** Single-instance host copy of the INSTALLED mstar artifact (Task 1
+ * pattern): a real-directory copy under `<repo>/node_modules/.mstar-e2e/` so
+ * the dist's bare imports walk up to the repo `node_modules` — the same
+ * physical instances the test process loaded. The cordis cross-check pins
+ * the invariant for THIS copy. Returns the copy root (parent of `dsh/`). */
+async function hostCopyInstalledMstar(dshHome: string): Promise<string> {
+  const root = join(REPO_ROOT, 'node_modules/.mstar-e2e', `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  const copy = join(root, 'dsh')
+  await mkdir(copy, { recursive: true })
+  await cp(installedMstarDir(dshHome), copy, { recursive: true })
+  const hostCordis = Bun.resolveSync('@deepseek-ai/cordis', import.meta.dir)
+  const mstarCordis = Bun.resolveSync('@deepseek-ai/cordis', join(copy, 'dist/index.js'))
+  expect(mstarCordis).toBe(hostCordis)
+  return root
+}
+
+/** One mstar-style Assignment prompt (decoration fixture pattern). */
+const ASSIGNMENT_PROMPT = [
+  '**Execute as**: fullstack-dev',
+  '**Delegation**: forbidden',
+  '**Task category**: logic',
+  '',
+  'Implement the assigned work.',
+].join('\n')
+
+/** The configured persona for `fullstack-dev` (Config source). */
+const PERSONA = 'You are a fullstack-dev executor for the Morning Star harness.'
+
+/** A DISABLED fallbacks loader entry (the real profile's loader view for a
+ * patched-out row: entry present, `disabled: true`, no service). */
+const disabledFallbacksEntry = {
+  options: { name: FALLBACKS_ENTRY_NAME, config: {} },
+  disabled: true,
+  fiber: {},
+}
+
+let booted: BootResult | undefined
+let dshHome: string | undefined
+let hostCopyRoot: string | undefined
+
+afterEach(async () => {
+  await booted?.dispose()
+  booted = undefined
+  if (dshHome !== undefined) await rm(dshHome, { recursive: true, force: true })
+  dshHome = undefined
+  if (hostCopyRoot !== undefined) await rm(hostCopyRoot, { recursive: true, force: true })
+  hostCopyRoot = undefined
+})
+
+describe.skipIf(skipReason !== undefined)('install-surface doctor three-state e2e (plan 20260817-dsh-roles-e2e Task 2)', () => {
+  test('real CLI doctor: uninstalled (--no-fallbacks) / disabled (cordis.patch.yml) / mounted + dsh-side degradation', async () => {
+    console.log('install-doctor-e2e: skip-guard probe ok (dsh bin + registry reachable)')
+
+    // --- Setup: temp DSH_HOME; CELL-1 install form: `--no-fallbacks`
+    // (the mstar row only — the fallbacks row is uninstalled). ---
+    dshHome = await mkdtemp(join(tmpdir(), 'dsh-doctor-home-'))
+    const initNoFallbacks = runCliInit(dshHome, ['--no-fallbacks'])
+    for (const line of initNoFallbacks.split('\n').filter((line) => line.trim() !== '')) console.log(`install-doctor-e2e: cli(no-fallbacks) | ${line}`)
+
+    // Version/surface pin (Task 1 deviation, reused): the dsh CLI writes the
+    // profile dependency as `^2.2.0`; pnpm's minimumReleaseAge gate can land
+    // the default add on a seeds-less version. The doctor reads loader rows
+    // only, but the dsh-side boots exercise the bundled gates — pin the
+    // repo-shipped version when the surface is missing.
+    if (!hasSeedsSurface(installedMstarDir(dshHome))) {
+      const repoVersion = await readVersion(join(packageRoot, 'package.json'))
+      console.log(`install-doctor-e2e: default add lacks the seeds surface — re-adding pinned @${repoVersion} (Task 1 deviation)`)
+      runDsh(dshHome, ['plugin', '--profile', DSH_PROFILE, 'add', `${MSTAR_SPEC}@${repoVersion}`], 300_000)
+    }
+
+    // --- CELL 1: fallbacks uninstalled ---
+    {
+      const dump = runDsh(dshHome, ['--profile', DSH_PROFILE, '--dump-config'], 30_000)
+      expect(dump).toContain(`name: '${MSTAR_SPEC}'`)
+      expect(dump).not.toContain('name: dsh-llm-fallbacks')
+      const doctor = runCliDoctor(dshHome)
+      console.log(`install-doctor-e2e: cell1(uninstalled) doctor exit ${doctor.exitCode}`)
+      for (const line of doctor.stdout.split('\n').filter((line) => line.trim() !== '')) console.log(`install-doctor-e2e: cell1 doctor | ${line}`)
+      expect(doctor.exitCode).toBe(1)
+      expect(doctor.stdout).toContain(`${MSTAR_SPEC}: mounted`)
+      expect(doctor.stdout).toContain(`${FALLBACKS_SPEC}: uninstalled`)
+      expect(doctor.stdout).toContain(`${FALLBACKS_SPEC} is uninstalled`)
+
+      // dsh side — the `--no-fallbacks` deployment boots WITHOUT the
+      // fallbacks row: fallbacksMounted false, the advisory is NOT invoked
+      // (false, zero logs), and the decoration still injects the persona
+      // from the Config source (degradation path never crashes).
+      hostCopyRoot = await hostCopyInstalledMstar(dshHome)
+      // Dynamic import exception (runtime-selected specifier): the installed
+      // dist path is only known after the REAL install — static imports
+      // cannot name it (Task 1 pattern).
+      const pluginModule = await import(pathToFileURL(join(hostCopyRoot, 'dsh/dist/index.js')).href)
+      booted = await bootApp({ pluginModule, agentsService: 'fake', rolePersonas: { 'fullstack-dev': PERSONA } })
+      const app = booted
+      expect(fallbacksMounted(app.ctx)).toBe(false)
+      const advisoryLogs: Array<[AdvisoryLogLevel, string]> = []
+      const priorAdvisory = setAdvisoryLogger((level, message) => { advisoryLogs.push([level, message]) })
+      try {
+        expect(await runFallbacksAdvisory(app.ctx, join(hostCopyRoot, 'dsh/harness-agents'))).toBe(false)
+        expect(advisoryLogs).toEqual([]) // unmounted → not invoked, no logs
+      } finally {
+        setAdvisoryLogger(priorAdvisory)
+      }
+      const { agent, scopeKey } = await fakeChild(app.ctx, ASSIGNMENT_PROMPT)
+      app.ctx.get('agents')!.register(agent)
+      expect(() => app.ctx.events.emit('subagent/start', startInfo(agent.id))).not.toThrow()
+      const assembly = await agent.ctx.systemPrompt.assemble({ scope: scopeKey })
+      expect(assembly.sections.find((s) => s.name === PERSONA_SECTION_NAME)?.text).toBe(PERSONA)
+      console.log('install-doctor-e2e: cell1 dsh-side — fallbacksMounted false, advisory false (0 logs), persona injected from Config (no crash)')
+      await app.dispose()
+      booted = undefined
+      await rm(hostCopyRoot, { recursive: true, force: true })
+      hostCopyRoot = undefined
+    }
+
+    // --- CELL 2: fallbacks installed then DISABLED via the REAL patch
+    // mechanism (cordis.patch.yml — the shape plan 001 probe-pinned). ---
+    {
+      const initFull = runCliInit(dshHome)
+      for (const line of initFull.split('\n').filter((line) => line.trim() !== '')) console.log(`install-doctor-e2e: cli(full) | ${line}`)
+      await writeFile(join(profileDir(dshHome), 'cordis.patch.yml'), `- id: llm-fallbacks\n  disabled: true\n`)
+      const dump = runDsh(dshHome, ['--profile', DSH_PROFILE, '--dump-config'], 30_000)
+      // The loader entry is PRESENT in the composed tree — disabled.
+      expect(dump).toContain('name: dsh-llm-fallbacks')
+      expect(dump).toContain('  disabled: true')
+      const doctor = runCliDoctor(dshHome)
+      console.log(`install-doctor-e2e: cell2(disabled) doctor exit ${doctor.exitCode}`)
+      for (const line of doctor.stdout.split('\n').filter((line) => line.trim() !== '')) console.log(`install-doctor-e2e: cell2 doctor | ${line}`)
+      expect(doctor.exitCode).toBe(1)
+      expect(doctor.stdout).toContain(`${MSTAR_SPEC}: mounted`)
+      expect(doctor.stdout).toContain(`${FALLBACKS_SPEC}: disabled`)
+      expect(doctor.stdout).toContain(`${FALLBACKS_SPEC} is disabled`)
+
+      // dsh side — loader entry present (the dump row above) but the
+      // capability is OFF: the probe skips the disabled entry (service
+      // absent), so fallbacksMounted is false and the advisory is not
+      // invoked. Same semantic the src probe spec pins (c)/(f2) — here
+      // against the INSTALLED artifact.
+      hostCopyRoot = await hostCopyInstalledMstar(dshHome)
+      // Dynamic import exception (runtime-selected specifier): the installed
+      // dist path is only known after the REAL install — static imports
+      // cannot name it (Task 1 pattern).
+      const pluginModule = await import(pathToFileURL(join(hostCopyRoot, 'dsh/dist/index.js')).href)
+      booted = await bootApp({ pluginModule, agentsService: 'fake', rolePersonas: { 'fullstack-dev': PERSONA } })
+      ;(booted.ctx.get('loader') as FakeLoaderRegistry).entriesList = [disabledFallbacksEntry]
+      expect(fallbacksMounted(booted.ctx)).toBe(false)
+      const advisoryLogs: Array<[AdvisoryLogLevel, string]> = []
+      const priorAdvisory = setAdvisoryLogger((level, message) => { advisoryLogs.push([level, message]) })
+      try {
+        expect(await runFallbacksAdvisory(booted.ctx, join(hostCopyRoot, 'dsh/harness-agents'))).toBe(false)
+        expect(advisoryLogs).toEqual([]) // disabled entry → not invoked, no logs
+      } finally {
+        setAdvisoryLogger(priorAdvisory)
+      }
+      console.log('install-doctor-e2e: cell2 dsh-side — loader entry present, capability off (fallbacksMounted false, advisory false)')
+      await booted.dispose()
+      booted = undefined
+      await rm(hostCopyRoot, { recursive: true, force: true })
+      hostCopyRoot = undefined
+    }
+
+    // --- CELL 3: both rows mounted (patch reverted) ---
+    {
+      await writeFile(join(profileDir(dshHome), 'cordis.patch.yml'), '[]')
+      const dump = runDsh(dshHome, ['--profile', DSH_PROFILE, '--dump-config'], 30_000)
+      expect(dump).toContain(`name: '${MSTAR_SPEC}'`)
+      expect(dump).toContain('name: dsh-llm-fallbacks')
+      const doctor = runCliDoctor(dshHome)
+      console.log(`install-doctor-e2e: cell3(mounted) doctor exit ${doctor.exitCode}`)
+      for (const line of doctor.stdout.split('\n').filter((line) => line.trim() !== '')) console.log(`install-doctor-e2e: cell3 doctor | ${line}`)
+      expect(doctor.exitCode).toBe(0)
+      expect(doctor.stdout).toContain(`${MSTAR_SPEC}: mounted`)
+      expect(doctor.stdout).toContain(`${FALLBACKS_SPEC}: mounted`)
+      expect(doctor.stdout).toContain('Doctor result: healthy')
+      // Runtime half of cell 3 (roles seeded) = Task 1 installed-deployment
+      // e2e (non-skip PASS: 13 mstar ids seeded, personas non-empty) — cited.
+      console.log('install-doctor-e2e: cell3 runtime seeded evidence = Task 1 install-e2e (13 roles seeded, cited)')
+    }
+  }, { timeout: 600_000 })
+})
+
+// The skip-guard reason (module scope): printed ALWAYS so a skipped run is
+// explicit in the output, never a silent green.
+if (skipReason !== undefined) {
+  console.log(`install-doctor-e2e: SKIPPED — ${skipReason}`)
+}

--- a/packages/dsh/tests/install-doctor-e2e.spec.ts
+++ b/packages/dsh/tests/install-doctor-e2e.spec.ts
@@ -86,6 +86,7 @@ function runDsh(dshHome: string, args: string[], timeoutMs = 120_000): string {
     env: dshEnv(dshHome),
     stdout: 'pipe',
     stderr: 'pipe',
+    timeout: timeoutMs,
   })
   const stdout = proc.stdout.toString()
   if (proc.exitCode !== 0) {
@@ -101,6 +102,7 @@ function runCliInit(dshHome: string, extraArgs: string[] = [], timeoutMs = 300_0
     env: dshEnv(dshHome),
     stdout: 'pipe',
     stderr: 'pipe',
+    timeout: timeoutMs,
   })
   const stdout = proc.stdout.toString()
   if (proc.exitCode !== 0) {
@@ -110,13 +112,16 @@ function runCliInit(dshHome: string, extraArgs: string[] = [], timeoutMs = 300_0
 }
 
 /** Run the REAL CLI `doctor --target dsh` as a subprocess; returns the exit
- * code AND stdout (issue states exit 1 — the code is part of the evidence). */
-function runCliDoctor(dshHome: string): { exitCode: number | null; stdout: string } {
+ * code AND stdout (issue states exit 1 — the code is part of the evidence).
+ * `timeoutMs` bounds the child so a hung CLI surfaces as a kill instead of
+ * relying on the outer per-test timeout alone. */
+function runCliDoctor(dshHome: string, timeoutMs = 300_000): { exitCode: number | null; stdout: string } {
   const proc = Bun.spawnSync([process.execPath, 'run', CLI_ENTRY, 'doctor', '--target', 'dsh'], {
     cwd: join(REPO_ROOT, 'packages/cli'),
     env: dshEnv(dshHome),
     stdout: 'pipe',
     stderr: 'pipe',
+    timeout: timeoutMs,
   })
   return { exitCode: proc.exitCode, stdout: proc.stdout.toString() }
 }
@@ -213,6 +218,11 @@ describe.skipIf(skipReason !== undefined)('install-surface doctor three-state e2
       const repoVersion = await readVersion(join(packageRoot, 'package.json'))
       console.log(`install-doctor-e2e: default add lacks the seeds surface — re-adding pinned @${repoVersion} (Task 1 deviation)`)
       runDsh(dshHome, ['plugin', '--profile', DSH_PROFILE, 'add', `${MSTAR_SPEC}@${repoVersion}`], 300_000)
+      // Post-pin dump probe (fix wave S-002 belt-and-suspenders): the
+      // re-add must not duplicate the mstar loader row (the --no-fallbacks
+      // shape keeps exactly one row).
+      const pinnedDump = runDsh(dshHome, ['--profile', DSH_PROFILE, '--dump-config'], 30_000)
+      expect((pinnedDump.match(/name: '@mstar-harness\/dsh'/g) ?? []).length, 'exactly one mstar loader row after pinned re-add').toBe(1)
     }
 
     // --- CELL 1: fallbacks uninstalled ---

--- a/packages/dsh/tests/install-e2e.spec.ts
+++ b/packages/dsh/tests/install-e2e.spec.ts
@@ -1,0 +1,347 @@
+/**
+ * Task 1 — installed-deployment e2e (plan `20260817-dsh-roles-e2e`): the
+ * REAL user install loop, closed end to end.
+ *
+ * Pipeline:
+ *   1. skip-guard — `dsh` bin on PATH + registry reachability. A missing
+ *      prerequisite SKIPS with the reason printed (never a silent green);
+ *      a skip is NOT AC-3 evidence.
+ *   2. Temp `DSH_HOME`; the REAL CLI (`packages/cli` `init --target dsh`)
+ *      installs both plugin rows (`@mstar-harness/dsh` + `dsh-llm-fallbacks`)
+ *      through the dsh profile surface (`dsh plugin --profile web add …`).
+ *   3. Installed-state probe: `--dump-config` rows + the installed package
+ *      layout (node-linker hoisted, `autoInstallPeers: false` — peers are
+ *      NOT materialized; the host provides the seam packages, exactly the
+ *      production topology this boot mirrors).
+ *   4. Single-instance invariant (HARD): the installed artifact's
+ *      build-external bare imports (`@deepseek-ai/cordis`,
+ *      `@deepseek-ai/dsh-skill-filesystem`, `@deepseek-ai/dsh-llm`,
+ *      `@deepseek-ai/dsh-tools`; `dsh-llm-fallbacks` imports
+ *      `@deepseek-ai/cordis` via `@deepseek-ai/dsh-settings` /
+ *      `@deepseek-ai/dsh-typert-protocol` / `@deepseek-ai/schemastery`)
+ *      MUST resolve to the test-process instances — the test process IS
+ *      the host. Mechanism: a real-directory copy of the installed
+ *      packages under `<repo>/node_modules/.mstar-e2e/<run>/` so the
+ *      bare-import walk-up reaches the repo's `node_modules` (the same
+ *      physical modules the test process loaded). Symlinks would realpath
+ *      back into the pnpm store (a SECOND cordis instance); `Bun.plugin`
+ *      onResolve is build-time only (probed 2026-08-17) — the copy is the
+ *      runtime-verified redirect.
+ *   5. `bootApp` composes the REAL dsh app shape in the profile entry-list
+ *      order (mstar row first, fallbacks row second — probed on dsh
+ *      0.1.0-rc.6): the seeds inject child arms at mstar apply and fires
+ *      when the fallbacks service appears. The `settings` seam (the real
+ *      app's `dsh-settings-file` row) is the structural fake — the real
+ *      fallbacks seed manager persists materialized roles through it.
+ *   6. The HOST config-stack re-composition is modeled (the real app's
+ *      HMR/typert path): the fallbacks effective readback reads the row
+ *      config captured at apply time, so after the seed write the host
+ *      re-applies the row with the settings-derived config; one
+ *      `subagent/start` decision point then re-runs the advisory's
+ *      merge-preserve re-declare and the effective taxonomy converges.
+ *   7. Seeds convergence is awaited (the existing decision-point /
+ *      advisory waitFor pattern, polled on the effective readback).
+ *   8. Assertions derive the expected id set from the INSTALLED artifact's
+ *      `harness-agents` mirror via `subagentRoleIds()` — never a hardcoded
+ *      list — and pin the plan's 13-role closure claim as a lower bound.
+ *
+ * AC-3 evidence: a NON-skip PASS of this spec (recorded in the SDD
+ * report); CI does not run dsh (`ci.yml` link-farm gate).
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { cp, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { bootApp, startInfo, type BootResult, type FakeSettingsRegistry } from './harness.ts'
+import { fallbacksService } from '../src/gates/fallbacks-probe.ts'
+import { subagentRoleIds } from '../src/gates/agent-personas.ts'
+import { packageRoot } from '../scripts/bundle-harness-assets.ts'
+
+/** Repo root (packages/dsh/tests → up three levels). */
+const REPO_ROOT = resolve(import.meta.dir, '../../..')
+/** The real CLI entry (plan 001 surface) run as a subprocess. */
+const CLI_ENTRY = join(REPO_ROOT, 'packages/cli/src/index.ts')
+/** The repo's own build mirror (synced by bundle-assets; gitignored). */
+const LOCAL_MIRROR = join(packageRoot, 'harness-agents')
+/** The profile the dsh CLI fixes for installs (dsh adapter `web`). */
+const DSH_PROFILE = 'web'
+/** Skip-guard probe: `dsh` bin on PATH + npm registry reachability (the
+ * `dsh plugin add` flow forwards to pnpm over the network). Module scope —
+ * the describe is skipped when either fails, with the reason printed. */
+const skipReason = await (async (): Promise<string | undefined> => {
+  const dshProbe = Bun.spawnSync(['dsh', '--version'], { stdout: 'pipe', stderr: 'pipe' })
+  if (dshProbe.exitCode !== 0) return 'dsh CLI not found on PATH (install @deepseek-ai/dsh first)'
+  try {
+    const response = await fetch('https://registry.npmjs.org/@mstar-harness%2Fdsh/latest', {
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!response.ok) return `npm registry probe failed (HTTP ${response.status})`
+  } catch (error) {
+    return `npm registry unreachable (${error instanceof Error ? error.message : String(error)})`
+  }
+  return undefined
+})()
+
+/** Spawn env with ambient harness vars pinned out (CLI-test convention)
+ * and `DSH_HOME` forced to the temp profile root. */
+function dshEnv(dshHome: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key === 'MSTAR_HARNESS_DIR' || key === 'MSTAR_CONTROL_ROOT' || key === 'SDD_DIR' || key === 'MSTAR_WORKING_BRANCH') continue
+    if (value !== undefined) env[key] = value
+  }
+  env.DSH_HOME = dshHome
+  return env
+}
+
+/** Run one dsh CLI command under the temp home; returns stdout on exit 0. */
+function runDsh(dshHome: string, args: string[], timeoutMs = 120_000): string {
+  const proc = Bun.spawnSync(['dsh', ...args], {
+    env: dshEnv(dshHome),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const stdout = proc.stdout.toString()
+  if (proc.exitCode !== 0) {
+    throw new Error(`dsh ${args.join(' ')} failed (${proc.exitCode}): ${stdout}\n${proc.stderr.toString()}`)
+  }
+  return stdout
+}
+
+/** Run the REAL CLI `init --target dsh` (plan 001 surface) as a subprocess. */
+function runCliInit(dshHome: string, timeoutMs = 300_000): string {
+  const proc = Bun.spawnSync([process.execPath, 'run', CLI_ENTRY, 'init', '--target', 'dsh'], {
+    cwd: join(REPO_ROOT, 'packages/cli'),
+    env: dshEnv(dshHome),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const stdout = proc.stdout.toString()
+  if (proc.exitCode !== 0) {
+    throw new Error(`mstar-harness init --target dsh failed (${proc.exitCode}): ${stdout}\n${proc.stderr.toString()}`)
+  }
+  return stdout
+}
+
+const profileDir = (dshHome: string) => join(dshHome, 'profiles', DSH_PROFILE)
+/** The installed package dirs under the hoisted profile node_modules. */
+const installedMstarDir = (dshHome: string) => join(profileDir(dshHome), 'node_modules/@mstar-harness/dsh')
+const installedFallbacksDir = (dshHome: string) => join(profileDir(dshHome), 'node_modules/dsh-llm-fallbacks')
+
+/** The seeds surface the B4 mechanism ships: the bundled seeds wiring in
+ * `dist/index.js` (the gates compile INTO the single-file bundle; the
+ * per-file `dist/gates/*.d.ts` stubs carry no runtime code) + the packaged
+ * `harness-agents` mirror. The string marker survives the bundle build. */
+function hasSeedsSurface(mstarPkgDir: string): boolean {
+  const distIndex = join(mstarPkgDir, 'dist/index.js')
+  if (!existsSync(distIndex) || !existsSync(join(mstarPkgDir, 'harness-agents'))) return false
+  return readFileSync(distIndex, 'utf8').includes('mstar seeds declared')
+}
+
+/** Read the `version` field of a package.json (package manifests are
+ * outside-controlled data — narrow the parsed shape before access). */
+async function readVersion(pkgJsonPath: string): Promise<string> {
+  const parsed: unknown = JSON.parse(await readFile(pkgJsonPath, 'utf8'))
+  if (typeof parsed !== 'object' || parsed === null || !('version' in parsed) || typeof parsed.version !== 'string') {
+    throw new Error(`package.json at ${pkgJsonPath} carries no string version field`)
+  }
+  return parsed.version
+}
+
+/** Poll until `predicate` — the seeds/decision-point waitFor pattern. */
+async function waitFor(label: string, predicate: () => boolean, timeoutMs = 20_000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error(`waitFor[${label}] timed out`)
+    const { promise, resolve } = Promise.withResolvers<void>()
+    setTimeout(resolve, 25)
+    await promise
+  }
+}
+
+/** The `roles.list` the fallbacks seed manager persisted through the
+ * settings seam (the `fallbacks` namespace), narrowed from the seam store.
+ * `undefined` until the first seed declaration lands. */
+function settingsRolesList(): unknown[] | undefined {
+  return settingsRolesPayload()?.list
+}
+
+/** The narrowed `{ list, rules }` roles payload from the settings seam. */
+function settingsRolesPayload(): { list: unknown[]; rules: unknown[] } | undefined {
+  const settings = booted?.ctx.get('settings') as FakeSettingsRegistry | undefined
+  if (settings === undefined) return undefined
+  const raw = settings.get('fallbacks')
+  if (typeof raw !== 'object' || raw === null || !('roles' in raw)) return undefined
+  const roles = raw.roles
+  if (typeof roles !== 'object' || roles === null || !('list' in roles) || !('rules' in roles)) return undefined
+  if (!Array.isArray(roles.list) || !Array.isArray(roles.rules)) return undefined
+  return { list: roles.list, rules: roles.rules }
+}
+
+let booted: BootResult | undefined
+let dshHome: string | undefined
+let hostCopyRoot: string | undefined
+
+afterEach(async () => {
+  await booted?.dispose()
+  booted = undefined
+  if (dshHome !== undefined) await rm(dshHome, { recursive: true, force: true })
+  dshHome = undefined
+  if (hostCopyRoot !== undefined) await rm(hostCopyRoot, { recursive: true, force: true })
+  hostCopyRoot = undefined
+})
+
+describe.skipIf(skipReason !== undefined)('installed-deployment e2e (plan 20260817-dsh-roles-e2e Task 1)', () => {
+  test('CLI install → installed-artifact boot → 13 mstar roles seeded (AC-3)', async () => {
+    // 1. skip-guard reason (module scope already probed; the describe is
+    //    skipped when it failed — printing here keeps the output explicit).
+    console.log(`install-e2e: skip-guard probe ok (dsh bin + registry reachable)`)
+
+    // 2. Temp DSH_HOME + the REAL CLI install (user path closure).
+    dshHome = await mkdtemp(join(tmpdir(), 'dsh-e2e-home-'))
+    const cliOut = runCliInit(dshHome)
+    for (const line of cliOut.split('\n').filter((line) => line.trim() !== '')) console.log(`install-e2e: cli | ${line}`)
+
+    // 3. Installed-state probe: dump-config rows + layout facts.
+    const dump = runDsh(dshHome, ['--profile', DSH_PROFILE, '--dump-config'], 30_000)
+    console.log(`install-e2e: dump-config rows: ${(dump.match(/^  name:/gm) ?? []).length}`)
+    expect(dump).toContain(`name: '@mstar-harness/dsh'`)
+    expect(dump).toContain('name: dsh-llm-fallbacks')
+    // Layout probe: peers NOT materialized (profile pnpm-workspace.yaml
+    // sets autoInstallPeers: false) — the host provides the seam packages.
+    const peersDir = join(profileDir(dshHome), 'node_modules/@deepseek-ai')
+    console.log(`install-e2e: peers materialized under DSH_HOME profile: ${existsSync(peersDir)} (host provides seams)`)
+
+    // 4. Version/surface probe of the DEFAULT install. The dsh CLI pins
+    //    `^2.2.0` in the profile manifest; pnpm's minimumReleaseAge gate
+    //    excludes fresh publishes (< ~1 day) from RANGE resolution, so the
+    //    default add can land on a version without the seeds surface. When
+    //    that happens, re-add pinned to the repo's shipped version (the
+    //    explicit version bypasses the age gate — the default path
+    //    converges once the publish passes the window). Recorded as a
+    //    deviation in the SDD report; never a silent skip.
+    const installedVersion = await readVersion(join(installedMstarDir(dshHome), 'package.json'))
+    if (!hasSeedsSurface(installedMstarDir(dshHome))) {
+      const repoVersion = await readVersion(join(packageRoot, 'package.json'))
+      console.log(`install-e2e: default add installed @mstar-harness/dsh@${installedVersion} WITHOUT the seeds surface — re-adding pinned @${repoVersion} (pnpm minimumReleaseAge range-resolution gate)`)
+      runDsh(dshHome, ['plugin', '--profile', DSH_PROFILE, 'add', `@mstar-harness/dsh@${repoVersion}`], 300_000)
+      const pinned = await readVersion(join(installedMstarDir(dshHome), 'package.json'))
+      expect(pinned).toBe(repoVersion)
+      expect(hasSeedsSurface(installedMstarDir(dshHome))).toBe(true)
+      console.log(`install-e2e: pinned add installed @mstar-harness/dsh@${pinned} with the full seeds surface`)
+    } else {
+      console.log(`install-e2e: default add installed @mstar-harness/dsh@${installedVersion} WITH the seeds surface — no pin needed`)
+    }
+
+    // 5. Single-instance resolution: copy the installed packages into the
+    //    host module graph (real dirs, NOT symlinks — see header comment)
+    //    so their bare imports resolve to the test-process instances.
+    const fallbacksVersion = await readVersion(join(installedFallbacksDir(dshHome), 'package.json'))
+    hostCopyRoot = join(REPO_ROOT, 'node_modules/.mstar-e2e', `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+    const mstarCopy = join(hostCopyRoot, 'dsh')
+    const fallbacksCopy = join(hostCopyRoot, 'fallbacks')
+    await mkdir(mstarCopy, { recursive: true })
+    await mkdir(fallbacksCopy, { recursive: true })
+    await cp(installedMstarDir(dshHome), mstarCopy, { recursive: true })
+    await cp(installedFallbacksDir(dshHome), fallbacksCopy, { recursive: true })
+    // Resolution cross-check (the invariant, pinned at the module level):
+    // both dists must resolve cordis to the SAME physical file the test
+    // process uses.
+    const hostCordis = Bun.resolveSync('@deepseek-ai/cordis', import.meta.dir)
+    const mstarCordis = Bun.resolveSync('@deepseek-ai/cordis', join(mstarCopy, 'dist/index.js'))
+    const fallbacksCordis = Bun.resolveSync('@deepseek-ai/cordis', join(fallbacksCopy, 'dist/index.js'))
+    expect(mstarCordis).toBe(hostCordis)
+    expect(fallbacksCordis).toBe(hostCordis)
+    console.log(`install-e2e: cordis resolved for installed dists: ${basename(hostCordis)} (single instance — ${mstarCordis === hostCordis && fallbacksCordis === hostCordis})`)
+
+    // 6. Boot the INSTALLED artifact composition: mstar row first, then the
+    //    fallbacks row — the real profile entry-list order (probed on dsh
+    //    0.1.0-rc.6), so the seeds inject child arms at mstar apply and
+    //    fires when the fallbacks service appears. Runtime-selected module
+    //    specifiers: the installed dist paths are only known after the real
+    //    install — static imports cannot name them.
+    const pluginModule = await import(pathToFileURL(join(mstarCopy, 'dist/index.js')).href)
+    const fallbacksModule = await import(pathToFileURL(join(fallbacksCopy, 'dist/index.js')).href)
+    // The real dsh app always composes the `dsh-settings-file` row before
+    // the plugin layers — the fallbacks `declareSeeds` writes its seed
+    // registry through the `settings` service (without it, `writeRoles`
+    // throws `seedsSettingsUnavailable` and no seed can land). The test
+    // process is the host, so the settings seam is the structural fake
+    // (same philosophy as the loader/jobs/agents/sessions fakes).
+    booted = await bootApp({ pluginModule, fallbacksModule, settingsService: 'fake' })
+    // The installed plugin resolves its OWN packaged mirror (package-
+    // relative from the copied dist) — the runtime source of truth.
+    const artifactMirror = join(mstarCopy, 'harness-agents')
+    const expectedIds = subagentRoleIds(artifactMirror)
+    expect(expectedIds.length).toBeGreaterThanOrEqual(13) // plan closure claim; derived, grows with the mirror
+    console.log(`install-e2e: installed mirror yields ${expectedIds.length} subagent role ids (${expectedIds.join(', ')})`)
+    if (existsSync(LOCAL_MIRROR)) {
+      const localIds = subagentRoleIds(LOCAL_MIRROR)
+      console.log(`install-e2e: local build mirror yields ${localIds.length} ids — installed artifact taxonomy ${JSON.stringify([...expectedIds].sort()) === JSON.stringify([...localIds].sort()) ? 'matches' : `DIFFERS (local only: ${localIds.filter((id) => !expectedIds.includes(id)).join(', ')})`}`)
+    }
+
+    // 7. Durable seed write: the mstar inject child declares the mirror-
+    //    derived batch through the REAL fallbacks seed manager, which
+    //    materializes the rows and persists them via the settings seam
+    //    (the real app's `dsh-settings-file` namespace).
+    await waitFor('seeds-settings', () => {
+      const list = settingsRolesList()
+      if (list === undefined) return false
+      return expectedIds.every((id) => list.some((row) => typeof row === 'object' && row !== null && 'id' in row && row.id === id))
+    })
+    console.log('install-e2e: seed declaration persisted via the settings seam (all mstar ids)')
+
+    // 8. Host config-stack re-composition (the real dsh app's HMR/typert
+    //    config path): the fallbacks effective readback reads the row
+    //    config captured at apply time; the real host re-composes the row
+    //    from the settings store and re-applies it. Model that: dispose
+    //    the fallbacks fiber and re-apply with the settings-derived
+    //    config. The mstar inject child re-fires on the re-apply and
+    //    re-declares (idempotent).
+    const rolesPayload = settingsRolesPayload()
+    expect(rolesPayload, 'settings payload carries the materialized roles').toBeDefined()
+    await booted.fallbacksFiber!.dispose()
+    const composed: Record<string, unknown> = { ...fallbacksModule.defaultFallbacksConfig, roles: rolesPayload }
+    await booted.ctx.plugin(fallbacksModule, composed)
+    console.log('install-e2e: fallbacks row re-applied with the settings-derived config (host re-composition)')
+
+    // 9. Decision-point convergence: one `subagent/start` emit models a
+    //    real dispatch — the advisory one-shot latch (reset by the
+    //    fallbacks teardown) re-runs the merge-preserve re-declare, so the
+    //    effective taxonomy converges deterministically (the preset ↔
+    //    mstar declare race on re-apply is absorbed).
+    booted.ctx.events.emit('subagent/start', startInfo('e2e-convergence'))
+
+    // 10. Seeds convergence on the effective readback (the existing
+    //     waitFor pattern).
+    await waitFor('seeds', () => {
+      const service = fallbacksService(booted!.ctx)
+      if (service === undefined) return false
+      const rows = service.getEffectiveRoles().roles
+      return expectedIds.every((id) => rows.some((row) => row.id === id && row.seeded))
+    })
+
+    // 11. Effective-taxonomy assertions: every derived id seeded, persona
+    //     non-empty (same source as the decoration), defaults not
+    //     overridden.
+    const readback = fallbacksService(booted!.ctx)!.getEffectiveRoles()
+    const byId = new Map(readback.roles.map((row) => [row.id, row]))
+    for (const id of expectedIds) {
+      const row = byId.get(id)
+      expect(row, `effective role row for ${id}`).toBeDefined()
+      expect(row!.seeded, `seeded source for ${id}`).toBe(true)
+      expect(row!.persona?.trim(), `persona non-empty for ${id}`).not.toBe('')
+      expect(row!.seedPersona?.trim(), `seedPersona non-empty for ${id}`).not.toBe('')
+      expect(row!.personaOverridden, `default persona for ${id}`).toBe(false)
+    }
+    console.log(`install-e2e: effective roles PASS — ${expectedIds.length} mstar ids seeded with non-empty personas (total effective rows: ${readback.roles.length})`)
+  }, { timeout: 600_000 })
+})
+
+// The skip-guard reason (module scope): printed ALWAYS so a skipped run is
+// explicit in the output, never a silent green.
+if (skipReason !== undefined) {
+  console.log(`install-e2e: SKIPPED — ${skipReason}`)
+}

--- a/packages/dsh/tests/install-e2e.spec.ts
+++ b/packages/dsh/tests/install-e2e.spec.ts
@@ -102,6 +102,7 @@ function runDsh(dshHome: string, args: string[], timeoutMs = 120_000): string {
     env: dshEnv(dshHome),
     stdout: 'pipe',
     stderr: 'pipe',
+    timeout: timeoutMs,
   })
   const stdout = proc.stdout.toString()
   if (proc.exitCode !== 0) {
@@ -117,6 +118,7 @@ function runCliInit(dshHome: string, timeoutMs = 300_000): string {
     env: dshEnv(dshHome),
     stdout: 'pipe',
     stderr: 'pipe',
+    timeout: timeoutMs,
   })
   const stdout = proc.stdout.toString()
   if (proc.exitCode !== 0) {
@@ -230,6 +232,12 @@ describe.skipIf(skipReason !== undefined)('installed-deployment e2e (plan 202608
       const pinned = await readVersion(join(installedMstarDir(dshHome), 'package.json'))
       expect(pinned).toBe(repoVersion)
       expect(hasSeedsSurface(installedMstarDir(dshHome))).toBe(true)
+      // Post-pin dump probe (fix wave S-002 belt-and-suspenders): the
+      // re-add must not duplicate a loader row — exactly one mstar row
+      // and one fallbacks row, the production dump shape.
+      const pinnedDump = runDsh(dshHome, ['--profile', DSH_PROFILE, '--dump-config'], 30_000)
+      expect((pinnedDump.match(/name: '@mstar-harness\/dsh'/g) ?? []).length, 'exactly one mstar loader row after pinned re-add').toBe(1)
+      expect((pinnedDump.match(/name: dsh-llm-fallbacks/g) ?? []).length, 'exactly one fallbacks loader row after pinned re-add').toBe(1)
       console.log(`install-e2e: pinned add installed @mstar-harness/dsh@${pinned} with the full seeds surface`)
     } else {
       console.log(`install-e2e: default add installed @mstar-harness/dsh@${installedVersion} WITH the seeds surface — no pin needed`)
@@ -238,7 +246,6 @@ describe.skipIf(skipReason !== undefined)('installed-deployment e2e (plan 202608
     // 5. Single-instance resolution: copy the installed packages into the
     //    host module graph (real dirs, NOT symlinks — see header comment)
     //    so their bare imports resolve to the test-process instances.
-    const fallbacksVersion = await readVersion(join(installedFallbacksDir(dshHome), 'package.json'))
     hostCopyRoot = join(REPO_ROOT, 'node_modules/.mstar-e2e', `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
     const mstarCopy = join(hostCopyRoot, 'dsh')
     const fallbacksCopy = join(hostCopyRoot, 'fallbacks')


### PR DESCRIPTION
## Iteration `iter-20260817-dsh-cli-roles` — CLI dsh install surface + roles e2e closure

**方向（grill-me 2026-08-17 收敛）**：
1. **方向 2 — CLI 支持 dsh 插件安装 + 顺便安装 llm-fallbacks**：`npx @mstar-harness/cli init --target dsh` 编排双命令契约（`dsh plugin --profile web add @mstar-harness/dsh` + `add dsh-llm-fallbacks`；默认全量、`--no-fallbacks` 可退、幂等 skip、fail-loud）；`doctor --target dsh` 报 fallbacks capability 三态（uninstalled/disabled/mounted）。
2. **方向 3 — roles 存在性闭环验证**：B4 seeds 机制不动；installed-deployment e2e（真实 CLI 安装 → installed-artifact boot → 13 个 mstar 角色 effective seeded）非 skip PASS = AC-3 证据；capability 三态矩阵逐格真实验证；full-support 文档（dsh README 三联 + root 双语一行）。
3. **方向 1** = 方向 2+3 即 roadmap §8 安装面收口（§10.3 留下轮）。

**Plans**（2，均 SDD 串行 + QC tri N=3 + QA mandatory）：
| plan_id | 内容 | QC | QA | merge |
|---|---|---|---|---|
| 20260817-cli-dsh-install | CLI `init --target dsh` adapter + `--no-fallbacks` + 幂等 + doctor 三态 + README 双语/枚举点 + fragment | tri 3/3 + re-review 2/2 Approve | PASS | `cc67461` |
| 20260817-dsh-roles-e2e | installed-deployment e2e + capability 三态闭环 + full-support 文档 + fragment | tri 3/3 + re-review 3/3 Approve | PASS | `c8a4b89` |

**Fragments**: `.changes/unreleased/` 新增 `cli-dsh-install-target.md`（cli, root）+ `dsh-roles-e2e-closure.md`（dsh, root）——与既有 6 个合并为下一个 release（用户裁决：迭代后一起发）。

**验证摘要**（QA 实跑）：真实 dsh 0.1.0-rc.6 + temp `DSH_HOME`——双装/幂等/`--no-fallbacks`/fail-loud/dry-run 五态冒烟；doctor 三态词面；install-e2e 非 skip PASS（13 角色 seeded）；cli 254 + dsh 993 全绿；ASCII + drift-lint 绿；F4 双命令契约不变（零 patch 折叠）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change shells out to `dsh`/pnpm with timeout and YAML dump parsing, so install/doctor behavior depends on external CLI output stability; risk is mitigated by fail-loud errors, idempotent adds, and broad fake/real e2e tests rather than touching auth or production data paths.
> 
> **Overview**
> **CLI dsh install surface** — `@mstar-harness/cli` now treats **dsh** as a first-class `--target`. `init --target dsh` runs two separate `dsh plugin --profile web add` calls (`@mstar-harness/dsh`, then `dsh-llm-fallbacks`), probes the composed loader via `--dump-config` for idempotent skips, supports `--dry-run` (preview only, no probe) and dsh-only `--no-fallbacks`, and fails loudly if `dsh` is missing. `doctor --target dsh` labels each row **`uninstalled` / `disabled` / `mounted`** (parsed disable markers), prints those lines even on success, and exits **1** when any row is not mounted.
> 
> **Wiring & tests** — New `packages/cli/src/adapters/dsh.ts` is registered in the adapter map; install-mode `doctor` now surfaces adapter `notes`; `runInstallInit` accepts `InstallInitFlags`. Unit/e2e coverage uses a fake `dsh` on `PATH` plus optional real `DSH_HOME` specs.
> 
> **Docs & dsh package** — Root `README` pair, `INSTALL.md`, and `docs/cli.md` promote the one-command install and doctor verify path (dsh is no longer documented as “not a CLI target”). `packages/dsh` README triple adds CLI entry, zero-config 13-role seeds, and `minimumReleaseAge` guidance; test `harness.ts` can boot installed dist + real `dsh-llm-fallbacks` with a fake settings service for **install-e2e** and **install-doctor-e2e** closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2160d41191e643c06613731d7245ccb4b8178edf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->