### PR TITLE
feat: v3.1.0 project research corpus + dsh hot-path bounds

### DIFF
--- a/.changes/unreleased/dsh-digest-bounds.md
+++ b/.changes/unreleased/dsh-digest-bounds.md
@@ -1,0 +1,9 @@
+---
+category: Harness
+packages: dsh
+---
+
+- **Engine-status digest join caps**: the `mstar:engine-status` runtime-context digest (`engineStatusSummary` in `packages/dsh/src/gates/system-prompt.ts`) now renders at most 8 plan rows and 4 lease rows in catalog-array order, appending a final `+N more` overflow marker when the list is longer — the digest stays a bounded snapshot and truncation stays visible. At-or-under-cap output and the empty `none` / `none active` copy are unchanged; per-item `stripInterpolationHazard` screening and the compact residuals counts are untouched. The caps are module-level constants, deliberately not re-exported. The sibling `<mstar_engine_status>` pre-step catalog row (`renderEngineStatusCatalog`, `packages/dsh/src/gates/catalog.ts:288` plans join / `:300` leases join) stays uncapped by design: sharing the constants would close a `system-prompt.ts ↔ catalog.ts` import cycle, and duplicating them would fork the values — the sibling follow-up is registered on the v3.1.0 roadmap.
+
+<!-- CN -->
+- **Engine-status 摘要 join 上限**：`mstar:engine-status` 运行时上下文摘要（`packages/dsh/src/gates/system-prompt.ts` 的 `engineStatusSummary`）现按目录数组顺序最多渲染 8 条计划行与 4 条租约行，列表更长时在末尾追加 `+N more` 溢出标记——摘要保持有界快照，截断可见。等于上限时的输出与空数组的 `none` / `none active` 文案均不变；逐项 `stripInterpolationHazard` 屏蔽与紧凑的 residuals 计数保持不变。上限为模块级常量，刻意不导出。兄弟 `<mstar_engine_status>` pre-step 目录行（`renderEngineStatusCatalog`，`packages/dsh/src/gates/catalog.ts:288` 计划 join / `:300` 租约 join）按设计保持无上限：共享常量会闭合 `system-prompt.ts ↔ catalog.ts` 导入环，复制常量又会分叉取值——兄弟行后续工作已登记在 v3.1.0 roadmap 上。

--- a/.changes/unreleased/dsh-ledger-tail-read.md
+++ b/.changes/unreleased/dsh-ledger-tail-read.md
@@ -1,0 +1,9 @@
+---
+category: Harness
+packages: root, dsh
+---
+
+- **Agent-flow ledger tail read**: `readAgentFlow` now reads large ledgers (above the 64 KiB read gate) as a bounded latest-first tail — seek from EOF, align the window start to a line boundary, and double the window backward until it holds `limit` complete lines — so the catalog pays O(window) at the byte layer instead of parsing every historical line. Small ledgers keep the existing full-read path verbatim; both paths feed the same parse funnel, so tail/full parity is structural. Write path (append + 500-line truncation under the per-workflow lock) is untouched.
+
+<!-- CN -->
+- **Agent-flow 台账尾部读取**：`readAgentFlow` 现以有界的最新优先尾部方式读取大台账（超过 64 KiB 读取门限）——从 EOF 后向展开、对齐行边界，成倍回溯直至窗口含 `limit` 条完整行——目录层按字节支付 O(window)，不再解析每条历史行。小台账保留原有全量读取路径不变；两条路径共用同一解析漏斗，尾部/全量结果结构上一致。写入路径（追加 + 锁内 500 行截断）保持不变。

--- a/.changes/unreleased/project-research-corpus.md
+++ b/.changes/unreleased/project-research-corpus.md
@@ -1,0 +1,11 @@
+---
+category: Harness
+packages: root, engine
+---
+
+- **Project-scoped research corpus**: theme research (surveys, epic roadmaps, third-party notes) now lives under `{PROJECT_DIR}/<id>/references/` — named as current by `mstar-project-governance` (Scope table), `artifact-storage-paths.md` (new path-SSOT row), and `knowledge-and-designs.md` (boundary: research ≠ specs ≠ knowledge ≠ iteration guides).
+- **Engine filename listing**: `PROJECT_REFERENCES_DIR` + `listProjectReferenceFiles(projectDir)` in `packages/engine/src/project.ts` — sorted relative paths (root files + one-level subdirectory files; skips `roadmap.md` / `residuals.json` strays; missing dir → `[]`); directory metadata only, never file bodies, never a markdown schema.
+
+<!-- CN -->
+- **项目级研究语料**：主题研究（surveys、epic roadmaps、第三方 notes）现存放于 `{PROJECT_DIR}/<id>/references/` — 由 `mstar-project-governance`（Scope 表）、`artifact-storage-paths.md`（路径 SSOT 新行）与 `knowledge-and-designs.md`（边界：研究 ≠ specs ≠ knowledge ≠ 迭代 guides）命名。
+- **Engine 文件名列表**：`packages/engine/src/project.ts` 新增 `PROJECT_REFERENCES_DIR` + `listProjectReferenceFiles(projectDir)` — 返回排序相对路径（根级文件 + 一层子目录文件；跳过 `roadmap.md` / `residuals.json` 游离文件；目录缺失 → `[]`）；仅目录元数据，不读文件正文，不做 markdown schema 校验。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ If one of these checks fails, stop and report why.
 
 ## Local maintenance workspace (`.mstar/`, gitignored)
 
-The repo's harness root is **`.mstar/`** (the `mstar-plan-conventions` consumer default — same convention consumer projects use): `status.json`, `plans/`, `iterations/`, `knowledge/`, `sdd/`, `references/`, `archived/` and in-progress maint docs all live under `.mstar/`.
+The repo's harness root is **`.mstar/`** (the `mstar-plan-conventions` consumer default — same convention consumer projects use): `status.json`, `plans/`, `iterations/`, `knowledge/`, `sdd/`, `projects/`, `archived/` and in-progress maint docs all live under `.mstar/`.
 
 | Path | Purpose |
 |------|---------|

--- a/packages/dsh/src/gates/agent-flow.ts
+++ b/packages/dsh/src/gates/agent-flow.ts
@@ -94,7 +94,7 @@
  * relative path; the public exports (`recordDispatch` / `recordSettle` /
  * `readAgentFlow` + constants + types) are re-exported verbatim by the entry.
  */
-import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmdirSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
+import { appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, renameSync, rmdirSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { type Context } from '@deepseek-ai/cordis'
 import { assignmentHeaderRegion, parseAssignmentFields } from '@mstar-harness/engine'
@@ -133,6 +133,17 @@ export const AGENT_FLOW_DEFAULT_LIMIT = 50
  * small-file append path free of a full read per dispatch).
  */
 export const AGENT_FLOW_SIZE_GATE_BYTES = 64 * 1024
+/**
+ * The READ-path byte gate (plan `20260820-dsh-ledger-tail-read`): ledgers at
+ * or below this size take the existing full-read path verbatim; larger files
+ * are read as a bounded latest-first TAIL so the catalog pays O(window) at
+ * the byte layer instead of parsing every historical line. Private by design
+ * (plan: "no new exports; public surface stays `readAgentFlow` + the
+ * existing constants") — tests never depend on its exact value. This is the
+ * read-side sibling of the write-side `AGENT_FLOW_SIZE_GATE_BYTES` (same
+ * 64 KiB magnitude, different purpose: bounded tail vs truncation gate).
+ */
+const AGENT_FLOW_TAIL_READ_THRESHOLD_BYTES = 64 * 1024
 /**
  * WORKFLOW field length caps (qc2 W-3 fix-wave) — ONE constant family at
  * the ledger boundary, enforced on BOTH the consumer (workflow-ledger
@@ -1257,6 +1268,65 @@ function summaryOf(events: readonly AgentFlowEvent[]): AgentFlowSummaryRow[] {
 }
 
 /**
+ * Acquire the ledger's decoded content for the parse funnel (plan
+ * `20260820-dsh-ledger-tail-read`): files at or below
+ * `AGENT_FLOW_TAIL_READ_THRESHOLD_BYTES` take the existing full read
+ * verbatim; LARGER files are read as a bounded latest-first TAIL — seek
+ * from EOF, align the window start to a line boundary, and double the
+ * window backward until it holds at least `n` complete lines or reaches
+ * BOF. Both paths yield a decoded `content` string consumed by the SINGLE
+ * parse funnel in `readAgentFlow` — there is no second parse loop, so
+ * tail/full parity is structural (a trailing partial line is handled by
+ * that shared funnel exactly as today: malformed → skipped).
+ *
+ * May throw (stat / open / read errors, EISDIR) — `readAgentFlow` catches
+ * and maps to `null`, preserving today's degrade contract (every tail-path
+ * fs failure degrades exactly like the old `readFileSync` throw).
+ * @param file - the ledger file path (already known to exist).
+ * @param n - the requested window bound: the tail window must hold at least
+ *   this many complete lines before it stops doubling (default 50).
+ */
+function ledgerContent(file: string, n: number): string {
+  const size = statSync(file).size
+  if (size <= AGENT_FLOW_TAIL_READ_THRESHOLD_BYTES) {
+    return readFileSync(file, 'utf8')
+  }
+  // Tail read: read the last `threshold` bytes, align to a line boundary
+  // (the leading segment may be a partial line — drop through the first
+  // newline when the window starts above BOF), and double the window
+  // backward until it holds `n` complete lines or reaches BOF. The window
+  // end is ALWAYS EOF, so the last segment matches the full read exactly.
+  let windowBytes = AGENT_FLOW_TAIL_READ_THRESHOLD_BYTES
+  const fd = openSync(file, 'r')
+  try {
+    for (;;) {
+      const start = Math.max(0, size - windowBytes)
+      const buffer = Buffer.alloc(size - start)
+      let read = 0
+      while (read < buffer.length) {
+        const got = readSync(fd, buffer, read, buffer.length - read, start + read)
+        if (got === 0) break // EOF — the file shrank mid-read (concurrent truncate)
+        read += got
+      }
+      let content = buffer.toString('utf8')
+      if (start > 0) {
+        // Align the window start to a line boundary: drop the leading
+        // partial line (the window start may cut a line in half — the
+        // leading segment is not a complete line).
+        const firstNewline = content.indexOf('\n')
+        content = firstNewline >= 0 ? content.slice(firstNewline + 1) : ''
+      }
+      // Number of complete (newline-terminated) lines in the aligned window.
+      const completeLines = content.split('\n').length - 1
+      if (start === 0 || completeLines >= n) return content
+      windowBytes *= 2
+    }
+  } finally {
+    closeSync(fd)
+  }
+}
+
+/**
  * Read the agent-flow ledger as the catalog view (spec §2.1.3 — fix-wave
  * qc1 F-001 / qc2 F-6): the latest events first (bounded by `limit`) plus
  * the role × outcome summary over the SAME window (so `by role` counts sum
@@ -1271,6 +1341,14 @@ function summaryOf(events: readonly AgentFlowEvent[]): AgentFlowSummaryRow[] {
  * <id>`), never the harness root — the dir parameter IS the workflow dir
  * (the catalog passes `join(harnessDir, selection.dir)`; the writer appends
  * there via `resolveAgentFlowWriteDir`).
+ *
+ * Large-file reads (plan `20260820-dsh-ledger-tail-read`): ledgers above
+ * `AGENT_FLOW_TAIL_READ_THRESHOLD_BYTES` are read as a bounded latest-first
+ * tail — seek from EOF, aligned to a line boundary, doubling backward until
+ * the window holds `limit` complete lines — so the catalog pays O(window) at
+ * the byte layer instead of parsing every historical line. Both paths feed
+ * the SAME parse funnel below (`ledgerContent` yields a `content` string),
+ * so tail/full parity is structural.
  * @param workflowDir - the workflow dir whose `agent-flow.jsonl` is read.
  * @param limit - explicit window bound: `undefined` → `AGENT_FLOW_DEFAULT_LIMIT`;
  * otherwise `Math.max(0, Math.floor(limit))` — `0` requests the EMPTY window.
@@ -1281,11 +1359,15 @@ export function readAgentFlow(workflowDir: string, limit?: number): AgentFlowVie
     // Missing ledger = no records yet — the empty view, never a degrade.
     return { events: [], summary: [] }
   }
+  // Explicit limit semantics (qc2 F-6): undefined → default; otherwise a
+  // non-negative floor — `0` → the empty window. Computed BEFORE the read so
+  // the tail path knows how many complete lines the window must hold.
+  const n = limit === undefined ? AGENT_FLOW_DEFAULT_LIMIT : Math.max(0, Math.floor(limit))
   let content: string
   try {
-    content = readFileSync(file, 'utf8')
+    content = ledgerContent(file, n)
   } catch {
-    return null // unreadable (EACCES / io error) — advisory degrade only
+    return null // unreadable (EACCES / io error / EISDIR) — advisory degrade only
   }
   const events: AgentFlowEvent[] = []
   for (const line of content.split(/\r?\n/)) {
@@ -1298,9 +1380,6 @@ export function readAgentFlow(workflowDir: string, limit?: number): AgentFlowVie
       continue // malformed line — skip, never crash the catalog
     }
   }
-  // Explicit limit semantics (qc2 F-6): undefined → default; otherwise a
-  // non-negative floor — `0` → the empty window.
-  const n = limit === undefined ? AGENT_FLOW_DEFAULT_LIMIT : Math.max(0, Math.floor(limit))
   const latestFirst = events.reverse().slice(0, n)
   return {
     events: latestFirst.map(eventView),

--- a/packages/dsh/src/gates/system-prompt.ts
+++ b/packages/dsh/src/gates/system-prompt.ts
@@ -314,18 +314,59 @@ function engineStatusProvider(ctx: Context, resolver: HarnessResolver, bootHarne
 }
 
 /**
+ * Cap on plan rows joined into the `mstar:engine-status` digest (plan
+ * `20260820-dsh-digest-bounds` Task 1). Module-level and intentionally NOT
+ * re-exported — `catalog.ts` must not import it (a reverse import would
+ * close a `system-prompt.ts ↔ catalog.ts` cycle); `renderEngineStatusCatalog`
+ * stays uncapped (sibling surface, documented in the fragment).
+ */
+const DIGEST_PLAN_CAP = 8
+
+/**
+ * Cap on lease rows joined into the `mstar:engine-status` digest (plan
+ * `20260820-dsh-digest-bounds` Task 1). Same module-local scope and
+ * non-export rule as {@link DIGEST_PLAN_CAP}.
+ */
+const DIGEST_LEASE_CAP = 4
+
+/**
+ * Join the screened projection of `items` in catalog-array order, capped at
+ * `cap`: when `items.length > cap` the FIRST `cap` items render followed by
+ * a final `+N more` overflow marker (`N = items.length - cap`) as the last
+ * join element; at or under the cap the full join renders with no marker.
+ * The `render` callback owns the per-item `stripInterpolationHazard`
+ * screening (before the join, same as the uncapped code); the marker is an
+ * engine-derived literal and stays unscreened. Callers guard the empty case
+ * (`length === 0` → `none` / `none active`) — this helper is never reached
+ * for empty arrays.
+ */
+function joinCapped<T>(items: readonly T[], cap: number, separator: string, render: (item: T) => string): string {
+  const visible = items.slice(0, cap).map(render)
+  if (items.length > cap) visible.push(`+${items.length - cap} more`)
+  return visible.join(separator)
+}
+
+/**
  * The bounded machine summary: watermark + iteration gate + one compact
  * state line (+ the compass direction one-liner when present). Deliberately
  * EXCLUDES the full status.json surface — residual finding detail,
  * agent-flow events, knowledge digest and branch/policy anchors stay out.
+ *
+ * The plan/lease joins are capped (plan `20260820-dsh-digest-bounds` Task
+ * 1): at most {@link DIGEST_PLAN_CAP} plan rows and {@link DIGEST_LEASE_CAP}
+ * lease rows render, in catalog-array order, with a final `+N more` overflow
+ * marker when the array is longer — the digest stays a bounded snapshot and
+ * overflow stays visible. At-or-under-cap arrays render exactly as before
+ * (no marker); empty arrays keep the `none` / `none active` copy (the
+ * caller's `length === 0` branch — the capped join is never reached).
  *
  * STRICT-interpolation safety (plan QC fix wave W-1): every operator-
  * controlled value (harness dir, plan ids, plan statuses, iteration id,
  * lease planId/holder, direction prose) is screened through
  * `stripInterpolationHazard` before embedding — a hostile `{{…}}` in any of
  * them can never throw the renderer. Engine-derived literals (version,
- * enforcement word, violation codes, transition, severities) are constants,
- * not operator text, and stay unscreened.
+ * enforcement word, violation codes, transition, severities, the `+N more`
+ * overflow marker) are constants, not operator text, and stay unscreened.
  */
 function engineStatusSummary(source: MstarEngineStatusSource): string {
   const lines = [
@@ -339,9 +380,9 @@ function engineStatusSummary(source: MstarEngineStatusSource): string {
   }
   const state = source.state
   if (state !== null) {
-    const plans = state.plans.length === 0 ? 'none' : state.plans.map((p) => `${stripInterpolationHazard(p.id)}(${stripInterpolationHazard(p.status)})`).join(' ')
+    const plans = state.plans.length === 0 ? 'none' : joinCapped(state.plans, DIGEST_PLAN_CAP, ' ', (p) => `${stripInterpolationHazard(p.id)}(${stripInterpolationHazard(p.status)})`)
     const residuals = state.residuals.length === 0 ? 'none' : state.residuals.map((r) => `${r.severity} ${r.count}`).join(', ')
-    const leases = state.leases.length === 0 ? 'none active' : state.leases.map((l) => `${stripInterpolationHazard(l.planId)} → ${stripInterpolationHazard(l.holder)}`).join('; ')
+    const leases = state.leases.length === 0 ? 'none active' : joinCapped(state.leases, DIGEST_LEASE_CAP, '; ', (l) => `${stripInterpolationHazard(l.planId)} → ${stripInterpolationHazard(l.holder)}`)
     lines.push(`plans: ${plans} | residuals: ${residuals} | leases: ${leases}`)
     if (state.direction !== null) lines.push(`direction: ${stripInterpolationHazard(state.direction)}`)
   }

--- a/packages/dsh/tests/agent-flow.spec.ts
+++ b/packages/dsh/tests/agent-flow.spec.ts
@@ -141,6 +141,31 @@ const settleLine = (overrides: Record<string, unknown> = {}): string => JSON.str
   ...overrides,
 })
 
+/**
+ * A v1 dispatch line padded to ~2 KiB via an ignored display field — the
+ * LARGE-ledger fixture line (plan `20260820-dsh-ledger-tail-read`): 200 of
+ * these ≈ 400 KiB, deterministically above the 64 KiB read byte gate, and
+ * each line is large enough that the FIRST 64 KiB tail window holds fewer
+ * than `AGENT_FLOW_DEFAULT_LIMIT` complete lines — forcing the tail window
+ * to double backward (the growth step is exercised too). The `pad` field is
+ * ignored by the parse funnel (structural narrowing), so a padded line
+ * carries the SAME logical event as its unpadded sibling.
+ */
+const paddedDispatchLine = (ts: number): string =>
+  JSON.stringify({
+    v: 1,
+    ts,
+    kind: 'dispatch',
+    agent: 'a1',
+    role: 'fullstack-dev',
+    planId: '20260810-x',
+    taskId: 'T2',
+    taskCategory: 'logic',
+    verdict: 'ok',
+    hard: false,
+    pad: 'x'.repeat(2048),
+  })
+
 /* ---------------------------------- helpers ---------------------------------- */
 
 /** One pending subagent tool call in the registry pipeline shape. */
@@ -532,6 +557,89 @@ describe('agent-flow ledger — recordDispatch / readAgentFlow', () => {
       expect(view!.events.map((e) => e.kind)).toEqual(['settle', 'dispatch'])
       // The root ledger is never written.
       expect(existsSync(join(harnessDir, AGENT_FLOW_FILE))).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('agent-flow tail read — bounded latest-first window (plan `20260820-dsh-ledger-tail-read`)', () => {
+  it('P2-AC-1: a large padded ledger (200 × ~2 KiB lines) reads its latest 50 events latest-first via the bounded tail', async () => {
+    const { root, workflowDir } = await tempHarness('dsh-agentflow-tail-large-')
+    try {
+      const file = join(workflowDir, AGENT_FLOW_FILE)
+      const lines: string[] = []
+      for (let i = 0; i < 200; i += 1) lines.push(paddedDispatchLine(1_700_000_000_000 + i))
+      await writeFile(file, lines.join('\n') + '\n')
+      // Fixture regime: ~2 KiB/line × 200 ≈ 400 KiB — deterministically above
+      // the 64 KiB read gate (the test never depends on the gate's exact value).
+      expect(statSync(file).size).toBeGreaterThan(256 * 1024)
+
+      const view = readAgentFlow(workflowDir, 50)
+      expect(view).not.toBeNull()
+      // Latest 50 events, latest-first (the newest line is the first event).
+      expect(view!.events).toHaveLength(50)
+      expect(view!.events[0]!.ts).toBe(1_700_000_000_199)
+      expect(view!.events[49]!.ts).toBe(1_700_000_000_150)
+      for (let i = 1; i < view!.events.length; i += 1) {
+        expect(view!.events[i]!.ts).toBeLessThanOrEqual(view!.events[i - 1]!.ts)
+      }
+      // The summary covers the SAME 50-event window (role × verdict counts).
+      expect(view!.summary).toEqual([{ role: 'fullstack-dev', outcome: 'ok', count: 50 }])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('P2-AC-3 parity: the padded-large tail window equals the unpadded-small full window (same logical events)', async () => {
+    const { root, workflowDir } = await tempHarness('dsh-agentflow-tail-parity-large-')
+    try {
+      const file = join(workflowDir, AGENT_FLOW_FILE)
+      const padded: string[] = []
+      for (let i = 0; i < 200; i += 1) padded.push(paddedDispatchLine(1_700_000_000_000 + i))
+      await writeFile(file, padded.join('\n') + '\n')
+      const largeView = readAgentFlow(workflowDir, 50)
+      expect(largeView).not.toBeNull()
+      expect(statSync(file).size).toBeGreaterThan(256 * 1024)
+
+      const { root: rootSmall, workflowDir: workflowDirSmall } = await tempHarness('dsh-agentflow-tail-parity-small-')
+      try {
+        const fileSmall = join(workflowDirSmall, AGENT_FLOW_FILE)
+        const small: string[] = []
+        for (let i = 0; i < 200; i += 1) small.push(dispatchLine({ ts: 1_700_000_000_000 + i }))
+        await writeFile(fileSmall, small.join('\n') + '\n')
+        const smallView = readAgentFlow(workflowDirSmall, 50)
+        expect(smallView).not.toBeNull()
+        // Fixture regime: ~160 B/line × 200 ≈ 32 KiB — below the 64 KiB gate.
+        expect(statSync(fileSmall).size).toBeLessThan(64 * 1024)
+
+        // The two read paths yield the SAME latest-first window + summary
+        // (single parse funnel — parity is structural).
+        expect(largeView!.events).toEqual(smallView!.events)
+        expect(largeView!.summary).toEqual(smallView!.summary)
+      } finally {
+        await rm(rootSmall, { recursive: true, force: true })
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('P2-AC-2: an incomplete trailing line on the large path does not throw — the partial line is skipped at the newline boundary', async () => {
+    const { root, workflowDir } = await tempHarness('dsh-agentflow-tail-trunc-')
+    try {
+      const file = join(workflowDir, AGENT_FLOW_FILE)
+      const lines: string[] = []
+      for (let i = 0; i < 200; i += 1) lines.push(paddedDispatchLine(1_700_000_000_000 + i))
+      // Append a TORN final line: a valid JSON prefix cut off mid-write, with
+      // NO trailing newline — the tail window ends at EOF on the partial line.
+      await writeFile(file, lines.join('\n') + '\n' + '{"v":1,"ts":1700000000200,"kind":"dis')
+      const view = readAgentFlow(workflowDir)
+      expect(view).not.toBeNull()
+      // No throw: the incomplete line is skipped (malformed → funnel skip);
+      // the latest COMPLETE events still come back latest-first.
+      expect(view!.events).toHaveLength(50)
+      expect(view!.events[0]!.ts).toBe(1_700_000_000_199)
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/packages/dsh/tests/system-prompt.spec.ts
+++ b/packages/dsh/tests/system-prompt.spec.ts
@@ -502,3 +502,54 @@ describe('stripInterpolationHazard (STRICT {{variable}} screening — plan QC fi
     for (const out of outputs) expect(PERSONA_INTERPOLATION_HAZARD.test(out)).toBe(false)
   })
 })
+
+describe('mstar:engine-status digest join caps (plan 20260820-dsh-digest-bounds Task 1)', () => {
+  /** A snapshot carrying `planCount` plan rows; the first `leaseCount` rows hold execution leases. */
+  function boundedSnapshot(planCount: number, leaseCount: number): string {
+    const plans = Array.from({ length: planCount }, (_, i) => ({
+      plan_id: `p-${i}`,
+      title: `Plan ${i}`,
+      status: 'InProgress',
+      ...(i < leaseCount ? { execution_lease: { holder: `holder-${i}`, claimed_at: '2026-08-19' } } : {}),
+    }))
+    return v2Snapshot('v2.2.0', { type: 'iteration', plans })
+  }
+
+  /** Boot a fresh app seeded with a snapshot of `planCount` plans / `leaseCount` leases. */
+  async function bootBounded(planCount: number, leaseCount: number) {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-system-prompt-bounds-'))
+    const harnessDir = join(root, 'harness')
+    await mkdir(harnessDir, { recursive: true })
+    await seedHarness(harnessDir, {
+      'status.json': v2Root([v2WorkflowEntry('v2.2.0', 'iteration')]),
+      'workflows/v2.2.0/snapshot.json': boundedSnapshot(planCount, leaseCount),
+    })
+    return bootApp({ root })
+  }
+
+  it('(caps-1) 20 plans + 10 leases render the first 8/4 in catalog order with `+N more` markers, never all 20 plan ids', async () => {
+    const app = booted = await bootBounded(20, 10)
+    const text = (await app.ctx.systemPrompt.assemble()).contexts.find((c) => c.name === ENGINE_STATUS_CONTEXT_NAME)!.text
+    // First 8 plan ids space-joined + the final `+12 more` marker; first 4
+    // leases `; `-joined + the final `+6 more` marker (residuals stay `none`).
+    expect(text).toContain('plans: p-0(InProgress) p-1(InProgress) p-2(InProgress) p-3(InProgress) p-4(InProgress) p-5(InProgress) p-6(InProgress) p-7(InProgress) +12 more | residuals: none | leases: p-0 → holder-0; p-1 → holder-1; p-2 → holder-2; p-3 → holder-3; +6 more')
+    // The 9th plan id and the last plan id never reach the digest.
+    expect(text).not.toContain('p-8(InProgress)')
+    expect(text).not.toContain('p-19(')
+    // The 5th lease holder never reaches the digest.
+    expect(text).not.toContain('holder-4')
+  })
+
+  it('(caps-2) at-cap length (8 plans + 4 leases) renders the full join with NO overflow marker', async () => {
+    const app = booted = await bootBounded(8, 4)
+    const text = (await app.ctx.systemPrompt.assemble()).contexts.find((c) => c.name === ENGINE_STATUS_CONTEXT_NAME)!.text
+    expect(text).toContain('plans: p-0(InProgress) p-1(InProgress) p-2(InProgress) p-3(InProgress) p-4(InProgress) p-5(InProgress) p-6(InProgress) p-7(InProgress) | residuals: none | leases: p-0 → holder-0; p-1 → holder-1; p-2 → holder-2; p-3 → holder-3')
+    expect(text).not.toContain('+0 more')
+  })
+
+  it('(caps-3) empty arrays still render the existing `none` / `none active` copy (helper never reached)', async () => {
+    const app = booted = await bootBounded(0, 0)
+    const text = (await app.ctx.systemPrompt.assemble()).contexts.find((c) => c.name === ENGINE_STATUS_CONTEXT_NAME)!.text
+    expect(text).toContain('plans: none | residuals: none | leases: none active')
+  })
+})

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -187,11 +187,13 @@ export type {
   TechDebtSummary,
 } from "./project.js";
 export {
+  PROJECT_REFERENCES_DIR,
   PROJECT_REGISTER_FILE,
   PROJECT_ROADMAP_FILE,
   ROADMAP_STATUSES,
   _DEFAULT_PROJECT,
   findingsCleanupGate,
+  listProjectReferenceFiles,
   techDebtRollup,
   validateProjectRegister,
   validateRoadmap,

--- a/packages/engine/src/project.ts
+++ b/packages/engine/src/project.ts
@@ -24,6 +24,12 @@
  *   validation delegates verbatim to `validateResidual` (status.ts), so the
  *   severity enum + lifecycle semantics are preserved at the new address.
  * - `_DEFAULT_PROJECT` fallback for project-less flows (compass ruling 2).
+ * - Theme-scoped research corpus `projects/<id>/references/` (plan
+ *   20260820-project-research-corpus Task 1; compass ruling 1): engine owns
+ *   `PROJECT_REFERENCES_DIR` + `listProjectReferenceFiles` — directory
+ *   metadata only (`readdirSync` with `withFileTypes`), never file bodies,
+ *   never a markdown schema; placement semantics are skills prose, not
+ *   engine validation.
  * - Project-register consumers (QC wave-1 W-D relocation): `findingsCleanupGate`
  *   (findings-cleanup modes; status-and-residuals.md § Findings cleanup
  *   modes) and `techDebtRollup` (the `metadata.tech_debt_summary` rollup
@@ -40,6 +46,9 @@ import { isOpenResidual, normalizeSeverity, validateResidual, type ResidualEntry
 
 /** Roadmap file name inside `projects/<id>/` (plan Task 4 — writer contract). */
 export const PROJECT_ROADMAP_FILE = "roadmap.md";
+
+/** Theme-scoped research directory name inside `projects/<id>/` (plan 20260820-project-research-corpus Task 1 — compass ruling 1). */
+export const PROJECT_REFERENCES_DIR = "references";
 
 /** Project register file name inside `projects/<id>/` (plan Task 4). */
 export const PROJECT_REGISTER_FILE = "residuals.json";
@@ -518,4 +527,45 @@ export function techDebtRollup(projectDir: string): TechDebtRollup {
   const overall = "DRIFT" as const;
 
   return { computed, stored, checks, overall };
+}
+
+/**
+ * List theme-scoped research files under `<projectDir>/references/` (plan
+ * 20260820-project-research-corpus Task 1 — compass ruling 1): top-level
+ * files plus files exactly one subdirectory deep; deeper nesting ignored;
+ * directories never listed; regular files only (`Dirent.isFile()`). Returns
+ * paths relative to the references root with `/` separators, sorted by code
+ * unit. Strays named exactly `roadmap.md` / `residuals.json` at the
+ * references **root** are excluded — project-layer filenames are never
+ * research rows. `projectDir` is the **per-project** directory (the caller
+ * resolves `join(resolveProjectDir(startDir), projectId)`; `_DEFAULT_PROJECT`
+ * is the fallback id), never the projects root. Missing or unreadable
+ * `references/` → `[]`; never throws; never opens a file body.
+ */
+export function listProjectReferenceFiles(projectDir: string): string[] {
+  const root = join(projectDir, PROJECT_REFERENCES_DIR);
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.name === PROJECT_ROADMAP_FILE || entry.name === PROJECT_REGISTER_FILE) continue;
+    if (entry.isFile()) {
+      files.push(entry.name);
+    } else if (entry.isDirectory()) {
+      let nested: Dirent[];
+      try {
+        nested = readdirSync(join(root, entry.name), { withFileTypes: true });
+      } catch {
+        continue; // unreadable subdirectory contributes nothing
+      }
+      for (const child of nested) {
+        if (child.isFile()) files.push(`${entry.name}/${child.name}`);
+      }
+    }
+  }
+  return files.sort();
 }

--- a/packages/engine/test/project.test.ts
+++ b/packages/engine/test/project.test.ts
@@ -19,15 +19,17 @@
  *   flows).
  */
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { GateResult } from "../src/core.js";
 import {
+  PROJECT_REFERENCES_DIR,
   PROJECT_REGISTER_FILE,
   PROJECT_ROADMAP_FILE,
   ROADMAP_STATUSES,
   _DEFAULT_PROJECT,
+  listProjectReferenceFiles,
   validateProjectRegister,
   validateRoadmap,
 } from "../src/project.js";
@@ -531,5 +533,66 @@ describe("project file names + _default fallback constants (plan Task 4)", () =>
 
   test("_DEFAULT_PROJECT is the project-less fallback id", () => {
     expect(_DEFAULT_PROJECT).toBe("_default");
+  });
+});
+
+describe("listProjectReferenceFiles — theme-scoped research listing (plan 20260820-project-research-corpus Task 1)", () => {
+  test("PROJECT_REFERENCES_DIR names the references subdirectory", () => {
+    expect(PROJECT_REFERENCES_DIR).toBe("references");
+  });
+
+  test("missing or non-directory references/ -> [] and never throws", () => {
+    const empty = tmpRoot("mstar-refs-empty-");
+    try {
+      expect(listProjectReferenceFiles(empty)).toEqual([]);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+    const asFile = tmpRoot("mstar-refs-file-");
+    writeFileSync(join(asFile, "references"), "not a directory");
+    try {
+      expect(listProjectReferenceFiles(asFile)).toEqual([]);
+    } finally {
+      rmSync(asFile, { recursive: true, force: true });
+    }
+  });
+
+  test("lists root files + one-level subdirectory files, sorted by code unit", () => {
+    const root = tmpRoot("mstar-refs-tree-");
+    const refs = join(root, "references");
+    mkdirSync(join(refs, "dsh-skills-survey"), { recursive: true });
+    mkdirSync(join(refs, "deep", "nested"), { recursive: true });
+    writeFileSync(join(refs, "z-last.md"), "x");
+    writeFileSync(join(refs, "a-first.md"), "x");
+    writeFileSync(join(refs, "dsh-skills-survey", "README.md"), "x");
+    writeFileSync(join(refs, "dsh-skills-survey", "inventory.md"), "x");
+    writeFileSync(join(refs, "deep", "level2.md"), "x");
+    writeFileSync(join(refs, "deep", "nested", "ignored.md"), "x"); // two levels deep — ignored
+    try {
+      expect(listProjectReferenceFiles(root)).toEqual([
+        "a-first.md",
+        "deep/level2.md",
+        "dsh-skills-survey/README.md",
+        "dsh-skills-survey/inventory.md",
+        "z-last.md",
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("skips roadmap.md / residuals.json strays at the references root, keeps same names one level deep", () => {
+    const root = tmpRoot("mstar-refs-strays-");
+    const refs = join(root, "references");
+    mkdirSync(join(refs, "notes"), { recursive: true });
+    writeFileSync(join(refs, "roadmap.md"), "x");
+    writeFileSync(join(refs, "residuals.json"), "x");
+    writeFileSync(join(refs, "survey.md"), "x");
+    writeFileSync(join(refs, "notes", "roadmap.md"), "x");
+    try {
+      expect(listProjectReferenceFiles(root)).toEqual(["notes/roadmap.md", "survey.md"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/skills/mstar-plan-artifacts/references/knowledge-and-designs.md
+++ b/skills/mstar-plan-artifacts/references/knowledge-and-designs.md
@@ -15,6 +15,7 @@
 | **`{SPECS_DIR}`**（可选） | 冻结 v1-spec、ADR、program roadmap — **跨迭代长期权威** | 产品/API 规范性最高权威；**iteration-start** 由 product/architect 主写 |
 | **`{ITERATION_DIR}`**（可选） | **`<iteration-id>/` package**（`delivery-compass.md` + `guides/`、`specs/`） | Agent handoff；迭代级草稿；close 时 compound **提升** → knowledge |
 | **`{KNOWLEDGE_DIR}`**（可选） | 实现细节 SSOT、架构细则、契约说明、跨版本 tracker — **经 `mstar-compound` 结晶** | Agent handoff；**不**在 iteration-start 由 product/architect 新增 |
+| **`{PROJECT_DIR}/<id>/references/`**（可选） | 主题化研究：surveys、epic roadmaps、第三方 notes — **与项目绑定**，非跨迭代 corpora | 项目所有者 / operator；engine 只列文件名，**无 markdown schema** |
 | **`{PLAN_DIR}/`** | 单 plan 主文件、durable gate summary、可选 `residuals/` | 计划执行与长期决策留档 |
 
 
@@ -42,6 +43,14 @@
 - **必须**维护 `**{KNOWLEDGE_DIR}/README.md**` 作为**目录索引**：至少包含表格列 **Document（链接）**、**Source Plan（`plans[].id`）**、**Description**、**Status**（如 `Active` / `Superseded by implementation (<plan-id>)` / `Archived`）。
 - 可选：目录级 `**{KNOWLEDGE_DIR}/AGENTS.md**` 承载命名、维护节奏、与 `{SPECS_DIR}` 的权威边界（Nexus 模式）；harness 宽规则仍以 `mstar-plan-conventions` 与本 reference 为准。
 - 初始化启用知识库时：创建空表头的 `README.md`，随文档递增行。
+
+## `{PROJECT_DIR}/<id>/references/`（可选·主题化研究语料）
+
+- **物理路径**：`**{PROJECT_DIR}/<id>/references/**`（默认 `{HARNESS_DIR}/projects/<id>/references/`；`.mstarc` `project_dir` 声明时用声明值）。
+- **放什么**：**主题化研究** — surveys、epic roadmaps、第三方 notes，与拥有它的项目（`<id>`）绑定（compass ruling 1）。项目缺失用 `_default`（`{PROJECT_DIR}/_default/references/`）。
+- **不放什么**：冻结规格 / ADR（→ `{SPECS_DIR}/`）；compound 结晶的实现 SSOT（→ `{KNOWLEDGE_DIR}/`）；迭代内 ranking notes 与草稿 spec（→ `{ITERATION_DIR}/<id>/guides|specs/`）。研究**不**迁入这三处 corpora，三处内容也**不**迁入 `references/`。
+- **engine 职责边界**：`listProjectReferenceFiles(projectDir)` 只返回**文件名**（相对路径、`/` 分隔、code-unit 排序；跳过根级 `roadmap.md` / `residuals.json`；缺失目录 → `[]`）；**不**读文件正文，**不**做 markdown schema 校验 — 归属语义是本 reference（技能散文）契约，不是 engine 校验。
+- **历史 dump**：harness 根 `.mstar/references/` 已退役（dogfood 后缺省或仅一行 redirect）；当前路径由 `mstar-project-governance` Scope 表与 `mstar-plan-conventions` `references/artifact-storage-paths.md` 命名。
 
 ## 文件命名
 
@@ -74,6 +83,7 @@
 - `**{PLAN_DIR}/residuals/<plan-id>/`**：偏 **仍 open 的 R# 长文补充**（与 project register `entries[<plan-id>]` 配套，canonical 见 `mstar-plan-conventions` **SKILL.md** 开篇）；见下文「open residual 散文详情」。
 - `**{KNOWLEDGE_DIR}/**`：偏 **可复用的实现向设计上下文**（架构细则、决策、分析），可被后续 plan 或多会话反复引用。
 - `**{ITERATION_DIR}/**`：偏 **某一迭代/版本** 的 package（compass + guides/specs），通常按版本索引而非按单 plan 长期复用。
+- `**{PROJECT_DIR}/<id>/references/**`：偏 **主题化研究**（surveys、epic 备注、第三方 notes），随项目绑定；与 specs / knowledge / iteration guides 职责不混写。
 - review bundle、gate summary、residuals、knowledge、iterations 可互链，但职责不混写。
 
 ---

--- a/skills/mstar-plan-conventions/references/artifact-storage-paths.md
+++ b/skills/mstar-plan-conventions/references/artifact-storage-paths.md
@@ -20,6 +20,7 @@
 | **workflow notes ledger** | `{HARNESS_DIR}/workflows/<id>/notes.jsonl`（gitignored；append-only 运行时笔记） | `mstar-plan-artifacts`、`mstar-iteration` |
 | **project roadmap** | `.mstar/projects/<id>/roadmap.md`（gitignored；frontmatter `{project_id, title, status, created_at, milestones[]?, residuals_ref?}` + 正文约定） | `mstar-plan-artifacts`、`mstar-iteration` |
 | **project register** | `.mstar/projects/<id>/residuals.json`（gitignored；open residual SSOT：`entries[<plan-id>]` 数组；项目缺失用 `_default`） | `mstar-plan-artifacts`、`mstar-review-qc` |
+| **project references（研究语料）** | `.mstar/projects/<id>/references/`（gitignored；主题化 surveys / epic 备注 / 第三方 notes，与项目绑定；与 `{SPECS_DIR}` / `{KNOWLEDGE_DIR}` / `{ITERATION_DIR}` 不同） | `mstar-project-governance`、`mstar-plan-artifacts` |
 | **迭代 package** | `.mstar/iterations/<iteration-id>/`（gitignored；`delivery-compass.md`、`guides/`、`specs/`、可选 `README.md`） | `mstar-iteration`（读写）；close 时 `mstar-compound`（提升读；默认排除 compass） |
 | **迭代索引** | `.mstar/iterations/README.md`（gitignored；一行 = 一次迭代） | `mstar-iteration`（读写） |
 | **规格** | `{HARNESS_DIR}/specs/`（默认 tracked；解析见 `mstar-plan-conventions`） | `mstar-plan-artifacts` |

--- a/skills/mstar-project-governance/SKILL.md
+++ b/skills/mstar-project-governance/SKILL.md
@@ -19,6 +19,7 @@ description: Morning Star 项目治理层约定 —— `projects/<id>/roadmap.md
 |------|------|
 | `roadmap.md` | 项目方向与目标（frontmatter machine-checkable + body 约定） |
 | `residuals.json` | 项目 register：open residual 的 **SSOT**（`entries[<plan-id>]` 数组） |
+| `references/` | 主题化研究语料（surveys / epic 备注 / 第三方 notes）。与 `{SPECS_DIR}`（冻结规格/ADR）、`{KNOWLEDGE_DIR}`（compound 结晶实现 SSOT）、`{ITERATION_DIR}`（迭代 package）**不同**；engine 只列文件名（`listProjectReferenceFiles`），**不做** markdown schema 校验 |
 
 - **`_default` 回退**：无项目流程（未指定 project id 的 plan / 单 plan / hotfix）落到 **`projects/_default/`**（engine `_DEFAULT_PROJECT`）。项目归属由 plan 的 project id 决定；未归属即 `_default`。
 - 本 skill 的 schema 事实与 **`packages/engine/src/project.ts`** 逐字一致（`validateRoadmap` / `validateProjectRegister` / `findingsCleanupGate` / `techDebtRollup`）；技能文本是语义 SSOT，engine 是确定性校验。


### PR DESCRIPTION
## Summary

Iteration **v3.1.0** (`iteration/v3.1.0` → `main`). Scale M, three business plans.

1. **Project research corpus** — `{PROJECT_DIR}/<id>/references/`; engine `listProjectReferenceFiles` (filenames only); dogfood dump under `projects/_default/references/` (live `.mstar/references/` dump retired to a one-line redirect).
2. **Agent-flow tail-read** — `readAgentFlow` last-N window via 64 KiB doubling tail; write truncation 500 unchanged; single parse funnel.
3. **Digest join caps** — `engineStatusSummary` `DIGEST_PLAN_CAP=8` / `DIGEST_LEASE_CAP=4` + `+N more`. Sibling `renderEngineStatusCatalog` stays uncapped (import cycle).

## Test plan

- `bun run engine:build`
- `bun test packages/engine/test/project.test.ts`
- `cd packages/dsh && bun test tests/agent-flow.spec.ts`
- `cd packages/dsh && bun test tests/system-prompt.spec.ts`

Do not auto-merge. Fragments under `.changes/unreleased/` (no CHANGELOG hand-edit).
