### PR TITLE
feat(audit): structured three-section report template for pr-review comments

### DIFF
--- a/.changes/unreleased/pr-review-report-template.md
+++ b/.changes/unreleased/pr-review-report-template.md
@@ -1,0 +1,8 @@
+---
+packages: root, opencode
+---
+
+- **PR deep-review report template**: the GitHub Review body now follows a fixed three-section report — Verdict (verdict token + confidence score + four-class emoji findings table), Review (PR summary, ranked findings with merge class, linked-issue AC, verified checks, considered & rejected), and a collapsible **Plan to fix** section holding the fix plan in a fenced ```md block. Chat display contract unchanged.
+
+<!-- CN -->
+- **PR 深审报告模板**：GitHub Review 评论改为固定三段式报告 —— 结论区（verdict + 置信度分数 + 四类发现的 emoji 统计表）、陈述区（PR 内容概述、按 merge class 排序的 findings 详述、linked-issue AC、Verified、Considered & rejected）、建议区（可折叠的 **Plan to fix**，以 ```md 围栏块承载修复计划）。Chat 输出契约不变。

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -217,7 +217,7 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
 2. Build one review payload:
    - `event`: `COMMENT` — **never** `APPROVE`, **never** `REQUEST_CHANGES`, never a merge.
    - `commit_id`: the PR head SHA.
-   - `body`: **first two lines are the display contract** — `{verdict} · {score_pct}%` then the tally line (`must-fix=<n> should-fix=<n> nit=<n> unverified=<n>`) — then ranked findings (short) + linked-issue leftover reasoning + optional folded plan index (below). `event` stays `COMMENT` — **never** `APPROVE`, **never** `REQUEST_CHANGES`, never a merge.
+   - `body`: follow **§ Report template (below)** — three sections (Verdict → Review → Plan to fix). `event` stays `COMMENT` — **never** `APPROVE`, **never** `REQUEST_CHANGES`, never a merge.
    - `comments[]`: one entry per finding whose `path` + `line` is in the three-dot diff, `side: RIGHT`. Finding body = title + evidence + impact + fix sketch — not the whole plan.
 3. Post it:
    ```
@@ -228,15 +228,63 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
 5. Record `html_url` / review id for `comments:`. Only now clean up the worktree (or after the n/a-no-PR skip).
 6. **Batch:** each reviewer posts on **their own PRs** only. No second PM summary comment unless the Assignment says so.
 
+### Report template (GitHub Review `body`)
+
+The posted review body is a three-section report. Section order fixed; omit a subsection only when its content is genuinely empty (write `none`, never delete the heading).
+
+**Section emoji map** — verdict: `ship it` ✅ · `needs fixes` ⚠️ · `blocked` ⛔. Finding classes: 🔴 must-fix · 🟠 should-fix · 🔵 nit · ❓ unverified.
+
+````markdown
+## <verdict-emoji> Verdict: `<verdict>` · Confidence <score_pct>%
+
+| Findings | Count |
+| --- | --- |
+| 🔴 must-fix | <n> |
+| 🟠 should-fix | <n> |
+| 🔵 nit | <n> |
+| ❓ unverified | <n> |
+
+## 📋 Review
+
+**What this PR does**: <2–3 sentences summarizing the diff's intent and surface — from the PR description plus your own read of the changed files, not copied marketing text.>
+
+### Findings
+
+<Ranked findings (§ List cut). Each finding keeps its normal format — title, evidence (`file:line`), impact, **Merge class**, **Confidence**, fix sketch — with its class emoji prefixing the title.>
+
+### Linked-issue AC
+
+<When § Linked-issue hygiene applied: per-criterion met / unmet / cut with one-line reasoning. Otherwise `none`.>
+
+### ✅ Verified
+
+<Concise what-checks-proved summary — the smallest runtime checks actually run and what they showed. Residual unverified leads go here as `- ❓ <lead>` lines, not into the findings table.>
+
+### 🗑️ Considered & rejected
+
+<- <finding>: rejected because <one line>. Otherwise `none` — rejections come from the three-way attack / vet pass (§ Attack and vet), so the next reviewer does not re-chase them.>
+
+## 🛠️ Plan to fix
+
+<details><summary>展开修复计划 / Expand fix plan</summary>
+<br>
+
+```md
+<Fix plan in markdown when the audit produced one: ordered steps per finding, files touched, verification gates. Omit the block entirely only when no fix is proposed.>
+```
+
+</details>
+````
+
+- The Verdict section replaces the old two-line tally header on GitHub: same facts (verdict token + `score_pct` as Confidence + four-class tally), structured. The chat display contract (§ Display contract) is unchanged.
+- When the fix plan itself contains fenced code blocks, open the outer fence with four backticks so the inner fences survive.
+
 ### Folding plans into the summary
 
-Fold follow-up plans into the review body **only if** this review wrote them. A short index — title, priority, effort, 1–3 sentence sketch, plan path — inside:
+Fold follow-up plans into the review body **only if** this review wrote them. Put a short index — title, priority, effort, 1–3 sentence sketch, plan path — as the first content inside the § Report template **Plan to fix** `<details>` block, before the ```md fix-plan block:
 
 ```
-<details><summary>Follow-up plans</summary>
-
 - <plan title> — P1 / S — <1–3 sentence sketch> (`{PLAN_DIR}/audit-<date>/NNN-<slug>.md`)
-</details>
 ```
 
 Never dump full plan files.
@@ -261,16 +309,18 @@ Never dump full plan files.
   - `inline: <N> posted / <M> attempted (<K> summary-only fallback)`
   - `plans_folded: yes` | `no`
 
-### Display contract (chat + GitHub Review `body`)
+### Display contract (chat output)
 
-First two lines of the display (chat output and the GitHub Review `body`) — verbatim:
+First two lines of the **chat** display — verbatim:
 
 ```
 {verdict} · {score_pct}%
 must-fix=<n> should-fix=<n> nit=<n> unverified=<n>
 ```
 
-Then existing ranked findings / leftover AC / optional `<details>` plan index. Do not put `score_pct%` on the `- verdict:` token line.
+Then ranked findings / leftover AC summary. Do not put `score_pct%` on the `- verdict:` token line.
+
+The GitHub Review `body` no longer uses the two-line header — it follows § Report template, whose Verdict section carries the same facts structured (verdict token + Confidence + four-class emoji tally table).
 
 ### List cut
 


### PR DESCRIPTION
## What

Restructures the GitHub Review body posted by `mstar-audit` § `pr` variant (deep PR review) into a fixed three-section report. Chat output is unchanged.

| Section | Content |
| --- | --- |
| Verdict (结论区) | verdict token + emoji · Confidence (`score_pct`) · four-class emoji findings table (🔴 must-fix / 🟠 should-fix / 🔵 nit / ❓ unverified) |
| Review (陈述区) | PR summary, ranked findings with merge class, linked-issue AC reasoning, ✅ Verified checks (unverified leads as `❓` lines), 🗑️ Considered & rejected |
| Plan to fix (建议区) | collapsible `<details>` holding the fix plan in a fenced ```md block; follow-up plan index folds in here |

## Why

The old body was a flat two-line header plus ranked findings — hard to scan and no place for a fix proposal. The structured report keeps all facts (verdict, tally, score) but presents them scannably, gives rejected findings an explicit home so reviewers don't re-chase them, and carries the fix plan collapsibly.

## Notes

- Scoring logic untouched: tally, `score_pct` formula, verdict-from-tally, override invariant all verbatim.
- Chat two-line display contract unchanged; § Display contract now scoped to chat with cross-reference to the new template.
- Empty subsections render `none`, never drop headings — stable parseable shape.

## Changeset

- `skills/mstar-audit/references/pr-review.md`: new § Report template (GitHub Review body); Procedure `body` bullet points at it; Folding-plans section retargeted into the Plan-to-fix details block; Display contract scoped to chat.
- `.changes/unreleased/pr-review-report-template.md`: bilingual changelog fragment (root + opencode).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill contract change. No scoring, posting event, or runtime code is modified.
> 
> **Overview**
> GitHub Review bodies from `mstar-audit` deep PR review now use a **fixed three-section report** instead of a two-line tally header plus a flat findings list.
> 
> **Verdict** carries the same facts (token, `score_pct` as Confidence, four-class counts) as an emoji table. **Review** adds a short PR summary, ranked findings, linked-issue AC, Verified checks, and an explicit **Considered & rejected** list so later reviewers do not re-chase vet discards. **Plan to fix** is a collapsible `<details>` with the markdown fix plan; follow-up plan indexes fold into that block.
> 
> Chat still uses the two-line `{verdict} · {score_pct}%` / tally contract. Empty subsections must say `none` rather than drop headings. Scoring, `COMMENT`-only posting, and inline comments are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f293eb2e3265c9a8893b775cc4b2aa35209e09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->