### PR TITLE
fix(harness): residual cleanup — engine persistence, host gates, validator CLI closure

### DIFF
--- a/.changes/unreleased/engine-cleanup.md
+++ b/.changes/unreleased/engine-cleanup.md
@@ -1,0 +1,11 @@
+---
+category: Harness
+packages: root, engine, dsh
+---
+
+- **Engine public surface**: `redactSecrets` is no longer re-exported from the `@mstar-harness/engine` barrel (breaking for downstream imports of the bare package); the audit-module utility is now reachable via the new `@mstar-harness/engine/src/audit` subpath, and the `RedactResult` / `SecretFinding` types stay in the barrel. Barrel importers must migrate to the subpath.
+- **dsh**: the audit seam (`packages/dsh/src/gates/seams.ts`) now imports `redactSecrets` from the `./src/audit` subpath instead of the barrel.
+
+<!-- CN -->
+- **Engine 公共面**：`redactSecrets` 不再从 `@mstar-harness/engine` barrel 再导出（对从裸包导入的下游为破坏性变更）；该审计模块工具改由新增的 `@mstar-harness/engine/src/audit` 子路径提供，`RedactResult` / `SecretFinding` 类型仍留在 barrel。barrel 引用方需迁移到子路径。
+- **dsh**：审计 seam（`packages/dsh/src/gates/seams.ts`）改为从 `./src/audit` 子路径导入 `redactSecrets`，不再走 barrel。

--- a/.changes/unreleased/validator-closure.md
+++ b/.changes/unreleased/validator-closure.md
@@ -1,0 +1,9 @@
+---
+category: Harness
+packages: root, cli
+---
+
+- **audit-004 validator CLI surface closure verification**: the five validator commands (`mstar status tech-debt`, `mstar status findings-cleanup <plan-id>`, `mstar lease verify-integration`, `mstar worktree qc-alignment`, `mstar host skill-root`) were smoke-verified runnable against the repo fixtures from the dist build (`node packages/cli/dist/mstar-harness.js`), each exiting per its documented semantics; no command code changed. Residual `20260816-audit-004-validator-cli-surface` moves to in-place `lifecycle: resolved` with the smoke evidence referenced.
+
+<!-- CN -->
+- **audit-004 validator CLI 面闭环**：五个 CLI 命令（`mstar status tech-debt`、`mstar status findings-cleanup <plan-id>`、`mstar lease verify-integration`、`mstar worktree qc-alignment <file>`、`mstar host skill-root`）已用 dist 构建产物（`node packages/cli/dist/mstar-harness.js`）对仓库 fixtures 冒烟验证可运行，退出码符合各自文档语义；无任何命令实现改动。残留项 `20260816-audit-004-validator-cli-surface` 原地置为 `lifecycle: resolved`，证据见冒烟输出。

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -21,8 +21,8 @@ The four verification layers of a plan's review chain: **L1** implementer (write
 ### Workflow lifecycle
 An orchestrated flow (single-plan or iteration) treated as a first-class runtime entity: running state, phase machine, leases/execution policy and logs are contained in one lifecycle directory (`workflows/<id>/snapshot.json` + per-workflow jsonl); the global status table keeps only active lifecycle entries and removes them at terminal state. One lifecycle may be shared by multiple concurrent sessions; terminal state is the natural archive (no compaction ceremony). Not a *session*: a session is one agent conversation and is shorter than a lifecycle.
 
-### Project register
-The durable home for cross-lifecycle debt and direction: open residuals (with severity and lifecycle provenance) and roadmap live under a project; flows without an explicit project fall back to `_default`. Closing a residual is a register state change, not a status-key shuffle. The v1 root `residual_findings` array was retired in v3.0.0.
+### Closure-verification plan
+A plan whose residual's fix may already have landed — grep the current checkout (CLI surface, docs, skill callouts) before planning a re-implementation; if the work is done, re-scope to verification-only: smoke the real artifact, confirm no stale import-only callouts, fill the changeset gap if missing, close the residual in place. Prevents re-implementing a command that already exists.
 
 ## Agent canvas (dsh panel)
 

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -21,6 +21,9 @@ The four verification layers of a plan's review chain: **L1** implementer (write
 ### Workflow lifecycle
 An orchestrated flow (single-plan or iteration) treated as a first-class runtime entity: running state, phase machine, leases/execution policy and logs are contained in one lifecycle directory (`workflows/<id>/snapshot.json` + per-workflow jsonl); the global status table keeps only active lifecycle entries and removes them at terminal state. One lifecycle may be shared by multiple concurrent sessions; terminal state is the natural archive (no compaction ceremony). Not a *session*: a session is one agent conversation and is shorter than a lifecycle.
 
+### Project register
+The durable home for cross-lifecycle debt and direction: open residuals (with severity and lifecycle provenance) and roadmap live under a project; flows without an explicit project fall back to `_default`. Closing a residual is a register state change, not a status-key shuffle. The v1 root `residual_findings` array was retired in v3.0.0.
+
 ### Closure-verification plan
 A plan whose residual's fix may already have landed — grep the current checkout (CLI surface, docs, skill callouts) before planning a re-implementation; if the work is done, re-scope to verification-only: smoke the real artifact, confirm no stale import-only callouts, fill the changeset gap if missing, close the residual in place. Prevents re-implementing a command that already exists.
 

--- a/packages/dsh/src/gates/seams.ts
+++ b/packages/dsh/src/gates/seams.ts
@@ -27,6 +27,14 @@ import {
   validateRoleMapping,
   validateSchemaYaml,
 } from '@mstar-harness/engine'
+// `./src/audit` subpath import is PURE-FUNCTION-ONLY: it resolves to the
+// separate `dist/audit.js` bundle, a distinct module instance from the
+// barrel's `dist/engine.js` (each inlines its own copies of core/lease/
+// path/status/workflow). Stateful or lock-bearing engine functions
+// (withStatusWriteLock, registerWorkflow, promoteAuditPlans, writeJson,
+// …) MUST NOT be imported via this subpath — cross-instance state would
+// be duplicated. `redactSecrets` is a pure regex scan (no mutable
+// module-level state), so this import is safe.
 import { redactSecrets } from '@mstar-harness/engine/src/audit'
 import type { GateResult, SecretFinding, ValidationResult } from '@mstar-harness/engine'
 import type { FsTarget, FsWriteIntent } from '@deepseek-ai/dsh-fs'

--- a/packages/dsh/src/gates/seams.ts
+++ b/packages/dsh/src/gates/seams.ts
@@ -21,13 +21,13 @@ import {
   applyEnforcement,
   assertLightDarkParity,
   lintLoadOrder,
-  redactSecrets,
   referenceExists,
   validateAuditStatusBlocks,
   validateDesignTokenFrontmatter,
   validateRoleMapping,
   validateSchemaYaml,
 } from '@mstar-harness/engine'
+import { redactSecrets } from '@mstar-harness/engine/src/audit'
 import type { GateResult, SecretFinding, ValidationResult } from '@mstar-harness/engine'
 import type { FsTarget, FsWriteIntent } from '@deepseek-ai/dsh-fs'
 import { formatViolation, resolveSeamHard, HarnessResolver, actorAgentOf } from './_shared.ts'

--- a/packages/dsh/src/gates/status.ts
+++ b/packages/dsh/src/gates/status.ts
@@ -322,7 +322,21 @@ function gateStatusIntent(
   } catch (error) {
     ctx.logger(LOGGER_NAME).error(`status gate degraded to allow: ${(error as Error).message}`)
     try {
-      ctx.emit('mstar/status-gate', { operation, target: target.displayPath, result: { ok: true, violations: [] }, hard: false, degraded: true })
+      // f9: the degraded advisory reflects ACTUAL enforcement mode — under
+      // hard the envelope still allows the write (never a veto), but the
+      // advisory carries `hard: true` so hard deployments can tell a dead
+      // control apart from a warn-only pass. `repair` stays unset (this was
+      // NOT a repair-escape allow — the gate errored, the write was never
+      // vetoed).
+      let hard = false
+      try {
+        hard = harnessDir !== null && resolveHard(harnessDir, config)
+      } catch {
+        // `resolveHard` reads `.mstarc`/compass frontmatter from disk — a
+        // throwing resolve must not re-enter the envelope (second-catch
+        // death loop); fall back to a fail-safe warn-mode advisory.
+      }
+      ctx.emit('mstar/status-gate', { operation, target: target.displayPath, result: { ok: true, violations: [] }, hard, degraded: true })
     } catch (emitError) {
       // Best-effort observability: a throwing advisory consumer must not take
       // the gate down with it (the error log above is the durable signal).

--- a/packages/dsh/src/gates/status.ts
+++ b/packages/dsh/src/gates/status.ts
@@ -69,7 +69,13 @@ export interface StatusGateAdvisory {
   target: string
   /** The gate verdict (warn-mode: `hardBlocked` false; hard repair escape: `hardBlocked` true). */
   result: GateResult
-  /** Resolved enforcement flag: false for warn-mode advisories, true for hard-mode repair escapes. */
+  /**
+   * Resolved enforcement flag: true whenever the gate ran under hard
+   * enforcement — for hard-mode repair escapes AND for degraded-hard
+   * advisories (f9: the catch emits `hard` reflecting ACTUAL enforcement,
+   * so a hard deployment can distinguish a dead control from a warn-only
+   * pass). False only for warn-mode advisories.
+   */
   hard: boolean
   /** True when hard mode allowed a write/edit to an ALREADY-invalid document (repair escape). */
   repair?: boolean

--- a/packages/dsh/src/gates/workflow-selection.ts
+++ b/packages/dsh/src/gates/workflow-selection.ts
@@ -12,7 +12,7 @@
  * Module boundary: no barrel — consumers import by explicit relative path.
  */
 import { existsSync, readdirSync, statSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 import {
   readJson,
   resolveWorkflowDir,
@@ -44,9 +44,20 @@ const TERMINAL_STATUS_CACHE_MAX = 64
  * rewrite would be served stale until the file is touched — the
  * documented mtime-first tradeoff the finding asks for; terminal
  * snapshots are written once via temp-file + rename (mtime always
- * changes).
+ * changes). Deleted snapshots are EVICTED (plan 20260822-gate-fixes
+ * Task 3 / f12): a dead key must not hold the cap.
  */
 const terminalStatusCache = new Map<string, { mtimeMs: number; terminal: boolean }>()
+
+/**
+ * Test-only observability hook (plan 20260822-gate-fixes Task 3 / f12):
+ * whether a snapshot path is still cached. Production code never calls
+ * this — the eviction contract (delete → key gone) is asserted by the
+ * workflow-selection spec.
+ */
+export function _terminalStatusCacheHas(snapshotPath: string): boolean {
+  return terminalStatusCache.has(snapshotPath)
+}
 
 /**
  * One snapshot's terminal-status verdict, mtime-first (qc3 S-2 fix-wave):
@@ -62,6 +73,11 @@ function terminalStatusOf(snapshotPath: string): { terminal: boolean; mtimeMs: n
   try {
     mtimeMs = statSync(snapshotPath).mtimeMs
   } catch {
+    // The target vanished — evict the dead key so the cap is not held by
+    // a workflow that no longer exists (f12; the caller's `existsSync`
+    // short-circuit never reaches this function, so the read loop evicts
+    // there too).
+    terminalStatusCache.delete(snapshotPath)
     return undefined
   }
   const cached = terminalStatusCache.get(snapshotPath)
@@ -194,7 +210,14 @@ export function resolveReadWorkflow(harnessDir: string): WorkflowSelectionView {
   for (const entry of entries) {
     if (!entry.isDirectory()) continue
     const snapshotPath = join(workflowsDir, entry.name, WORKFLOW_SNAPSHOT_FILE)
-    if (!existsSync(snapshotPath)) continue
+    if (!existsSync(snapshotPath)) {
+      // Deleted snapshot (or the whole workflow dir) — evict the stale
+      // cache key (f12): this short-circuit never reaches `terminalStatusOf`,
+      // so the dead entry would otherwise hold the cache cap forever while
+      // the workflow stays invisible.
+      terminalStatusCache.delete(snapshotPath)
+      continue
+    }
     // mtime-first fast path (qc3 S-2 fix-wave): stat + cache-hit reuse the
     // terminal verdict without parsing the snapshot JSON (the steady state
     // for terminal snapshots — the per-TTL reparse was pure waste).
@@ -202,6 +225,14 @@ export function resolveReadWorkflow(harnessDir: string): WorkflowSelectionView {
     if (verdict === undefined || !verdict.terminal) continue
     if (best === undefined || verdict.mtimeMs > best.mtimeMs) {
       best = { workflowId: entry.name, dir: join(relative(harnessDir, workflowsDir), entry.name), mtimeMs: verdict.mtimeMs }
+    }
+  }
+  // The dir itself can be deleted (not just the snapshot) — the walk above
+  // never sees a vanished dir, so prune any cached key whose parent dir is
+  // gone (f12; cap semantics unchanged).
+  for (const cachedPath of terminalStatusCache.keys()) {
+    if (!existsSync(join(dirname(cachedPath), WORKFLOW_SNAPSHOT_FILE))) {
+      terminalStatusCache.delete(cachedPath)
     }
   }
   if (best === undefined) {

--- a/packages/dsh/tests/status-gate.spec.ts
+++ b/packages/dsh/tests/status-gate.spec.ts
@@ -270,9 +270,17 @@ describe('status gate — error-containment envelope (qc3 F-1)', () => {
 
     const intent = await app.ctx.waterfall('fs/write-intent', brokenTarget(app.harnessDir), {}, () => undefined)
 
+    // f9: the degraded advisory reflects ACTUAL enforcement mode — under
+    // hard the envelope still allows the write (never a veto), but the
+    // advisory carries `hard: true` so hard deployments can tell a dead
+    // control apart from a warn-only pass; `repair` stays unset (this was
+    // NOT a repair-escape allow — the gate errored, the write was never
+    // vetoed).
     expect(intent).toBeUndefined()
     expect(advisories).toHaveLength(1)
     expect(advisories[0]!.degraded).toBe(true)
+    expect(advisories[0]!.hard).toBe(true)
+    expect(advisories[0]!.repair).toBeUndefined()
     expect(advisories[0]!.result.ok).toBe(true)
   })
 

--- a/packages/dsh/tests/workflow-selection.spec.ts
+++ b/packages/dsh/tests/workflow-selection.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Plan `20260822-gate-fixes` Task 3 (f12) — terminalStatusCache eviction
+ * on file deletion.
+ *
+ * The terminal-mtime fallback (`resolveReadWorkflow`) walks every workflow
+ * dir per catalog refresh; the module-level `terminalStatusCache` holds a
+ * snapshot path → `{ mtimeMs, terminal }` verdict with a 64-entry cap.
+ * The qc3 S-2 fix-wave capped the cache but never EVICTED a key whose
+ * target file was deleted: the `resolveReadWorkflow` loop short-circuits on
+ * `!existsSync(snapshotPath)` and never reaches `terminalStatusOf`, so the
+ * stale entry kept holding the cap while the dead workflow stayed
+ * invisible. This spec pins the eviction contract:
+ *
+ * - after a cached terminal snapshot is deleted, the next read re-probes
+ *   (the deleted workflow id is never selected) AND the cache key is gone;
+ * - deleting the whole workflow dir is equivalent to deleting the snapshot
+ *   file (both hit the `existsSync` short-circuit).
+ */
+import { describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, utimes } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveReadWorkflow, _terminalStatusCacheHas } from '../src/gates/workflow-selection.ts'
+import { seedHarness, v2Root, v2Snapshot } from './harness.ts'
+
+describe('workflow selection — terminalStatusCache eviction on deletion (f12)', () => {
+  it('deleting the workflow dir evicts the cached key; the next read re-probes and selects nothing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-mstar-wfsel-evict-dir-'))
+    const harnessDir = join(root, 'harness')
+    await mkdir(harnessDir, { recursive: true })
+    await seedHarness(harnessDir, {
+      'status.json': v2Root([]),
+      'workflows/wf-new/snapshot.json': v2Snapshot('wf-new', { status: 'completed', ended_at: '2026-08-19', plans: [{ id: 'plan-new', status: 'Done' }] }),
+    })
+    const snapshotPath = join(harnessDir, 'workflows/wf-new/snapshot.json')
+
+    // First read populates the cache (terminal verdict cached by mtime).
+    expect(resolveReadWorkflow(harnessDir)).toEqual({ kind: 'terminal', workflowId: 'wf-new', dir: 'workflows/wf-new' })
+
+    // Delete the whole workflow dir.
+    await rm(join(harnessDir, 'workflows/wf-new'), { recursive: true, force: true })
+
+    // The next read re-probes: no terminal snapshot remains — the deleted
+    // workflow must NOT be selected, and the dead cache key must be gone.
+    expect(resolveReadWorkflow(harnessDir)).toEqual({
+      kind: 'error',
+      code: 'workflow.selection.no-snapshot',
+      message: expect.stringContaining('no terminal workflow snapshot'),
+    })
+    expect(_terminalStatusCacheHas(snapshotPath)).toBe(false)
+  })
+
+  it('deleting just the snapshot.json evicts the cached key; a remaining terminal is still selected', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-mstar-wfsel-evict-file-'))
+    const harnessDir = join(root, 'harness')
+    await mkdir(harnessDir, { recursive: true })
+    await seedHarness(harnessDir, {
+      'status.json': v2Root([]),
+      'workflows/wf-old/snapshot.json': v2Snapshot('wf-old', { status: 'completed', ended_at: '2026-08-18', plans: [{ id: 'plan-old', status: 'Done' }] }),
+      'workflows/wf-new/snapshot.json': v2Snapshot('wf-new', { status: 'completed', ended_at: '2026-08-19', plans: [{ id: 'plan-new', status: 'Done' }] }),
+    })
+    // Deterministic mtimes: wf-old older, wf-new newer (selection by file mtime).
+    const oldPath = join(harnessDir, 'workflows/wf-old/snapshot.json')
+    const newPath = join(harnessDir, 'workflows/wf-new/snapshot.json')
+    const base = Date.now() / 1000
+    await utimes(oldPath, base - 200, base - 200)
+    await utimes(newPath, base - 100, base - 100)
+
+    // First read caches both verdicts and selects the newest terminal.
+    expect(resolveReadWorkflow(harnessDir)).toEqual({ kind: 'terminal', workflowId: 'wf-new', dir: 'workflows/wf-new' })
+    expect(_terminalStatusCacheHas(newPath)).toBe(true)
+
+    // Delete only the newest snapshot file (dir remains).
+    await rm(newPath, { force: true })
+
+    // The next read must not select the deleted workflow; it falls back to
+    // the surviving terminal, and the dead key is evicted from the cache.
+    expect(resolveReadWorkflow(harnessDir)).toEqual({ kind: 'terminal', workflowId: 'wf-old', dir: 'workflows/wf-old' })
+    expect(_terminalStatusCacheHas(newPath)).toBe(false)
+  })
+})

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -16,13 +16,17 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/engine.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./src/audit": {
+      "types": "./dist/audit.d.ts",
+      "default": "./dist/audit.js"
+    }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts --target node --outfile dist/engine.js && bunx tsc",
+    "build": "rm -rf dist && bun build src/index.ts --target node --outfile dist/engine.js && bun build src/audit.ts --target node --outfile dist/audit.js && bunx tsc",
     "test": "bun test",
     "prepublishOnly": "bun run build"
   },

--- a/packages/engine/src/audit.ts
+++ b/packages/engine/src/audit.ts
@@ -646,7 +646,7 @@ export async function promoteAuditPlans(
     }
     mkdirSync(workflowDir, { recursive: true });
     try {
-      writeJson(snapshotPath, snapshot as unknown as Record<string, unknown>);
+      writeJson(snapshotPath, snapshot);
       registerWorkflowEntryLocked(statusPath, entry);
     } catch (error) {
       rmSync(snapshotPath, { force: true });

--- a/packages/engine/src/core.ts
+++ b/packages/engine/src/core.ts
@@ -103,7 +103,7 @@ export function readJson(filePath: string): Record<string, unknown> {
  * stored state; revisit if the harness moves to a filesystem without
  * rename-atomicity guarantees.
  */
-export function writeJson(filePath: string, value: Record<string, unknown>): void {
+export function writeJson<T>(filePath: string, value: T): void {
   const parent = dirname(filePath);
   mkdirSync(parent, { recursive: true });
   const tmp = join(parent, `.${basename(filePath)}.${process.pid}.${randomUUID()}.tmp`);

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -247,7 +247,6 @@ export {
   AUDIT_PRIORITIES,
   AUDIT_RISKS,
   promoteAuditPlans,
-  redactSecrets,
   scaffoldAuditPlan,
   validateAuditStatusBlocks,
 } from "./audit.js";

--- a/packages/engine/src/migrate.ts
+++ b/packages/engine/src/migrate.ts
@@ -926,9 +926,16 @@ export async function applyMigratePlan(plan: MigratePlan): Promise<MigrateResult
         `refusing to apply migration: invalid project register: ${gate.violations.map((v) => v.message).join("; ")}`,
       );
     }
-    const filePath = projectTargetOf(plan.register.file);
-    mkdirSync(dirname(filePath), { recursive: true });
-    writeJson(filePath, plan.register.data as unknown as Record<string, unknown>);
+    // Zero entries -> no register file (audit-20260821-f3): the planner
+    // already returns `register: null` when there are no open residuals,
+    // but a hand-built plan may carry a gate-passing empty `{ entries: {} }`
+    // — writing an empty register would orphan an empty file. Validate
+    // FIRST so an invalid doc (e.g. missing `entries`) still throws.
+    if (Object.keys(plan.register.data.entries ?? {}).length > 0) {
+      const filePath = projectTargetOf(plan.register.file);
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeJson(filePath, plan.register.data as unknown as Record<string, unknown>);
+    }
   }
 
   // 5. Roadmap seeds (additive).

--- a/packages/engine/src/migrate.ts
+++ b/packages/engine/src/migrate.ts
@@ -934,7 +934,7 @@ export async function applyMigratePlan(plan: MigratePlan): Promise<MigrateResult
     if (Object.keys(plan.register.data.entries ?? {}).length > 0) {
       const filePath = projectTargetOf(plan.register.file);
       mkdirSync(dirname(filePath), { recursive: true });
-      writeJson(filePath, plan.register.data as unknown as Record<string, unknown>);
+      writeJson(filePath, plan.register.data);
     }
   }
 
@@ -964,7 +964,7 @@ export async function applyMigratePlan(plan: MigratePlan): Promise<MigrateResult
         message: "no-op: status.json already at schema version 2 (migrated) \u2014 nothing to do",
       };
     }
-    writeJson(statusPath, plan.rootV2.data as unknown as Record<string, unknown>);
+    writeJson(statusPath, plan.rootV2.data);
     return {
       applied: true,
       message: `migrated ${plan.snapshots.length} lifecycles into workflows/, project layer seeded, root status.json replaced (v1 archived to ${plan.archive.file})`,

--- a/packages/engine/src/status.ts
+++ b/packages/engine/src/status.ts
@@ -712,7 +712,7 @@ export function registerWorkflowEntryLocked(statusPath: string, entry: WorkflowE
   if (!gate.ok) {
     throw new Error(`refusing to write invalid status.json: ${gate.violations.map((v) => v.message).join("; ")}`);
   }
-  writeJson(statusPath, doc as unknown as Record<string, unknown>);
+  writeJson(statusPath, doc);
   return doc;
 }
 
@@ -777,7 +777,7 @@ export async function unregisterWorkflow(root: string, id: string): Promise<Stat
     if (!gate.ok) {
       throw new Error(`refusing to write invalid status.json: ${gate.violations.map((v) => v.message).join("; ")}`);
     }
-    writeJson(statusPath, doc as unknown as Record<string, unknown>);
+    writeJson(statusPath, doc);
     return doc;
   });
 }

--- a/packages/engine/src/workflow.ts
+++ b/packages/engine/src/workflow.ts
@@ -322,6 +322,6 @@ export async function writeWorkflowSnapshot(snapshot: WorkflowSnapshot, dir: str
   // acquisition (the lockdir lands inside `dir`, dirname of the snapshot).
   mkdirSync(dir, { recursive: true });
   await withStatusWriteLock(snapshotPath, () => {
-    writeJson(snapshotPath, snapshot as unknown as Record<string, unknown>);
+    writeJson(snapshotPath, snapshot);
   });
 }

--- a/packages/engine/test/audit.test.ts
+++ b/packages/engine/test/audit.test.ts
@@ -839,3 +839,23 @@ describe("promoteAuditPlans", () => {
     expect(existsSync(join(harnessDir, "status.json"))).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// f11: redactSecrets must NOT be re-exported from the engine barrel —
+// the deterministic validator surface stays public; the redaction utility
+// stays module-private (import from the audit module directly).
+// ---------------------------------------------------------------------------
+
+describe("engine barrel hides redactSecrets (f11)", () => {
+  test("importing redactSecrets from the barrel resolves to undefined", async () => {
+    // Dynamic import: this test intentionally exercises the module loading
+    // boundary — the assertion is that the barrel's runtime namespace lacks
+    // the removed export, which a static named import could not express.
+    const barrel = await import("../src/index.js");
+    expect((barrel as Record<string, unknown>).redactSecrets).toBeUndefined();
+  });
+
+  test("the audit module still exports redactSecrets directly", () => {
+    expect(typeof redactSecrets).toBe("function");
+  });
+});

--- a/packages/engine/test/migrate.test.ts
+++ b/packages/engine/test/migrate.test.ts
@@ -627,6 +627,30 @@ describe("applyMigratePlan — executor on a copied fixture tree", () => {
     }
   });
 
+  test("constructed register with data { entries: null } still throws and writes nothing (audit-20260821-f3)", async () => {
+    const root = fixtureTree();
+    try {
+      const plan = migrateHarnessTree(root);
+      plan.register = {
+        file: "projects/_null-entries-register/residuals.json",
+        source: "constructed",
+        // `entries: null` is NOT a realistic planner shape (buildRegister
+        // emits `entries: {}` or returns null), but it locks the
+        // validate-before-skip ordering: validateProjectRegister rejects
+        // a non-object `entries` ("entries must be an object keyed by plan
+        // id"), so the `?? {}` zero-entries skip must never swallow it.
+        // The gate runs first — invalid docs throw, only gate-passing
+        // empty `{ entries: {} }` registers are skipped.
+        data: { entries: null },
+      };
+
+      await expect(applyMigratePlan(plan)).rejects.toThrow(/entries must be an object/);
+      expect(existsSync(join(root, "projects", "_null-entries-register", "residuals.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("a v1 tree with no status.json refuses to migrate", () => {
     const root = tmpRoot("migrate-nov1-");
     try {

--- a/packages/engine/test/migrate.test.ts
+++ b/packages/engine/test/migrate.test.ts
@@ -559,6 +559,74 @@ describe("applyMigratePlan — executor on a copied fixture tree", () => {
     }
   });
 
+  test("constructed empty register ({ entries: {} }) applies but writes no register file or parent dir (audit-20260821-f3)", async () => {
+    const root = fixtureTree();
+    try {
+      const plan = migrateHarnessTree(root);
+      // Hand-build the non-null empty register the planner never produces:
+      // `data.entries` is a valid (gate-passing) empty map, so the only
+      // reason to skip the write is the zero-entries rule.
+      plan.register = {
+        file: "projects/_empty-register/residuals.json",
+        source: "constructed",
+        data: { entries: {} },
+      };
+      // Isolate the register step: no roadmap write may create the parent
+      // dir for us.
+      plan.roadmap = null;
+
+      const result = await applyMigratePlan(plan);
+      expect(result.applied).toBe(true);
+      expect(existsSync(join(root, "projects", "_empty-register", "residuals.json"))).toBe(false);
+      expect(existsSync(join(root, "projects", "_empty-register"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("constructed register with >=1 entry writes the doc verbatim (audit-20260821-f3 control)", async () => {
+    const root = fixtureTree();
+    try {
+      const plan = migrateHarnessTree(root);
+      const data = {
+        entries: {
+          "plan-a": [{ ...residual(), source_plan: "plan-a", registered_at: "2026-08-21" }],
+        },
+      };
+      plan.register = {
+        file: "projects/_default/residuals.json",
+        source: "constructed",
+        data,
+      };
+      plan.roadmap = null;
+
+      const result = await applyMigratePlan(plan);
+      expect(result.applied).toBe(true);
+      const registerPath = join(root, "projects", "_default", "residuals.json");
+      expect(existsSync(registerPath)).toBe(true);
+      expect(readJson(registerPath)).toEqual(data);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("constructed register with data {} (missing entries) still throws and writes nothing (audit-20260821-f3)", async () => {
+    const root = fixtureTree();
+    try {
+      const plan = migrateHarnessTree(root);
+      plan.register = {
+        file: "projects/_invalid-register/residuals.json",
+        source: "constructed",
+        data: {},
+      };
+
+      await expect(applyMigratePlan(plan)).rejects.toThrow(/missing required field: entries/);
+      expect(existsSync(join(root, "projects", "_invalid-register", "residuals.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("a v1 tree with no status.json refuses to migrate", () => {
     const root = tmpRoot("migrate-nov1-");
     try {

--- a/packages/opencode/src/mstar.ts
+++ b/packages/opencode/src/mstar.ts
@@ -832,12 +832,51 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
           );
         }
       } else if (input.tool === "edit") {
-        // v1 limitation (qc2 F-005 / qc3 F-7): validates the PRE-edit on-disk
-        // file, not the patched result — an edit that turns a valid file
-        // invalid is caught by the subsequent write, and editing an already
-        // invalid file re-warns about the state being replaced. Computing the
-        // patched doc for `edit` is a later-slice improvement.
-        const gate = await validateStatusWrite(filePath);
+        // f8 (audit-20260821-f8): when the OpenCode `edit` args carry a
+        // literal `oldString` -> `newString` pair (one pair per tool call —
+        // no replacements array, no regex), synthesize the PATCHED text and
+        // lint the patched coordination doc, so an edit that turns a valid
+        // file invalid is caught at this hook instead of by the next write.
+        // Only literal, uniquely-present replacements are composable here:
+        // the host's fuzzy matchers (LineTrimmed / BlockAnchor /
+        // WhitespaceNormalized) are NOT re-implemented — a fuzzy edit may
+        // patch a different span than a guessed synthesis. Fallback to the
+        // pre-edit lint when the shape is not composable: missing or empty
+        // `oldString`, missing `newString`, `replaceAll` not a boolean,
+        // literal not uniquely present (unless `replaceAll === true`), or
+        // the file cannot be read.
+        const oldString = args.oldString;
+        const newString = args.newString;
+        const replaceAll = args.replaceAll;
+        let patchedDoc: unknown;
+        if (
+          typeof oldString === "string" &&
+          oldString.length > 0 &&
+          typeof newString === "string" &&
+          (replaceAll === undefined || typeof replaceAll === "boolean")
+        ) {
+          try {
+            const text = fs.readFileSync(filePath, "utf8");
+            const hits = text.split(oldString).length - 1;
+            if (replaceAll === true || hits === 1) {
+              const patched = text.split(oldString).join(newString);
+              try {
+                patchedDoc = JSON.parse(patched);
+              } catch {
+                // Patched JSON would not parse — surface the invalid state
+                // by passing the raw text as a non-object doc (validators
+                // report invalid-doc instead of silently passing).
+                patchedDoc = patched;
+              }
+            }
+          } catch {
+            // Read failure (missing/unreadable file) -> pre-edit lint below.
+          }
+        }
+        const gate =
+          patchedDoc !== undefined
+            ? await validateStatusWrite(filePath, { doc: patchedDoc })
+            : await validateStatusWrite(filePath);
         if (gate?.hardBlocked) {
           defaultStatusLogger(
             "error",

--- a/packages/opencode/src/mstar.ts
+++ b/packages/opencode/src/mstar.ts
@@ -832,6 +832,13 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
           );
         }
       } else if (input.tool === "edit") {
+        // Classify the target FIRST (qc3 S-1): the dir-resolvers loader is
+        // cached, so the kind check is cheap — the synchronous file read +
+        // split/join + parse below only runs for canonical coordination
+        // docs. Non-coordination targets (source files, configs, prose —
+        // the overwhelming majority of edits) skip the read/parse entirely.
+        classifyDirResolvers = await dirResolversLoader.load();
+        if (harnessDocKindOfTarget(filePath) === null) return;
         // f8 (audit-20260821-f8): when the OpenCode `edit` args carry a
         // literal `oldString` -> `newString` pair (one pair per tool call —
         // no replacements array, no regex), synthesize the PATCHED text and
@@ -864,9 +871,13 @@ export const MorningStarHarnessPlugin: Plugin = async () => {
                 patchedDoc = JSON.parse(patched);
               } catch {
                 // Patched JSON would not parse — surface the invalid state
-                // by passing the raw text as a non-object doc (validators
-                // report invalid-doc instead of silently passing).
-                patchedDoc = patched;
+                // with an explicit non-object marker (`null`): the validators
+                // report status.invalid-doc / workflow.snapshot.invalid /
+                // project.register.invalid. Passing the raw string instead
+                // would hit the status validator's STRING-as-PATH overload
+                // and misreport `status.migration-required` (qc3 S-2). The
+                // gate still fires — never a silent pass.
+                patchedDoc = null;
               }
             }
           } catch {

--- a/packages/opencode/test/status-write-hook.test.ts
+++ b/packages/opencode/test/status-write-hook.test.ts
@@ -639,7 +639,13 @@ describe("hard mode (compass enforcement: hard — Slice 5, roadmap §8.5 C4/D2)
     }
   });
 
-  test("plugin wiring: write tool in a hard repo logs error-level lines, never throws", async () => {
+  test("plugin wiring (f8): edit literal replace that corrupts status.json is caught POST-patch in hard mode", async () => {
+    // Regression (audit-20260821-f8): the edit branch validated only the
+    // PRE-edit on-disk file, so an edit that turns a valid status.json
+    // invalid (version 2 -> 1) passed silently. The hook must synthesize
+    // the patched doc from the literal single `oldString` -> `newString`
+    // pair and lint the patched result. Pre-change this test is red: the
+    // pre-edit file is valid, so no logs are emitted.
     const { project, statusPath } = makeHardRepo(true);
     try {
       const plugin = await MorningStarHarnessPlugin();
@@ -651,18 +657,136 @@ describe("hard mode (compass enforcement: hard — Slice 5, roadmap §8.5 C4/D2)
       };
       try {
         await beforeWrite!(
-          { tool: "write", sessionID: "s1", callID: "c1" },
-          { args: { filePath: statusPath, content: JSON.stringify(invalidDoc) } },
+          { tool: "edit", sessionID: "s1", callID: "c1" },
+          { args: { filePath: statusPath, oldString: '"version": 2', newString: '"version": 1' } },
         );
       } finally {
         console.error = original;
       }
-      expect(errors.some((e) => e.includes("[mstar-harness]") && e.includes("hard gate"))).toBe(true);
-      // The GateResult is not silently discarded: the hook surfaces the
-      // hardBlocked state explicitly (host has no refusal channel).
+      expect(errors.some((e) => e.includes("[mstar-harness]") && e.includes("status.migration-required"))).toBe(true);
       expect(errors.some((e) => e.includes("hard-gate blocked (hardBlocked=true)"))).toBe(true);
     } finally {
       rmSync(project, { recursive: true, force: true });
     }
   });
+
+  test("plugin wiring (f8): edit with a benign literal single replace stays silent (patched doc still valid)", async () => {
+    const { project, statusPath } = makeHardRepo(true);
+    try {
+      const plugin = await MorningStarHarnessPlugin();
+      const beforeWrite = plugin["tool.execute.before"];
+      const errors: string[] = [];
+      const original = console.error;
+      console.error = (message?: unknown) => {
+        errors.push(String(message));
+      };
+      try {
+        await beforeWrite!(
+          { tool: "edit", sessionID: "s1", callID: "c1" },
+          {
+            args: {
+              filePath: statusPath,
+              oldString: '"updated_at": "2026-08-08"',
+              newString: '"updated_at": "2026-08-09"',
+            },
+          },
+        );
+      } finally {
+        console.error = original;
+      }
+      expect(errors.filter((e) => e.includes("[mstar-harness]"))).toEqual([]);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test("plugin wiring (f8): oldString absent from the file falls back to pre-edit lint (no fuzzy synthesis)", async () => {
+    // The host applies fuzzy matchers (LineTrimmed/BlockAnchor/
+    // WhitespaceNormalized) when the literal misses; the hook MUST NOT
+    // re-implement them. `oldString` never occurs in the file, and the
+    // `newString` would corrupt the doc if applied — the correct behavior
+    // is to lint the (valid) pre-edit file and stay silent.
+    const { project, statusPath } = makeHardRepo(true);
+    try {
+      const plugin = await MorningStarHarnessPlugin();
+      const beforeWrite = plugin["tool.execute.before"];
+      const errors: string[] = [];
+      const original = console.error;
+      console.error = (message?: unknown) => {
+        errors.push(String(message));
+      };
+      try {
+        await beforeWrite!(
+          { tool: "edit", sessionID: "s1", callID: "c1" },
+          { args: { filePath: statusPath, oldString: '"workflows": [{', newString: '"version": 1' } },
+        );
+      } finally {
+        console.error = original;
+      }
+      expect(errors.filter((e) => e.includes("[mstar-harness]"))).toEqual([]);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test("plugin wiring (f8): replaceAll literal edit corrupting every workflow entry is caught post-patch in hard mode", async () => {
+    const { project, statusPath } = makeHardRepo(true);
+    // Two valid workflow entries WITH matching non-terminal snapshots so
+    // the pre-edit file passes the item-level lint; the replaceAll edit
+    // turns every "type": "plan" into "type": "sprint".
+    mkdirSync(join(project, ".mstar", "workflows", "wf-1"), { recursive: true });
+    mkdirSync(join(project, ".mstar", "workflows", "wf-2"), { recursive: true });
+    writeFileSync(
+      join(project, ".mstar", "workflows", "wf-1", "snapshot.json"),
+      JSON.stringify(validSnapshotDoc, null, 2),
+    );
+    writeFileSync(
+      join(project, ".mstar", "workflows", "wf-2", "snapshot.json"),
+      JSON.stringify({ ...validSnapshotDoc, id: "wf-2" }, null, 2),
+    );
+    writeFileSync(
+      statusPath,
+      JSON.stringify(
+        {
+          version: 2,
+          updated_at: "2026-08-08",
+          workflows: [
+            { id: "wf-1", type: "plan", started_at: "2026-08-08", dir: "workflows/wf-1" },
+            { id: "wf-2", type: "plan", started_at: "2026-08-08", dir: "workflows/wf-2" },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    try {
+      const plugin = await MorningStarHarnessPlugin();
+      const beforeWrite = plugin["tool.execute.before"];
+      const errors: string[] = [];
+      const original = console.error;
+      console.error = (message?: unknown) => {
+        errors.push(String(message));
+      };
+      try {
+        await beforeWrite!(
+          { tool: "edit", sessionID: "s1", callID: "c1" },
+          {
+            args: {
+              filePath: statusPath,
+              oldString: '"type": "plan"',
+              newString: '"type": "sprint"',
+              replaceAll: true,
+            },
+          },
+        );
+      } finally {
+        console.error = original;
+      }
+      expect(errors.some((e) => e.includes("[mstar-harness]") && e.includes("status.workflow.invalid-type"))).toBe(true);
+      expect(errors.some((e) => e.includes("hard-gate blocked (hardBlocked=true)"))).toBe(true);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/packages/opencode/test/status-write-hook.test.ts
+++ b/packages/opencode/test/status-write-hook.test.ts
@@ -789,4 +789,99 @@ describe("hard mode (compass enforcement: hard — Slice 5, roadmap §8.5 C4/D2)
     }
   });
 
+  test("plugin wiring (qc3 S-3 / qc2 S): edit whose literal replace breaks JSON syntax reports invalid-doc, not migration-required", async () => {
+    // Regression (qc3 S-2/S-3 + qc2 f8): when the patched text fails
+    // JSON.parse, the hook used to pass the RAW STRING as `doc`; for the
+    // status kind the string overload of the validator treats it as a FILE
+    // PATH, reads `{}` for the missing path, and misreports
+    // `status.migration-required` instead of the true invalid-doc cause.
+    // The fix passes an explicit non-object marker (`null`) so the gate
+    // fires with `status.invalid-doc` on ALL kinds. The gate must never
+    // pass silently.
+    const { project, statusPath } = makeHardRepo(true);
+    try {
+      const plugin = await MorningStarHarnessPlugin();
+      const beforeWrite = plugin["tool.execute.before"];
+      const errors: string[] = [];
+      const original = console.error;
+      console.error = (message?: unknown) => {
+        errors.push(String(message));
+      };
+      try {
+        await beforeWrite!(
+          { tool: "edit", sessionID: "s1", callID: "c1" },
+          {
+            args: {
+              filePath: statusPath,
+              oldString: '"workflows": []',
+              newString: '"workflows": [',
+            },
+          },
+        );
+      } finally {
+        console.error = original;
+      }
+      // The true cause is surfaced — not the string-as-path fallthrough.
+      expect(errors.some((e) => e.includes("[mstar-harness]") && e.includes("status.invalid-doc"))).toBe(true);
+      expect(errors.some((e) => e.includes("status.migration-required"))).toBe(false);
+      // The gate fires (hard mode: error lines + hardBlocked refusal marker).
+      expect(errors.some((e) => e.includes("hard-gate blocked (hardBlocked=true)"))).toBe(true);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test("plugin wiring (qc1 S-004): non-unique literal WITHOUT replaceAll falls back to pre-edit lint", async () => {
+    // The same literal occurs in two workflow entries; without
+    // `replaceAll: true` the replacement is ambiguous (the host could
+    // target either span) so the hook MUST NOT synthesize — it lints the
+    // (valid) pre-edit file and stays silent.
+    const { project, statusPath } = makeHardRepo(true);
+    mkdirSync(join(project, ".mstar", "workflows", "wf-1"), { recursive: true });
+    mkdirSync(join(project, ".mstar", "workflows", "wf-2"), { recursive: true });
+    writeFileSync(
+      join(project, ".mstar", "workflows", "wf-1", "snapshot.json"),
+      JSON.stringify(validSnapshotDoc, null, 2),
+    );
+    writeFileSync(
+      join(project, ".mstar", "workflows", "wf-2", "snapshot.json"),
+      JSON.stringify({ ...validSnapshotDoc, id: "wf-2" }, null, 2),
+    );
+    writeFileSync(
+      statusPath,
+      JSON.stringify(
+        {
+          version: 2,
+          updated_at: "2026-08-08",
+          workflows: [
+            { id: "wf-1", type: "plan", started_at: "2026-08-08", dir: "workflows/wf-1" },
+            { id: "wf-2", type: "plan", started_at: "2026-08-08", dir: "workflows/wf-2" },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    try {
+      const plugin = await MorningStarHarnessPlugin();
+      const beforeWrite = plugin["tool.execute.before"];
+      const errors: string[] = [];
+      const original = console.error;
+      console.error = (message?: unknown) => {
+        errors.push(String(message));
+      };
+      try {
+        await beforeWrite!(
+          { tool: "edit", sessionID: "s1", callID: "c1" },
+          { args: { filePath: statusPath, oldString: '"type": "plan"', newString: '"type": "sprint"' } },
+        );
+      } finally {
+        console.error = original;
+      }
+      expect(errors.filter((e) => e.includes("[mstar-harness]"))).toEqual([]);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/skills/mstar-audit/SKILL.md
+++ b/skills/mstar-audit/SKILL.md
@@ -176,7 +176,7 @@ Follow `plan.main.md` template + **plan-quality-bar**. Additional audit-specific
 - **Planned at**: commit `<short SHA>`, <YYYY-MM-DD>
 ```
 
-> **Engine check (when available):** run `mstar audit scaffold <findings-file> [--dir <out-dir>]` (or `import { scaffoldAuditPlan, validateAuditStatusBlocks, redactSecrets } from "@mstar-harness/engine"` in a host hook) to scaffold the `audit-<date>/` plan directory (numbered plan files + README index) from findings, validate the audit Status blocks above, and redact credentials from audit excerpts. On `fail` -> do not proceed; fix and re-run. Skill text below remains authoritative when the runtime is absent.
+> **Engine check (when available):** run `mstar audit scaffold <findings-file> [--dir <out-dir>]` (or `import { scaffoldAuditPlan, validateAuditStatusBlocks } from "@mstar-harness/engine"` in a host hook) to scaffold the `audit-<date>/` plan directory (numbered plan files + README index) from findings, validate the audit Status blocks above, and redact credentials from audit excerpts. On `fail` -> do not proceed; fix and re-run. Skill text below remains authoritative when the runtime is absent.
 
 ## Handoff to execution
 


### PR DESCRIPTION
## Summary

Iteration `iter-20260822-residual-cleanup`: closes the final 7 deferred residuals (audit-2026-08-16/21). Register now has **0 open residuals**.

## Plans

| plan_id | Changes | QC | QA |
|---------|---------|----|----|
| `20260822-engine-cleanup` | f3 empty migrate register skip · f4 `writeJson<T>` typed persistence (6 casts removed) · f11 redactSecrets barrel removal + dsh subpath | Approve 3/3 | Pass |
| `20260822-gate-fixes` | f8 opencode edit post-patch validation (classify-first + invalid-json sentinel) · f9 dsh degraded-hard advisory · f12 terminalStatusCache eviction | Approve 3/3 | Pass |
| `20260822-validator-closure` | audit-004 closure-verification (5 commands already landed; smoke + fragment + residual close) | Approve 3/3 (qc2 reconcile) | Pass |

## Compound

3 knowledge docs crystallized (host-gate post-state validation / writeJson\<T\> / residual closure-verification) + CONCEPTS term. Roadmap audit tables fully resolved.

## Test evidence

- engine: 841 pass, opencode: 78, dsh: 1034
- typecheck / drift-lint / standalone-smoke: green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches coordination-doc write gates (OpenCode edit lint, dsh status-gate advisories, workflow-selection cache) and a breaking engine barrel export for `redactSecrets`. Persistence and migrate skip-empty-register changes are small but sit on status/register write paths.
> 
> **Overview**
> Closes the last deferred residuals with engine persistence/API cleanup, host-gate correctness, and verification-only CLI closure (no new validator commands).
> 
> **Engine:** `writeJson` is now generic so status/snapshot/register writers drop `as unknown as Record` casts. Migrate skips writing an empty `{ entries: {} }` project register (still validates first). `redactSecrets` is **removed from the `@mstar-harness/engine` barrel** (breaking for bare-package importers) and published on `@mstar-harness/engine/src/audit`; dsh seams import that subpath only (pure function — not stateful engine APIs).
> 
> **Host gates:** OpenCode `edit` now classifies first, then lints a synthesized post-patch doc for unique literal `oldString`/`newString` (fallback to pre-edit when fuzzy/ambiguous; invalid JSON uses a `null` sentinel so validators report `invalid-doc`, not `migration-required`). Dsh degraded status-gate advisories now carry actual `hard` enforcement. Terminal workflow-selection cache **evicts** deleted snapshot/dir keys so they no longer pin the cap.
> 
> **Docs/process:** Adds the *closure-verification plan* concept; skill callout no longer lists `redactSecrets` on the barrel. Validator CLI residual is closed by smoke evidence only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa26f01d41d9979f3a05f1abf8f276a3c5e2a48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->