### PR TITLE
feat(harness): pr-deep-review command + mstar-audit pr variant

### DIFF
--- a/.changes/unreleased/pr-deep-review.md
+++ b/.changes/unreleased/pr-deep-review.md
@@ -1,0 +1,9 @@
+---
+category: Harness
+packages: root, opencode
+---
+
+- Added a **generic deep PR review** command (`pr-deep-review`) + `mstar-audit` `pr` scope variant: worktree-isolated, evidence-first, verdict-producing review with concern lenses, linked-issue hygiene, and batch sibling-PR support.
+
+<!-- CN -->
+- 新增通用 PR 深度审查命令（`pr-deep-review`）+ `mstar-audit` `pr` variant：worktree 隔离、证据先行、合并前审查结论（`ship it` / `needs review` / `blocked`）、关联工单 AC 卫生与兄弟 PR 批量支持。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,13 +175,9 @@ If one of these checks fails, stop and report why.
 
 ## Local maintenance workspace (`.mstar/`, gitignored)
 
-The repo's harness root is **`.mstar/`** (the `mstar-plan-conventions` consumer default — same convention consumer projects use): `status.json`, `plans/`, `iterations/`, `knowledge/`, `sdd/`, `projects/`, `archived/` and in-progress maint docs all live under `.mstar/`.
+The repo's harness root is **`.mstar/`** (the `mstar-plan-conventions` consumer default — same convention consumer projects use): `status.json`, `workflows/`, `plans/`, `sdd/`, `iterations/`, `projects/`, `knowledge/`, `references/`, `specs/`, `archived/` and in-progress maint docs all live under `.mstar/`.
 
-| Path | Purpose |
-|------|---------|
-| `.mstar/docs/` | Design specs, decomposition notes, ADRs, reports for harness changes |
-
-**No tracked references to gitignored harness artifacts.** Tracked `*.ts` / `*.md` files must not cite paths under `.mstar/` (e.g. `.mstar/status.json`, `.mstar/plans/<id>.md`, `.mstar/references/*.md`, `.mstar/iterations/…`, `.mstar/sdd/…`, `.mstar/docs/…`, `.mstar/knowledge/…`): those files exist only in the local checkout, so references break fresh clones and CI. Refer to `{HARNESS_DIR}` / the consumer default (`.mstar/` → `.agents/` → `.plans/`/`plans/`) or a repo `.mstarc` declaration instead. This section is the maintenance contract that documents the local layout; the rule applies to all other tracked files.
+**No tracked references to gitignored harness artifacts.** Tracked `*.ts` / `*.md` files must not cite paths under `.mstar/` (e.g. `.mstar/status.json`, `.mstar/plans/<id>.md`, `.mstar/references/*.md`, `.mstar/iterations/…`, `.mstar/sdd/…`, `.mstar/knowledge/…`): those files exist only in the local checkout, so references break fresh clones and CI. Refer to `{HARNESS_DIR}` / the consumer default (`.mstar/` → `.agents/` → `.plans/`/`plans/`) or a repo `.mstarc` declaration instead. This section is the maintenance contract that documents the local layout; the rule applies to all other tracked files.
 
 **Runtime SSOT** for `mstar-*` skills stays in repo-root **`skills/`** (bundled via `packages/opencode` `bundle-assets`).
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Enter PM, then run the per-plan cycle: `Prepare → Execute → QC → QA gate �
 
 | Command | When |
 |---------|------|
-| `/pr-deep-review [pr|branch|scope] [full]` | Deep, evidence-first review of a pull request / branch / diff before merge → one verdict (`ship it` / `needs review` / `blocked`).<br>Worktree-isolated, read-only; findings can turn into plans for Prepare → Execute.<br>`full` — surface all findings instead of top 1–3.<br>SSOT → `mstar-audit` (`pr` variant). |
+| `/pr-deep-review [pr\|branch\|scope] [full]` | Deep, evidence-first review of a pull request / branch / diff before merge → one verdict (`ship it` / `needs review` / `blocked`).<br>Worktree-isolated, read-only; findings can turn into plans for Prepare → Execute.<br>`full` — surface all findings instead of top 1–3.<br>SSOT → `mstar-audit` (`pr` variant). |
 
 Phase 2 defaults: per-plan worktree + lease, `Findings cleanup: zero-residual`. Override only with explicit `Worktree mode: waived` / `Findings cleanup: allow-residual`. SSOT → `mstar-iteration`, `mstar-branch-worktree`, `mstar-plan-artifacts`.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ English / [中文](README_CN.md)
 [![Version](https://img.shields.io/github/v/release/btspoony/mstar-harness?include_prereleases&sort=semver&label=version&style=flat-square&labelColor=black&color=c4f042)](https://github.com/btspoony/mstar-harness/releases)
 [![Last commit](https://img.shields.io/github/last-commit/btspoony/mstar-harness?color=c4f042&labelColor=black&style=flat-square)](https://github.com/btspoony/mstar-harness/commits/main)
 [![dshfind](https://dshfind.com/api/badge/btspoony/mstar-harness?lang=en)](https://dshfind.com/zh/plugins/btspoony/mstar-harness?ref=badge)
-[![featured on dsh-suite](https://img.shields.io/badge/featured%20on-dsh--suite-4d6bfe)](https://whyihaveyou.github.io/dsh-suite/)
 [![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -103,16 +103,11 @@ Enter PM, then run the per-plan cycle: `Prepare → Execute → QC → QA gate �
 |---------|------|
 | `/codebase-audit [keywords]` | Read-only survey → prioritized, self-contained plans in `{PLAN_DIR}/audit-<date>/`.<br>Never edits source. Output feeds `/iteration-start` Research or normal Prepare → Execute.<br>Effort: `quick` / `deep` (default `standard`).<br>Scope: category focus (`security`, `perf`, `tests`, …); `branch` (current-branch changes only); `next` / `roadmap` (direction candidates only); `simplify` (DEBT-focused deep pass).<br>SSOT → `mstar-audit`. |
 
-### Command loading
+### PR deep review
 
-| Host | How commands load |
-|------|-------------------|
-| dsh (DeepSeek Harness) | `/iteration-start` · `/iteration-drive` · `/iteration-loop` · `/codebase-audit` (bundled `harness-commands/` via `ctx.commands`) |
-| omp | `/iteration-start` · `/iteration-drive` · `/iteration-loop` · `/codebase-audit` (filename commands from plugin `commands/`) |
-| OpenCode / Cursor | Bundled from `commands/` (OpenCode: plugin `harness-commands/`) |
-| Kimi / ZCode | `/morning-star-harness:iteration-start` · `:codebase-audit` (etc.) via plugin manifest |
-| Codex project | `.agents/skills/<name>/SKILL.md` (CLI symlinks from `commands/`) |
-| Codex global | Project-scoped commands **not** installed — use `--scope project` |
+| Command | When |
+|---------|------|
+| `/pr-deep-review [pr|branch|scope] [full]` | Deep, evidence-first review of a pull request / branch / diff before merge → one verdict (`ship it` / `needs review` / `blocked`).<br>Worktree-isolated, read-only; findings can turn into plans for Prepare → Execute.<br>`full` — surface all findings instead of top 1–3.<br>SSOT → `mstar-audit` (`pr` variant). |
 
 Phase 2 defaults: per-plan worktree + lease, `Findings cleanup: zero-residual`. Override only with explicit `Worktree mode: waived` / `Findings cleanup: allow-residual`. SSOT → `mstar-iteration`, `mstar-branch-worktree`, `mstar-plan-artifacts`.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -110,8 +110,6 @@ npm i -g @mstar-harness/cli
 |------|------|
 | `/pr-deep-review [pr\|branch\|scope] [full]` | 合并前对 PR / 分支 / diff 做证据先行的深度审查 → 单一结论（`ship it` / `needs review` / `blocked`）。<br>worktree 隔离、只读；发现可转为 plan 进入 Prepare → Execute。<br>`full` — 展示全部发现（默认只列 top 1–3）。<br>SSOT → `mstar-audit`（`pr` variant）。 |
 
-
-
 Phase 2 默认：每 plan worktree + lease，`Findings cleanup: zero-residual`。仅显式 `Worktree mode: waived` / `Findings cleanup: allow-residual` 可覆写。SSOT → `mstar-iteration`、`mstar-branch-worktree`、`mstar-plan-artifacts`。
 
 项目知识脚手架：`mstar-compound-refresh` → `references/project-knowledge-bootstrap.md`。

--- a/README_CN.md
+++ b/README_CN.md
@@ -104,16 +104,13 @@ npm i -g @mstar-harness/cli
 |------|------|
 | `/codebase-audit [关键词]` | 只读扫描 → 向 `{PLAN_DIR}/audit-<date>/` 写入优先级排序、自包含的改进计划。<br>不改源码。产出可喂给 `/iteration-start` Research 或常规 Prepare → Execute。<br>深度：`quick` / `deep`（默认 `standard`）。<br>范围：按类别聚焦（`security`、`perf`、`tests`、…）；`branch`（仅当前分支变更）；`next` / `roadmap`（仅方向候选）；`simplify`（聚焦技术债的深扫）。<br>SSOT → `mstar-audit`。 |
 
-### 命令加载
+### PR 深度审查
 
-| 宿主 | 命令加载 |
-|------|----------|
-| dsh（DeepSeek Harness） | `/iteration-start` · `/iteration-drive` · `/iteration-loop` · `/codebase-audit`（打包的 `harness-commands/`，经 `ctx.commands`） |
-| omp | `/iteration-start` · `/iteration-drive` · `/iteration-loop` · `/codebase-audit`（插件 `commands/` 文件名命令） |
-| OpenCode / Cursor | 从 `commands/` 打包（OpenCode：插件 `harness-commands/`） |
-| Kimi / ZCode | 插件 manifest：`/morning-star-harness:iteration-start` · `:codebase-audit` 等 |
-| Codex project | `.agents/skills/<name>/SKILL.md`（CLI 从 `commands/` 软链） |
-| Codex global | **不**装 project 命令 — 用 `--scope project` |
+| 命令 | 何时 |
+|------|------|
+| `/pr-deep-review [pr\|branch\|scope] [full]` | 合并前对 PR / 分支 / diff 做证据先行的深度审查 → 单一结论（`ship it` / `needs review` / `blocked`）。<br>worktree 隔离、只读；发现可转为 plan 进入 Prepare → Execute。<br>`full` — 展示全部发现（默认只列 top 1–3）。<br>SSOT → `mstar-audit`（`pr` variant）。 |
+
+
 
 Phase 2 默认：每 plan worktree + lease，`Findings cleanup: zero-residual`。仅显式 `Worktree mode: waived` / `Findings cleanup: allow-residual` 可覆写。SSOT → `mstar-iteration`、`mstar-branch-worktree`、`mstar-plan-artifacts`。
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -15,7 +15,6 @@ Harness Workflow Engine · Agent Plugin
 [![Version](https://img.shields.io/github/v/release/btspoony/mstar-harness?include_prereleases&sort=semver&label=version&style=flat-square&labelColor=black&color=c4f042)](https://github.com/btspoony/mstar-harness/releases)
 [![Last commit](https://img.shields.io/github/last-commit/btspoony/mstar-harness?color=c4f042&labelColor=black&style=flat-square)](https://github.com/btspoony/mstar-harness/commits/main)
 [![dshfind](https://dshfind.com/api/badge/btspoony/mstar-harness?lang=zh)](https://dshfind.com/zh/plugins/btspoony/mstar-harness?ref=badge)
-[![featured on dsh-suite](https://img.shields.io/badge/featured%20on-dsh--suite-4d6bfe)](https://whyihaveyou.github.io/dsh-suite/)
 [![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 </div>

--- a/commands/pr-deep-review.md
+++ b/commands/pr-deep-review.md
@@ -30,7 +30,7 @@ The `code-reviewer` seat is **read-only**: never edits the reviewed worktree, ne
 
 ## Execute
 
-Execute **`mstar-audit`** § `pr` variant end to end（scope → guidance load → concern lenses → evidence → three-way attack & vet → verdict → output）. Review is run in a dedicated worktree against `git diff origin/main...HEAD` — see `references/pr-review.md` for the full process.
+Execute **`mstar-audit`** § `pr` variant end to end（scope → guidance load → concern lenses → evidence → three-way attack & vet → verdict → output）. Review is run in a dedicated worktree against a diff from the PR's **real base** — resolve the base per `references/pr-review.md` § Worktree isolation (never assume `main`).
 
 Review findings that need fixing can be turned into self-contained plans for the normal Prepare → Execute flow (reusing **`mstar-audit`** Phase 4 + Handoff).
 

--- a/commands/pr-deep-review.md
+++ b/commands/pr-deep-review.md
@@ -26,7 +26,7 @@ Run a read-only, evidence-first deep review of a pull request, branch, or diff a
 | **Small PR / single pass** | PM dispatches a single `@code-reviewer` — review, then vet and synthesize the verdict |
 | **Batch of sibling PRs** | PM 按 PR 业务信息（业务域 / 变更面 / 技术栈）**平均分配**到四个席位：`@code-reviewer`（general）、`@fullstack-dev`、`@fullstack-dev-2`、`@frontend-dev` — 每个席位承载约 N/4 个 PR，摊薄同模型并发，降低 rate-limit。All worktrees created first, then all reviewers dispatched in one batch; each reviewer owns review + comment for its PRs only |
 
-All review seats (`code-reviewer` / `fullstack-dev` / `fullstack-dev-2` / `frontend-dev`) are **read-only** in this flow: never edit the reviewed worktree, never merge, never approve-as-merge. Implementer seats run in **Audit Mode** (permission suspension + `mstar-audit` process contract → `skills/mstar-roles/references/fullstack-dev-shared.md` / `frontend-dev.md`). PM dispatches; each reviewer executes the `pr` variant and returns findings + verdict to PM for consolidation.
+All review seats (`code-reviewer` / `fullstack-dev` / `fullstack-dev-2` / `frontend-dev`) are **read-only** in this flow: never edit the reviewed worktree, never merge, never approve-as-merge. Implementer seats run in **Audit Mode** (shared contract → `mstar-roles` `references/_shared/leaf-executor-core.md`). PM dispatches; each reviewer executes the `pr` variant and returns findings + verdict to PM for consolidation.
 
 ## Execute
 

--- a/commands/pr-deep-review.md
+++ b/commands/pr-deep-review.md
@@ -24,9 +24,9 @@ Run a read-only, evidence-first deep review of a pull request, branch, or diff a
 | Context | Who runs the review |
 |---------|-------------------|
 | **Small PR / single pass** | PM dispatches a single `@code-reviewer` — review, then vet and synthesize the verdict |
-| **Batch of sibling PRs** | One `@code-reviewer` per PR: all worktrees created first, then all reviewers dispatched in one batch; each reviewer owns review + comment for that PR only |
+| **Batch of sibling PRs** | PM 按 PR 业务信息（业务域 / 变更面 / 技术栈）**平均分配**到四个席位：`@code-reviewer`（general）、`@fullstack-dev`、`@fullstack-dev-2`、`@frontend-dev` — 每个席位承载约 N/4 个 PR，摊薄同模型并发，降低 rate-limit。All worktrees created first, then all reviewers dispatched in one batch; each reviewer owns review + comment for its PRs only |
 
-The `code-reviewer` seat is **read-only**: never edits the reviewed worktree, never merges, never approves-as-merge. PM dispatches; the reviewer executes the `pr` variant and returns findings + verdict to PM for presentation.
+All review seats (`code-reviewer` / `fullstack-dev` / `fullstack-dev-2` / `frontend-dev`) are **read-only** in this flow: never edit the reviewed worktree, never merge, never approve-as-merge. PM dispatches; each reviewer executes the `pr` variant and returns findings + verdict to PM for consolidation.
 
 ## Execute
 

--- a/commands/pr-deep-review.md
+++ b/commands/pr-deep-review.md
@@ -26,7 +26,7 @@ Run a read-only, evidence-first deep review of a pull request, branch, or diff a
 | **Small PR / single pass** | PM dispatches a single `@code-reviewer` — review, then vet and synthesize the verdict |
 | **Batch of sibling PRs** | PM 按 PR 业务信息（业务域 / 变更面 / 技术栈）**平均分配**到四个席位：`@code-reviewer`（general）、`@fullstack-dev`、`@fullstack-dev-2`、`@frontend-dev` — 每个席位承载约 N/4 个 PR，摊薄同模型并发，降低 rate-limit。All worktrees created first, then all reviewers dispatched in one batch; each reviewer owns review + comment for its PRs only |
 
-All review seats (`code-reviewer` / `fullstack-dev` / `fullstack-dev-2` / `frontend-dev`) are **read-only** in this flow: never edit the reviewed worktree, never merge, never approve-as-merge. PM dispatches; each reviewer executes the `pr` variant and returns findings + verdict to PM for consolidation.
+All review seats (`code-reviewer` / `fullstack-dev` / `fullstack-dev-2` / `frontend-dev`) are **read-only** in this flow: never edit the reviewed worktree, never merge, never approve-as-merge. Implementer seats run in **Audit Mode** (permission suspension + `mstar-audit` process contract → `skills/mstar-roles/references/fullstack-dev-shared.md` / `frontend-dev.md`). PM dispatches; each reviewer executes the `pr` variant and returns findings + verdict to PM for consolidation.
 
 ## Execute
 

--- a/commands/pr-deep-review.md
+++ b/commands/pr-deep-review.md
@@ -1,0 +1,37 @@
+---
+name: pr-deep-review
+description: Use when asked to deeply review a pull request, branch, or diff before merge — deciding whether a change is safe to ship with evidence-backed findings, rather than a shallow "looks good" pass. Produces a `ship it` / `needs review` / `blocked` verdict. Also for a batch of sibling PRs. Do not use for self-checking a change you just authored.
+agent: project-manager
+input: "[pr|branch|scope] [full]"
+---
+
+# Deep PR Review
+
+Run a read-only, evidence-first deep review of a pull request, branch, or diff and decide whether it is safe to ship. Output: verdict + findings presented to the user; optional `gh pr comment` is a separate explicit step — never auto-approve or merge.
+
+**Read-only advisory.** The review does not enter the harness plan state machine (`Todo → InProgress → InReview → Done`). Reviewers never edit the worktree, never merge, and never approve-as-merge.
+
+## Boot
+
+1. `mstar-harness-core`
+2. `mstar-audit` → SKILL.md（`pr` scope variant + references）
+3. `mstar-coding-behavior` (evidence discipline)
+4. `mstar-branch-worktree` (worktree isolation)
+5. `mstar-host` → active host reference (invoke capability for parallel subagents)
+
+## Routing（谁执行 review）
+
+| Context | Who runs the review |
+|---------|-------------------|
+| **Small PR / single pass** | PM dispatches a single `@code-reviewer` — review, then vet and synthesize the verdict |
+| **Batch of sibling PRs** | One `@code-reviewer` per PR: all worktrees created first, then all reviewers dispatched in one batch; each reviewer owns review + comment for that PR only |
+
+The `code-reviewer` seat is **read-only**: never edits the reviewed worktree, never merges, never approves-as-merge. PM dispatches; the reviewer executes the `pr` variant and returns findings + verdict to PM for presentation.
+
+## Execute
+
+Execute **`mstar-audit`** § `pr` variant end to end（scope → guidance load → concern lenses → evidence → three-way attack & vet → verdict → output）. Review is run in a dedicated worktree against `git diff origin/main...HEAD` — see `references/pr-review.md` for the full process.
+
+Review findings that need fixing can be turned into self-contained plans for the normal Prepare → Execute flow (reusing **`mstar-audit`** Phase 4 + Handoff).
+
+Output verdict + findings to the user; `gh pr comment` is a separate explicit step — never auto-approve or merge.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,8 +157,7 @@ dsh plugin --profile web add dsh-llm-fallbacks
 # or, from a local checkout:
 cd <repo>/packages/dsh && dsh plugin --profile web add .
 ```
-
-`dsh web` then boots the harness: in-process engine gates (status/dispatch/lease/worktree/seams), the bundled `mstar-*` skills mount, and the bundled slash commands (`/iteration-start`, `/iteration-drive`, `/iteration-loop`, `/codebase-audit`). Host behavior (tools, gates, enforcement, PM dispatch) → **`mstar-host`** → `references/dsh.md`; package docs → [`packages/dsh/README.md`](../packages/dsh/README.md).
+`dsh web` then boots the harness: in-process engine gates (status/dispatch/lease/worktree/seams), the bundled `mstar-*` skills mount, and the bundled slash commands (`/iteration-start`, `/iteration-drive`, `/iteration-loop`, `/codebase-audit`, `/pr-deep-review`). Host behavior (tools, gates, enforcement, PM dispatch) → **`mstar-host`** → `references/dsh.md`; package docs → [`packages/dsh/README.md`](../packages/dsh/README.md).
 
 ### `mstar-harness doctor`
 
@@ -289,11 +288,12 @@ Exit codes:
 
 ## Harness Slash Commands (not CLI subcommands)
 
-`/codebase-audit` and the `/iteration-*` commands ship with the harness plugin (`commands/*.md`), not the `mstar-harness` CLI binary. Host availability: dsh / omp / OpenCode / Cursor load them from the plugin; Kimi / ZCode expose `/morning-star-harness:<name>`; Codex installs them as project-local skills (`--scope project`). See the command-loading table in [README.md](../README.md#codebase-audit).
+`/codebase-audit`, `/pr-deep-review`, and the `/iteration-*` commands ship with the harness plugin (`commands/*.md`), not the `mstar-harness` CLI binary. Host availability: dsh / omp / OpenCode / Cursor load them from the plugin; Kimi / ZCode expose `/morning-star-harness:<name>`; Codex installs them as project-local skills (`--scope project`). See the command-loading table in [README.md](../README.md#codebase-audit).
+### `/pr-deep-review`
+
+Deep, evidence-first review of a pull request / branch / diff before merge → one verdict (`ship it` / `needs review` / `blocked`). Worktree-isolated and read-only; findings that need fixing can become self-contained plans (`{PLAN_DIR}/audit-<YYYY-MM-DD>/`) for the normal Prepare → Execute flow. SSOT → `mstar-audit` `pr` variant → `references/pr-review.md`.
 
 ### `/codebase-audit`
-
-Read-only codebase survey that writes prioritized, self-contained improvement plans to `{PLAN_DIR}/audit-<YYYY-MM-DD>/` (numbered plan files + `README.md` index). Never edits source; selected plans feed the normal Prepare → Execute flow.
 
 ```text
 /codebase-audit [simplify]

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -42,10 +42,11 @@ const CODEX_PROJECT_COMMAND_NAMES = [
   "iteration-drive",
   "iteration-loop",
   "codebase-audit",
+  "pr-deep-review",
 ] as const;
 
 const GLOBAL_ITERATION_SKILLS_WARNING =
-  "Codex project-scoped commands (iteration-start / iteration-drive / iteration-loop / codebase-audit) are installed as project-local skills under .agents/skills/ only. Global install skips them to avoid polluting other code agents. Re-run with --scope project to enable.";
+  "Codex project-scoped commands (iteration-start / iteration-drive / iteration-loop / codebase-audit / pr-deep-review) are installed as project-local skills under .agents/skills/ only. Global install skips them to avoid polluting other code agents. Re-run with --scope project to enable.";
 
 type MarketplaceEntry = {
   name: string;
@@ -207,7 +208,7 @@ function ensureIterationSkillLinks(dryRun: boolean) {
   const gitignoreEntries = CODEX_PROJECT_COMMAND_NAMES.map(iterationSkillGitignoreEntry);
   notes.push(...appendGitignore(projectRoot, gitignoreEntries, dryRun));
   notes.push(
-    "Installed Codex project-scoped command skills under .agents/skills/ (iteration-start, iteration-drive, iteration-loop, codebase-audit) \u2014 symlinked to harness commands/*.md.",
+    "Installed Codex project-scoped command skills under .agents/skills/ (iteration-start, iteration-drive, iteration-loop, codebase-audit, pr-deep-review) \u2014 symlinked to harness commands/*.md.",
   );
   return notes;
 }

--- a/packages/dsh/tests/commands.spec.ts
+++ b/packages/dsh/tests/commands.spec.ts
@@ -1,9 +1,9 @@
 /**
  * Bundled mstar commands (omp parity, iteration v2.1.0 gap fill): the plugin
  * registers the packaged `harness-commands/*.md` mirror (synced from the
- * repo root by `bundle-assets`; gitignored) on `ctx.commands` — the four
+ * repo root by `bundle-assets`; gitignored) on `ctx.commands` — the five
  * mstar slash commands (`iteration-start`, `iteration-drive`,
- * `iteration-loop`, `codebase-audit`), matching the omp/opencode command
+ * `iteration-loop`, `codebase-audit`, `pr-deep-review`), matching the omp/opencode command
  * surface. Each registered command's handler steers the command body into
  * the receiving agent as a user message (the dsh-commands "explicitly
  * schedule model-visible work through the receiving Agent" path).
@@ -37,8 +37,8 @@ function packagedCommandsDir(): string | undefined {
   return existsSync(dir) ? dir : undefined
 }
 
-/** The four mstar slash commands (repo-root `commands/` mirror). */
-const MSTAR_COMMANDS = ['iteration-start', 'iteration-drive', 'iteration-loop', 'codebase-audit'] as const
+/** The five mstar slash commands (repo-root `commands/` mirror). */
+const MSTAR_COMMANDS = ['iteration-start', 'iteration-drive', 'iteration-loop', 'codebase-audit', 'pr-deep-review'] as const
 
 /** The frontmatter `input` hint each command must advertise (the client-claim contract). */
 const EXPECTED_HINTS: Readonly<Record<(typeof MSTAR_COMMANDS)[number], string>> = {
@@ -46,6 +46,7 @@ const EXPECTED_HINTS: Readonly<Record<(typeof MSTAR_COMMANDS)[number], string>> 
   'iteration-loop': '[direction] [scale]',
   'iteration-drive': '[no args]',
   'codebase-audit': '[simplify]',
+  'pr-deep-review': '[pr|branch|scope] [full]',
 }
 
 /** One command's registered descriptor (the view the dsh web client resolves). */
@@ -95,7 +96,7 @@ function commandBody(dir: string, name: string): string {
 }
 
 describe('bundled mstar commands (omp parity)', () => {
-  it('registers the four mstar commands on ctx.commands from the packaged mirror', async () => {
+  it('registers the five mstar commands on ctx.commands from the packaged mirror', async () => {
     const dir = packagedCommandsDir()
     if (dir === undefined) {
       // bundle-assets has not run — nothing to register.

--- a/skills/mstar-audit/SKILL.md
+++ b/skills/mstar-audit/SKILL.md
@@ -128,6 +128,7 @@ If an audit directory from a previous run exists, **reconcile, don't duplicate**
 | `branch` | Current branch changes only | Files changed since merge-base with default branch + their direct importers. Tag every finding `introduced` or `pre-existing` |
 | `next` / `roadmap` | Direction category only, in depth | 4–6 grounded suggestions; selected ones become design/spike plans |
 | `simplify` | DEBT-focused deep pass: dead / duplicated / speculative / over-built / added-then-removed / hand-rolled-where-a-dependency-exists surfaces | Prove-or-reject per playbook §5; findings use Category DEBT; tiny-real items → "considered and rejected" rows, never inline TODOs (Hard Rule 1) |
+| `pr` | A single PR / branch / diff, deep review | Evidence-first review producing a verdict (`ship it` / `needs review` / `blocked`); read-only, stays outside the plan state machine — process detail in `references/pr-review.md` |
 
 ## Output format
 
@@ -201,3 +202,4 @@ Workflow, audit playbook, and finding format adapted from the [improve](https://
 
 - `references/audit-playbook.md` — nine-category audit checklist with finding format and prioritization rubric
 - `references/finding-format.md` — structured finding shape and evidence requirements
+- `references/pr-review.md` — deep PR-review process: worktree isolation, concern lenses, evidence rules, verdict synthesis, linked-issue hygiene, batch review

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -5,9 +5,8 @@ Read-only, evidence-first review of a pull request / branch / diff, producing ex
 ## Worktree isolation
 
 - **Resolve the real base first** — never assume `main`:
-  - Reviewing a PR: `gh pr view <n> --json baseRefName --jq .baseRefName` → `<base>`.
+  - Reviewing a PR: `gh pr view N --json baseRefName --jq .baseRefName` → `<base>`.
   - Reviewing a bare branch/diff: resolve the remote default via `git symbolic-ref refs/remotes/origin/HEAD` (fall back to `origin/main` only when it genuinely is the default).
-  - `git fetch origin <base>`, then use `git diff origin/<base>...HEAD` as the diff basis (three-dot: changes on the reviewed branch since the merge-base).
 - Choose the local branch name **before any fetch** — `pr-<n>` may already exist (a stale review, another reviewer's branch, the user's own branch); the fallback must also be collision-free, so loop until the recorded name is provably fresh:
   ```
   review_branch=pr-<n>
@@ -17,15 +16,20 @@ Read-only, evidence-first review of a pull request / branch / diff, producing ex
   done
   ```
   Record the final name as `<review-branch>` — it did not exist before this review created it.
-- Check the PR out into a **dedicated worktree** — never the primary repo cwd, never another harness worktree:
+- Establish the refs **with explicit refspecs**, then create the dedicated worktree — never the primary repo cwd, never another harness worktree:
   ```
-  git fetch origin <base>
+  git fetch origin +refs/heads/<base>:refs/remotes/origin/<base>
   git fetch origin pull/<n>/head:<review-branch>
   git worktree add <path> <review-branch>
   cd <path>   # review from here — a new linked worktree, cannot touch the primary checkout
   ```
-  Do **not** use `gh pr checkout <n>` as an alternative: it switches to the PR-head branch name (not the recorded `<review-branch>`) and bypasses the ownership protocol, so cleanup could delete the wrong ref or leave the gh-created branch behind. If you only have a PR ref, fetch it into the recorded name and `git worktree add` exactly as above.
-- Record before reviewing: review cwd, `<review-branch>`, HEAD sha, merge-base.
+  The explicit `+refs/heads/<base>:refs/remotes/origin/<base>` refspec updates the remote-tracking ref even on single-branch/narrowed `fetch` configs, so `origin/<base>` is never stale or missing. Do **not** use `gh pr checkout <n>` as an alternative: it switches to the PR-head branch name (not the recorded `<review-branch>`) and bypasses the ownership protocol. If you only have a PR ref, fetch it into the recorded name and `git worktree add` exactly as above.
+- Compute the diff basis **inside the worktree, against the recorded refs — never the primary `HEAD`** (the primary checkout may sit on a different branch):
+  ```
+  cd <path>
+  git diff origin/<base>...<review-branch>   # three-dot: changes on the reviewed branch since the merge-base
+  ```
+- Record before computing: review cwd, `<review-branch>`, HEAD sha, merge-base.
 - Clean up after the review (and after the comment is posted): `git worktree remove <path>` + `git worktree prune`, then delete **exactly** the recorded `<review-branch>` — it was verified not to exist before the fetch created it, so it is provably this review's own branch; never delete a pre-existing branch. Never remove other harness worktrees.
 
 ## Scoping

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -98,7 +98,8 @@ Check base-vs-branch before blaming the diff for CI failures. A red build that p
 
 - One worktree + one reviewer per PR.
 - All worktrees created **first**; all reviewers dispatched in **one batch**.
-- PM 按 PR 业务信息（业务域 / 变更面 / 技术栈）将 batch **平均分配**到四个席位（`code-reviewer` general、`fullstack-dev`、`fullstack-dev-2`、`frontend-dev`），每席位约 N/4 个 PR —— 摊薄同模型并发，降低 rate-limit。
+- PM 按 PR 业务信息（业务域 / 变更面 / 技术栈）将 batch **平均**分配到四个席位（`code-reviewer` general、`fullstack-dev`、`fullstack-dev-2`、`frontend-dev`），每席位约 N/4 个 PR —— 摊薄同模型并发，降低 rate-limit。
+- Implementer seats (`fullstack-dev` / `fullstack-dev-2` / `frontend-dev`) run under **Audit Mode** (`mstar-roles` references: permission suspension + `mstar-audit` process) — same read-only contract as `code-reviewer`.
 - Each reviewer owns review + comment for that PR only.
 - Sibling interactions are **noted, not fixed**, unless the ticket says so.
 

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -4,10 +4,20 @@ Read-only, evidence-first review of a pull request / branch / diff, producing ex
 
 ## Worktree isolation
 
-- `git fetch origin main` first, then use `git diff origin/main...HEAD` as the diff basis (three-dot: changes on the PR branch since the merge-base).
-- Check the PR out with `gh pr checkout <n>` into a **dedicated worktree** — never the primary repo cwd, never another harness worktree.
+- **Resolve the real base first** — never assume `main`:
+  - Reviewing a PR: `gh pr view <n> --json baseRefName --jq .baseRefName` → `<base>`.
+  - Reviewing a bare branch/diff: resolve the remote default via `git symbolic-ref refs/remotes/origin/HEAD` (fall back to `origin/main` only when it genuinely is the default).
+  - `git fetch origin <base>`, then use `git diff origin/<base>...HEAD` as the diff basis (three-dot: changes on the reviewed branch since the merge-base).
+- Check the PR out into a **dedicated worktree** — never the primary repo cwd, never another harness worktree:
+  ```
+  git fetch origin <base>
+  git fetch origin pull/<n>/head:pr-<n>   # or gh pr checkout <n> inside the worktree
+  git worktree add <path> pr-<n>
+  cd <path>   # review from here
+  ```
+  If you use the `gh pr checkout <n>` alternative, run it **from inside the worktree directory** (`cd <path>` first) — never from the primary cwd.
 - Record before reviewing: review cwd, local branch (`pr-<n>`), HEAD sha, merge-base.
-- Cleanup after the review (and after the comment is posted): `git worktree remove <path>`, delete the local branch, `git worktree prune`. Never remove other harness worktrees.
+- Clean up after the review (and after the comment is posted): `git worktree remove <path>` + `git worktree prune`, then delete **only the branch this review created** — verify it exists and that you created it (e.g. `git show-ref --verify refs/heads/pr-<n>` after confirming the fetch created it) before deleting; never delete a pre-existing PR-head branch. Never remove other harness worktrees.
 
 ## Scoping
 
@@ -73,7 +83,7 @@ Check base-vs-branch before blaming the diff for CI failures. A red build that p
 ## Comment triage
 
 - Judge the validity of bot/peer review comments before acting on them.
-- Fix minimally, or disagree with clear reasoning. Never gold-plate.
+- The reviewer seat is read-only — never edit the reviewed worktree. For valid comments, fold the minimal fix suggestion into the finding/plan (plan output) for the Prepare → Execute flow. For invalid comments, disagree on the PR comment with clear reasoning. Never gold-plate.
 
 ## Batch sibling PRs
 

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -8,20 +8,23 @@ Read-only, evidence-first review of a pull request / branch / diff, producing ex
   - Reviewing a PR: `gh pr view <n> --json baseRefName --jq .baseRefName` → `<base>`.
   - Reviewing a bare branch/diff: resolve the remote default via `git symbolic-ref refs/remotes/origin/HEAD` (fall back to `origin/main` only when it genuinely is the default).
   - `git fetch origin <base>`, then use `git diff origin/<base>...HEAD` as the diff basis (three-dot: changes on the reviewed branch since the merge-base).
-- Choose the local branch name **before any fetch** — `pr-<n>` may already exist (a stale review, another reviewer's branch, the user's own branch):
+- Choose the local branch name **before any fetch** — `pr-<n>` may already exist (a stale review, another reviewer's branch, the user's own branch); the fallback must also be collision-free, so loop until the recorded name is provably fresh:
   ```
   review_branch=pr-<n>
-  git rev-parse --verify --quiet refs/heads/$review_branch && review_branch=pr-<n>-$(date +%Y%m%d)
+  i=1
+  while git rev-parse --verify --quiet refs/heads/$review_branch; do
+    review_branch=pr-<n>-$(date +%Y%m%d)-$((i++))
+  done
   ```
-  If the name is taken, fall back to a unique one (`pr-<n>-<YYYYMMDD>`; append a counter if that collides too), and record the final name as `<review-branch>`.
+  Record the final name as `<review-branch>` — it did not exist before this review created it.
 - Check the PR out into a **dedicated worktree** — never the primary repo cwd, never another harness worktree:
   ```
   git fetch origin <base>
   git fetch origin pull/<n>/head:<review-branch>
   git worktree add <path> <review-branch>
-  cd <path>   # review from here
+  cd <path>   # review from here — a new linked worktree, cannot touch the primary checkout
   ```
-  If you use the `gh pr checkout <n>` alternative, run it **from inside the worktree directory** (`cd <path>` first) — never from the primary cwd.
+  Do **not** use `gh pr checkout <n>` as an alternative: it switches to the PR-head branch name (not the recorded `<review-branch>`) and bypasses the ownership protocol, so cleanup could delete the wrong ref or leave the gh-created branch behind. If you only have a PR ref, fetch it into the recorded name and `git worktree add` exactly as above.
 - Record before reviewing: review cwd, `<review-branch>`, HEAD sha, merge-base.
 - Clean up after the review (and after the comment is posted): `git worktree remove <path>` + `git worktree prune`, then delete **exactly** the recorded `<review-branch>` — it was verified not to exist before the fetch created it, so it is provably this review's own branch; never delete a pre-existing branch. Never remove other harness worktrees.
 
@@ -95,6 +98,7 @@ Check base-vs-branch before blaming the diff for CI failures. A red build that p
 
 - One worktree + one reviewer per PR.
 - All worktrees created **first**; all reviewers dispatched in **one batch**.
+- PM 按 PR 业务信息（业务域 / 变更面 / 技术栈）将 batch **平均分配**到四个席位（`code-reviewer` general、`fullstack-dev`、`fullstack-dev-2`、`frontend-dev`），每席位约 N/4 个 PR —— 摊薄同模型并发，降低 rate-limit。
 - Each reviewer owns review + comment for that PR only.
 - Sibling interactions are **noted, not fixed**, unless the ticket says so.
 

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -29,6 +29,18 @@ Read-only, evidence-first review of a pull request / branch / diff, producing ex
   cd <path>
   git diff origin/<base>...<review-branch>   # three-dot: changes on the reviewed branch since the merge-base
   ```
+- **Bare branch input** (no PR number) — review the remote branch directly; no local ownership protocol needed:
+  ```
+  git fetch origin +refs/heads/<branch>:refs/remotes/origin/<branch>
+  git worktree add --detach <path> origin/<branch>   # detached worktree; creates no local branch
+  cd <path>
+  git diff origin/<base>...origin/<branch>   # three-dot against the fetched remote-tracking ref
+  ```
+  Cleanup: `git worktree remove <path>` + `git worktree prune` only — there is no local branch to delete.
+- **Arbitrary diff input** (a changeset handed to the review, no ref attached) — review the provided diff as-is:
+  - Verify its provenance first (stated base/head SHAs when present); do not invent a checkout or substitute a different ref.
+  - Read the changed files in the current directory for context; the diff itself is the isolated changeset under review.
+  - No worktree, no branch, no fetch — nothing to clean up.
 - Record before computing: review cwd, `<review-branch>`, HEAD sha, merge-base.
 - Clean up after the review (and after the comment is posted): `git worktree remove <path>` + `git worktree prune`, then delete **exactly** the recorded `<review-branch>` — it was verified not to exist before the fetch created it, so it is provably this review's own branch; never delete a pre-existing branch. Never remove other harness worktrees.
 

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -1,0 +1,103 @@
+# Deep PR Review Process
+
+Read-only, evidence-first review of a pull request / branch / diff, producing exactly one verdict: `ship it` / `needs review` / `blocked`. Runs under `mstar-audit` § `pr` variant, reusing the Recon → Audit → Vet discipline (recon = PR scope + repo guidance; vet = three-way attack). The reviewer never edits the worktree, never merges, and never approves-as-merge.
+
+## Worktree isolation
+
+- `git fetch origin main` first, then use `git diff origin/main...HEAD` as the diff basis (three-dot: changes on the PR branch since the merge-base).
+- Check the PR out with `gh pr checkout <n>` into a **dedicated worktree** — never the primary repo cwd, never another harness worktree.
+- Record before reviewing: review cwd, local branch (`pr-<n>`), HEAD sha, merge-base.
+- Cleanup after the review (and after the comment is posted): `git worktree remove <path>`, delete the local branch, `git worktree prune`. Never remove other harness worktrees.
+
+## Scoping
+
+- Review the diff basis vs base: changed files plus what the change touches.
+- Read changed files **in full** — diffs hide context.
+- Inspect adjacent behavior when risk leaks past the named diff (importers, callers, dependent contracts).
+
+## Concern lenses
+
+Generic lenses:
+
+- `general` — repo guidance compliance, bugs, security, awkward complexity. Ignore lint-covered cosmetics.
+- `technical-coverage` — behavior coverage, real-surface proof, mock-heavy seams. Ignore blanket coverage demands.
+- `silent-failures` — swallowed errors, misleading fallbacks, unclassified failures, lossy logging.
+
+Conditional lenses:
+
+- `types` — invariants, escape hatches (`any` / `as` / `unknown`), schema drift, parse-don't-validate. Apply when types carry meaning (API / data layer / migration).
+- `cleanup` — dead code, duplicate logic, indirection without value. Apply for refactors and added-then-removed surfaces.
+- `comments` — comment rot, docstring truthfulness. Apply when docs changed.
+
+**Selection by change shape** (UI / API / migration / refactor / doc / tiny mechanical). Default set = `general` + `technical-coverage` + `silent-failures`. Never spawn all lenses blindly; tiny mechanical diffs → `general` only.
+
+## Evidence rules
+
+- Static findings cite exact file references (`path/file.ts:123`).
+- Run the **smallest runtime check that changes the verdict** (targeted command, not the full suite).
+- Mark unverified explicitly — a claim without verification is a lead, not a finding.
+- Mock-heavy tests around risky behavior = a finding (no real-surface proof), not proof of correctness.
+
+## Attack and vet
+
+Before writing a finding, run the three-way attack from `mstar-audit`:
+
+1. **Counter-example** — find a boundary case that makes the claim not hold.
+2. **Simpler explanation** — does a simpler explanation cover the same evidence?
+3. **Evidence verifiability** — open the cited lines and check they actually support the claim.
+
+Then open cited code yourself and dispose by-design / mis-attributed / duplicate. Subagents over-report; vet before presenting.
+
+## Verdict synthesis
+
+- Order findings by impact-if-shipped.
+- Cut to the top 1–3 unless `full` was requested.
+- No padding, no invented requirements, no style grading.
+- Choose exactly one verdict:
+  - `ship it` — evidence-backed, safe to ship.
+  - `needs review` — issues found; address before merge.
+  - `blocked` — a must-fix issue stands in the way of shipping.
+
+## Linked-issue hygiene
+
+If the PR closes/fixes a tracked issue, score **every** acceptance criterion against the diff:
+
+- Mark each: met / unmet / cut.
+- Leftover criteria get a follow-up or a narrowed scope **before** merge, with reasoning on the review comment.
+- Do not invent a follow-up when all criteria landed.
+
+## CI attribution
+
+Check base-vs-branch before blaming the diff for CI failures. A red build that predates the branch is not a finding against the PR.
+
+## Comment triage
+
+- Judge the validity of bot/peer review comments before acting on them.
+- Fix minimally, or disagree with clear reasoning. Never gold-plate.
+
+## Batch sibling PRs
+
+- One worktree + one reviewer per PR.
+- All worktrees created **first**; all reviewers dispatched in **one batch**.
+- Each reviewer owns review + comment for that PR only.
+- Sibling interactions are **noted, not fixed**, unless the ticket says so.
+
+## Plan output（handoff to execution）
+
+Review findings that need fixing can become plans for the normal Prepare → Execute flow — same contract as `mstar-audit` Phase 4:
+
+- Write the top findings as self-contained plans (numbered `001-<slug>.md` + `README.md` index) with the same fields as `mstar-audit` Phase 4: Priority / Effort / Risk / Depends on / Category / Planned at, plus verification gates.
+- Land them in `{PLAN_DIR}/audit-<date>/` — same path convention as `mstar-audit`, no new directory layout.
+- Enter the normal flow via `mstar audit promote` (or manual registration per `mstar-plan-artifacts`).
+- The review itself stays read-only: plans are written only when the user selects findings to pursue.
+
+## Output shape
+
+Verbatim labels, in order:
+
+- `- findings:` — list of evidence-backed findings (`none` when none).
+- `- verdict:` — one of `ship it` / `needs review` / `blocked`.
+- `- evidence:` — concise what-checks-proved summary.
+- `- unverified:` — residual unverified claims, or `none`.
+- `- next:` — one of `implementation` / `verify` / `docs`.
+- `- notes:` — only out-of-scope state the user must act on.

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -99,7 +99,7 @@ Check base-vs-branch before blaming the diff for CI failures. A red build that p
 - One worktree + one reviewer per PR.
 - All worktrees created **first**; all reviewers dispatched in **one batch**.
 - PM 按 PR 业务信息（业务域 / 变更面 / 技术栈）将 batch **平均**分配到四个席位（`code-reviewer` general、`fullstack-dev`、`fullstack-dev-2`、`frontend-dev`），每席位约 N/4 个 PR —— 摊薄同模型并发，降低 rate-limit。
-- Implementer seats (`fullstack-dev` / `fullstack-dev-2` / `frontend-dev`) run under **Audit Mode** (`mstar-roles` references: permission suspension + `mstar-audit` process) — same read-only contract as `code-reviewer`.
+- Implementer seats (`fullstack-dev` / `fullstack-dev-2` / `frontend-dev`) run under **Audit Mode** (shared contract → `mstar-roles` `references/_shared/leaf-executor-core.md`) — same read-only contract as `code-reviewer`.
 - Each reviewer owns review + comment for that PR only.
 - Sibling interactions are **noted, not fixed**, unless the ticket says so.
 

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -8,16 +8,22 @@ Read-only, evidence-first review of a pull request / branch / diff, producing ex
   - Reviewing a PR: `gh pr view <n> --json baseRefName --jq .baseRefName` → `<base>`.
   - Reviewing a bare branch/diff: resolve the remote default via `git symbolic-ref refs/remotes/origin/HEAD` (fall back to `origin/main` only when it genuinely is the default).
   - `git fetch origin <base>`, then use `git diff origin/<base>...HEAD` as the diff basis (three-dot: changes on the reviewed branch since the merge-base).
+- Choose the local branch name **before any fetch** — `pr-<n>` may already exist (a stale review, another reviewer's branch, the user's own branch):
+  ```
+  review_branch=pr-<n>
+  git rev-parse --verify --quiet refs/heads/$review_branch && review_branch=pr-<n>-$(date +%Y%m%d)
+  ```
+  If the name is taken, fall back to a unique one (`pr-<n>-<YYYYMMDD>`; append a counter if that collides too), and record the final name as `<review-branch>`.
 - Check the PR out into a **dedicated worktree** — never the primary repo cwd, never another harness worktree:
   ```
   git fetch origin <base>
-  git fetch origin pull/<n>/head:pr-<n>   # or gh pr checkout <n> inside the worktree
-  git worktree add <path> pr-<n>
+  git fetch origin pull/<n>/head:<review-branch>
+  git worktree add <path> <review-branch>
   cd <path>   # review from here
   ```
   If you use the `gh pr checkout <n>` alternative, run it **from inside the worktree directory** (`cd <path>` first) — never from the primary cwd.
-- Record before reviewing: review cwd, local branch (`pr-<n>`), HEAD sha, merge-base.
-- Clean up after the review (and after the comment is posted): `git worktree remove <path>` + `git worktree prune`, then delete **only the branch this review created** — verify it exists and that you created it (e.g. `git show-ref --verify refs/heads/pr-<n>` after confirming the fetch created it) before deleting; never delete a pre-existing PR-head branch. Never remove other harness worktrees.
+- Record before reviewing: review cwd, `<review-branch>`, HEAD sha, merge-base.
+- Clean up after the review (and after the comment is posted): `git worktree remove <path>` + `git worktree prune`, then delete **exactly** the recorded `<review-branch>` — it was verified not to exist before the fetch created it, so it is provably this review's own branch; never delete a pre-existing branch. Never remove other harness worktrees.
 
 ## Scoping
 

--- a/skills/mstar-roles/references/_shared/leaf-executor-core.md
+++ b/skills/mstar-roles/references/_shared/leaf-executor-core.md
@@ -54,3 +54,11 @@ All leaf executors share these anti-recursion red lines (role-specific sibling l
 - **NEVER** infer you may call `Task` / subagents because the host **lists** `subagent_type` names (`architect`, `fullstack-dev`, …). **Tool availability ≠ delegation authorization**; only **`Delegation: allowed (...)`** grants callees.
 - **NEVER** execute parallel-agent dispatch yourself to fan out child agents; dispatch is **PM-orchestration-only** (see `mstar-dispatch-gates`). If parallel runners are needed, report to PM for re-dispatch.
 - **NEVER** invoke a same-role or sibling role to perform **this** assignment unless `Delegation: allowed (...)` explicitly lists them.
+## Audit Mode (read-only review, shared)
+
+When the assignment is a review/audit dispatch — `Task category: audit`, `Audit mode: on`, or a `pr-deep-review` batch seat — the executor operates as a **read-only audit seat**, not an implementer:
+
+- **Permission contract**: no tracked-file writes, no `edit`/`write`/`ast_edit` on the reviewed worktree, no merge, no approve-as-merge. The write permissions the role normally has are **suspended for the assignment**; do not "fix things while reviewing".
+- **Process**: load `mstar-audit` (`pr` variant or audit process) + its references + `mstar-coding-behavior` evidence discipline; run the concern-lens review and the three-way attack; produce `findings` + `verdict` (`ship it` / `needs review` / `blocked` for PR review) + `unverified` in the `pr-deep-review` output shape.
+- **Mode lock**: one assignment = one mode. Review-assigned work is completed as review only; implementation mode applies to implementation assignments only.
+- **Completion Report**: `Status: Done`; `Git:` states `read-only, no commits` unless PM explicitly authorized a comment post.

--- a/skills/mstar-roles/references/frontend-dev.md
+++ b/skills/mstar-roles/references/frontend-dev.md
@@ -29,6 +29,14 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 - **NEVER** offload UI implementation, tests, or evidence to `explore`; use glob/grep/read first—short read-only `explore` only per `mstar-harness-core` explore boundaries.
 - **NEVER** self-decide branch pivots (including switching to `main`/`master`) beyond PM’s `Working branch` / `Branch policy`; conflicting or missing branch facts => `Blocked` to PM.
 - **NEVER** start UI implementation while the assignment’s Prepare / execute prerequisites (`plan locked`, `tasks`, branch contract) are unmet—return `Blocked` to PM instead of silent partial delivery.
+## Audit Mode (read-only review)
+
+When the assignment is a review/audit dispatch — `Task category: audit`, `Audit mode: on`, or a `pr-deep-review` batch seat — this role operates as a **read-only audit seat**, not an implementer:
+
+- **Permission contract**: no tracked-file writes, no `edit`/`write`/`ast_edit` on the reviewed worktree, no merge, no approve-as-merge. The write permissions this role normally has are **suspended for the assignment**; do not "fix things while reviewing".
+- **Process**: load `mstar-audit` (`pr` variant) + `references/pr-review.md` + `mstar-coding-behavior` evidence discipline; run the concern-lens review (frontend lenses: UI/interactions/a11y/performance) and the three-way attack; produce `findings` + `verdict` (`ship it` / `needs review` / `blocked`) + `unverified` in the `pr-deep-review` output shape.
+- **Mode lock**: one assignment = one mode. Review-assigned work is completed as review only; implementation mode applies to implementation assignments only.
+- **Completion Report**: `Status: Done`; `Git:` states `read-only, no commits` unless PM explicitly authorized a comment post.
 
 ## Core Responsibilities
 

--- a/skills/mstar-roles/references/frontend-dev.md
+++ b/skills/mstar-roles/references/frontend-dev.md
@@ -31,12 +31,7 @@ If any item below matches, **stop** and return `Blocked` to `project-manager` in
 - **NEVER** start UI implementation while the assignment’s Prepare / execute prerequisites (`plan locked`, `tasks`, branch contract) are unmet—return `Blocked` to PM instead of silent partial delivery.
 ## Audit Mode (read-only review)
 
-When the assignment is a review/audit dispatch — `Task category: audit`, `Audit mode: on`, or a `pr-deep-review` batch seat — this role operates as a **read-only audit seat**, not an implementer:
-
-- **Permission contract**: no tracked-file writes, no `edit`/`write`/`ast_edit` on the reviewed worktree, no merge, no approve-as-merge. The write permissions this role normally has are **suspended for the assignment**; do not "fix things while reviewing".
-- **Process**: load `mstar-audit` (`pr` variant) + `references/pr-review.md` + `mstar-coding-behavior` evidence discipline; run the concern-lens review (frontend lenses: UI/interactions/a11y/performance) and the three-way attack; produce `findings` + `verdict` (`ship it` / `needs review` / `blocked`) + `unverified` in the `pr-deep-review` output shape.
-- **Mode lock**: one assignment = one mode. Review-assigned work is completed as review only; implementation mode applies to implementation assignments only.
-- **Completion Report**: `Status: Done`; `Git:` states `read-only, no commits` unless PM explicitly authorized a comment post.
+Shared contract (permission suspension + `mstar-audit` process + mode lock + read-only report) → **`references/_shared/leaf-executor-core.md`**「Audit Mode (read-only review, shared)」. Frontend review lenses: UI / interactions / a11y / performance.
 
 ## Core Responsibilities
 

--- a/skills/mstar-roles/references/fullstack-dev-shared.md
+++ b/skills/mstar-roles/references/fullstack-dev-shared.md
@@ -53,6 +53,14 @@ When parallel, module boundaries must be explicit and write ownership must not o
 
 - **NEVER** treat `parallel_secondary` (`fullstack-dev-2`) as a generic “idle backup” for `primary`—each parallel track needs explicit boundaries (module / API / page island) in the assignment.
 - **NEVER** silently widen scope from `parallel_secondary` into another track’s files without PM reassignment.
+## Audit Mode (read-only review)
+
+When the assignment is a review/audit dispatch — `Task category: audit`, `Audit mode: on`, or a `pr-deep-review` batch seat — this role operates as a **read-only audit seat**, not an implementer:
+
+- **Permission contract**: no tracked-file writes, no `edit`/`write`/`ast_edit` on the reviewed worktree, no merge, no approve-as-merge. The write permissions this role normally has are **suspended for the assignment**; do not "fix things while reviewing".
+- **Process**: load `mstar-audit` (`pr` variant) + `references/pr-review.md` + `mstar-coding-behavior` evidence discipline; run the concern-lens review and the three-way attack; produce `findings` + `verdict` (`ship it` / `needs review` / `blocked`) + `unverified` in the `pr-deep-review` output shape.
+- **Mode lock**: one assignment = one mode. Review-assigned work is completed as review only; implementation mode applies to implementation assignments only.
+- **Completion Report**: `Status: Done`; `Git:` states `read-only, no commits` unless PM explicitly authorized a comment post.
 
 ## Execute Input Contract (Hard)
 

--- a/skills/mstar-roles/references/fullstack-dev-shared.md
+++ b/skills/mstar-roles/references/fullstack-dev-shared.md
@@ -55,12 +55,7 @@ When parallel, module boundaries must be explicit and write ownership must not o
 - **NEVER** silently widen scope from `parallel_secondary` into another track’s files without PM reassignment.
 ## Audit Mode (read-only review)
 
-When the assignment is a review/audit dispatch — `Task category: audit`, `Audit mode: on`, or a `pr-deep-review` batch seat — this role operates as a **read-only audit seat**, not an implementer:
-
-- **Permission contract**: no tracked-file writes, no `edit`/`write`/`ast_edit` on the reviewed worktree, no merge, no approve-as-merge. The write permissions this role normally has are **suspended for the assignment**; do not "fix things while reviewing".
-- **Process**: load `mstar-audit` (`pr` variant) + `references/pr-review.md` + `mstar-coding-behavior` evidence discipline; run the concern-lens review and the three-way attack; produce `findings` + `verdict` (`ship it` / `needs review` / `blocked`) + `unverified` in the `pr-deep-review` output shape.
-- **Mode lock**: one assignment = one mode. Review-assigned work is completed as review only; implementation mode applies to implementation assignments only.
-- **Completion Report**: `Status: Done`; `Git:` states `read-only, no commits` unless PM explicitly authorized a comment post.
+Shared contract (permission suspension + `mstar-audit` process + mode lock + read-only report) → **`references/_shared/leaf-executor-core.md`**「Audit Mode (read-only review, shared)」.
 
 ## Execute Input Contract (Hard)
 


### PR DESCRIPTION
## What

Generic **deep PR review** capability, distilled from a private consumer project's per-PR review practice — **zero project-specific content** (no product/ticketing/bot names, ticket ids, PR numbers, or org references).

- **`commands/pr-deep-review.md`** — PM entry command (Boot / Routing / Execute), mirrors `codebase-audit.md` shape. Read-only advisory; dispatches `code-reviewer`; batch sibling PRs = one reviewer per PR, all worktrees first, one dispatch batch.
- **`mstar-audit` `pr` scope variant** — surgical +2-line edit to `skills/mstar-audit/SKILL.md` (Scope-variants row + References row).
- **`skills/mstar-audit/references/pr-review.md`** — full process: worktree isolation, concern lenses (general / technical-coverage / silent-failures + conditional types / cleanup / comments), evidence rules, three-way attack + vet, verdict synthesis (`ship it` / `needs review` / `blocked`), linked-issue AC hygiene, CI base-vs-branch attribution, comment triage, batch sibling PRs, and **plan output** (findings → `{PLAN_DIR}/audit-<date>/` plans → `mstar audit promote` into Prepare → Execute).
- Docs: README (EN/CN) — new PR-deep-review command block; `docs/cli.md` — slash-command note + new section.
- Fragment: `.changes/unreleased/pr-deep-review.md` (root + opencode).

## Quality gate

- Plan `2026-08-23-pr-deep-review` registered (workflow snapshot + status.json v2, validated).
- `mstar skill lint skills/mstar-audit` → 0 violations (frontmatter + five-questions + citations OK).
- QC single-seat (inline, N=1): initial Request Changes (W-1 unescaped pipe in EN README row; S-1 stray blank lines CN) → fixes committed → targeted re-review **Approve** (qc.md revalidation block).
- Banned-token sweep (project-specific names/ticket ids/PR numbers/org names) → zero hits.
- README EN/CN parity maintained; drift-lint bilingual-pairing satisfied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly skills, commands, and docs; no engine, auth, or runtime gate changes. Residual risk is prompt-driven git worktree/fetch/cleanup instructions that agents must follow carefully.
> 
> **Overview**
> Adds a generic **deep PR review** flow: `/pr-deep-review` plus an `mstar-audit` **`pr`** scope variant that reviews a PR/branch/diff in a dedicated worktree and returns one verdict (`ship it` / `needs review` / `blocked`).
> 
> The new command is PM-routed and **read-only** (no plan state machine, no merge/approve). Small PRs go to `@code-reviewer`; sibling batches split across four seats after all worktrees exist. Process lives in `references/pr-review.md` (real base, collision-free branch names, concern lenses, three-way vet, linked-issue AC scoring, optional plan handoff).
> 
> Wires the command into Codex project-scoped install and dsh command registration tests. README EN/CN replace the host command-loading table with this command; CLI docs list it alongside `/codebase-audit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703fce98d50e6b40baaaa490ca5ee84b34e7ff63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->