### PR TITLE
feat(audit): durable local report archive for pr-review

### DIFF
--- a/.changes/unreleased/pr-review-local-report-archive.md
+++ b/.changes/unreleased/pr-review-local-report-archive.md
@@ -2,7 +2,7 @@
 packages: root, opencode
 ---
 
-- **PR deep-review local report archive**: each `pr`-variant review now saves a durable markdown report under `{PROJECT_DIR}/reports/pr-review/` (`_default` when project-less) — YAML frontmatter metadata (PR, head SHA, verdict, score, tally, review URL) plus the posted GitHub Review body verbatim; bare branch/diff reviews archive the chat display instead. Saved before worktree cleanup; new `- report:` field in the Completion Report output shape.
+- **PR deep-review local report archive**: each `pr`-variant review now saves a durable markdown report under `{PROJECT_DIR}/<project-id>/reports/pr-review/` (`_default` when project-less) — YAML frontmatter metadata (PR, head SHA, verdict, score, tally, review URL) plus the posted GitHub Review body verbatim; bare branch/diff reviews archive the chat display instead. Written via the primary checkout (never inside the review worktree), saved before worktree cleanup regardless of POST outcome; new `- report:` field in the Completion Report output shape.
 
 <!-- CN -->
-- **PR 深审本地报告留档**：`pr` 变体每次审查现会在 `{PROJECT_DIR}/reports/pr-review/`（无项目流程用 `_default`）落盘一份持久 markdown 报告 —— YAML frontmatter 元数据（PR、head SHA、verdict、score、tally、review URL）+ 逐字保存的 GitHub Review 正文；bare branch/diff 审查则存 chat 展示内容。于 worktree 清理前保存；Completion Report 输出形状新增 `- report:` 字段。
+- **PR 深审本地报告留档**：`pr` 变体每次审查现会在 `{PROJECT_DIR}/<project-id>/reports/pr-review/`（无项目流程用 `_default`）落盘一份持久 markdown 报告 —— YAML frontmatter 元数据（PR、head SHA、verdict、score、tally、review URL）+ 逐字保存的 GitHub Review 正文；bare branch/diff 审查则存 chat 展示内容。经主 checkout 写入（绝不写入 review worktree 内），于 worktree 清理前保存且不因 POST 失败而跳过；Completion Report 输出形状新增 `- report:` 字段。

--- a/.changes/unreleased/pr-review-local-report-archive.md
+++ b/.changes/unreleased/pr-review-local-report-archive.md
@@ -1,0 +1,8 @@
+---
+packages: root, opencode
+---
+
+- **PR deep-review local report archive**: each `pr`-variant review now saves a durable markdown report under `{PROJECT_DIR}/reports/pr-review/` (`_default` when project-less) — YAML frontmatter metadata (PR, head SHA, verdict, score, tally, review URL) plus the posted GitHub Review body verbatim; bare branch/diff reviews archive the chat display instead. Saved before worktree cleanup; new `- report:` field in the Completion Report output shape.
+
+<!-- CN -->
+- **PR 深审本地报告留档**：`pr` 变体每次审查现会在 `{PROJECT_DIR}/reports/pr-review/`（无项目流程用 `_default`）落盘一份持久 markdown 报告 —— YAML frontmatter 元数据（PR、head SHA、verdict、score、tally、review URL）+ 逐字保存的 GitHub Review 正文；bare branch/diff 审查则存 chat 展示内容。于 worktree 清理前保存；Completion Report 输出形状新增 `- report:` 字段。

--- a/commands/pr-deep-review.md
+++ b/commands/pr-deep-review.md
@@ -36,4 +36,4 @@ Execute **`mstar-audit`** § `pr` variant end to end（SKILL.md common core：re
 
 Review findings that need fixing can be turned into self-contained plans for the normal Prepare → Execute flow (reusing `mstar-audit` SKILL.md **`## Plan output (all variants)`** — same contract as the `pr` variant).
 
-Output verdict + findings to the user, with the posted GitHub Review URL. Posting procedure (when a PR number exists) → **`references/pr-review.md`** § Comment posting. Never auto-approve or merge.
+Output verdict + findings to the user, with the posted GitHub Review URL. Posting procedure (when a PR number exists) → **`references/pr-review.md`** § Comment posting; each reviewer also saves the durable local report → **`references/pr-review.md`** § Local report archive. Never auto-approve or merge.

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -225,7 +225,7 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
    ```
    (payload on stdin).
 4. **Line fallback:** if GitHub rejects some inline comments (e.g. 422 — line not in the diff), retry the review **without** those entries and fold them into the summary body. Do not loop more than once.
-5. Record `html_url` / review id for `comments:`, then save the local report (§ Local report archive) — **always, including after a failed or skipped POST**. Only now clean up the worktree (or after the n/a-no-PR skip).
+5. Save the local report (§ Local report archive) — **mandatory in all three branches**: POST succeeded (record `html_url` / review id for `comments:` first), POST failed, or `n/a-no-pr` (archive the chat display content). Only then clean up the worktree; bare branch/diff reviews have no worktree, but the save still happens.
 6. **Batch:** each reviewer posts on **their own PRs** only. No second PM summary comment unless the Assignment says so.
 
 ### Report template (GitHub Review `body`)

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -205,7 +205,7 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
 
 - **Before anything else:** synthesize the verdict first, then post **before** worktree cleanup (see § Worktree isolation — cleanup happens after the comment is posted).
 - **No PR number** (bare branch / arbitrary diff): set `comments: n/a-no-pr` and skip the API. Chat output still required; this is not a Blocked review.
-- **Auth / API failure:** deliver the chat verdict anyway; Completion Report status `Partial`/`Blocked` with the `gh` error. Do not claim `Done` — comments are mandatory when a PR exists.
+- **Auth / API failure:** deliver the chat verdict anyway; Completion Report status `Partial`/`Blocked` with the `gh` error. Do not claim `Done` — comments are mandatory when a PR exists. **The local report is still saved** (§ Local report archive — posting failure does not skip archival).
 
 ### Procedure
 
@@ -225,7 +225,7 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
    ```
    (payload on stdin).
 4. **Line fallback:** if GitHub rejects some inline comments (e.g. 422 — line not in the diff), retry the review **without** those entries and fold them into the summary body. Do not loop more than once.
-5. Record `html_url` / review id for `comments:`, then save the local report (§ Local report archive). Only now clean up the worktree (or after the n/a-no-PR skip).
+5. Record `html_url` / review id for `comments:`, then save the local report (§ Local report archive) — **always, including after a failed or skipped POST**. Only now clean up the worktree (or after the n/a-no-PR skip).
 6. **Batch:** each reviewer posts on **their own PRs** only. No second PM summary comment unless the Assignment says so.
 
 ### Report template (GitHub Review `body`)
@@ -293,8 +293,9 @@ Never dump full plan files.
 
 The posted PR comment is the deliverable; the local report is the durable reference copy — the PR thread may be buried, locked, or deleted, and bare-branch/diff reviews have no thread at all. The review seat saves **one markdown file per reviewed PR** (or branch/diff) as part of the mandatory deliverable, before worktree cleanup:
 
-- **Path**: `{PROJECT_DIR}/reports/pr-review/` (`{PROJECT_DIR}` per `mstar-conventions`; project-less reviews use `_default`). Gitignored local SSOT, same posture as residuals; a finding that must survive across clones gets promoted to tracked `{KNOWLEDGE_DIR}` / `{SPECS_DIR}`, not by tracking this directory.
-- **Filename**: `<YYYY-MM-DD>-pr<N>.md`; bare branch → `<YYYY-MM-DD>-<branch-slug>.md`; arbitrary diff → `<YYYY-MM-DD>-diff-<short-head-sha>.md`. Same target twice in one day → append `-r2`, `-r3`, … (never overwrite a prior report).
+- **Path**: `{PROJECT_DIR}/<project-id>/reports/pr-review/` — `<project-id>` from the Assignment / project context, `_default` when the review runs outside any project flow (same id convention as `projects/<id>/residuals.json`). Gitignored local SSOT, same posture as residuals; a finding that must survive across clones gets promoted to tracked `{KNOWLEDGE_DIR}` / `{SPECS_DIR}`, not by tracking this directory.
+- **Write via the primary checkout, never the worktree**: harness discovery must not start from the review worktree — its root has no gitignored `.mstar/`, and anything written there is destroyed by `git worktree remove` (§ Worktree isolation). Record the primary repository's absolute path **before** creating the worktree and write the report under it. Never create a `.mstar/` inside the review worktree to "host" the report.
+- **Filename**: `<YYYY-MM-DD>-pr<N>.md`; bare branch → `<YYYY-MM-DD>-<branch-slug>.md`; arbitrary diff → `<YYYY-MM-DD>-diff-<short-head-sha>.md`, or `<YYYY-MM-DD>-diff.md` when no head SHA was provided with the changeset (never invent one). Same target twice in one day → append `-r2`, `-r3`, … (never overwrite a prior report).
 - **Frontmatter** (machine-readable metadata):
   ```yaml
   ---
@@ -306,10 +307,14 @@ The posted PR comment is the deliverable; the local report is the durable refere
   verdict: ship it | needs fixes | blocked
   score_pct: <n>
   tally: { must-fix: <n>, should-fix: <n>, nit: <n>, unverified: <n> }
-  review_url: <posted review html_url>   # n/a-no-pr when skipped
+  review_url: <posted review html_url>   # n/a-no-pr when skipped; failed: <gh error summary> when POST failed
   generated_at: <YYYY-MM-DD>
   ---
   ```
+
+`head:` / `base:` are omitted when genuinely unknown (arbitrary diff without stated provenance) — never fabricate identifiers.
+
+**Posting failure does not skip archival.** The report is saved regardless of the POST outcome: on failure it archives the chat display content plus the `gh` error summary, so a failed POST still leaves the durable copy.
 - **Body**: the exact text posted as the GitHub Review body — verbatim, not a paraphrase. When `comments: n/a-no-pr` or posting failed, the body is the chat display content instead (§ Display contract two lines + ranked findings + leftover AC), so the local copy is still complete.
 - Fix plans referenced by the Plan-to-fix section keep living in `{PLAN_DIR}/audit-<date>/` when written — the report links them, never duplicates them.
 

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -225,7 +225,7 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
    ```
    (payload on stdin).
 4. **Line fallback:** if GitHub rejects some inline comments (e.g. 422 — line not in the diff), retry the review **without** those entries and fold them into the summary body. Do not loop more than once.
-5. Record `html_url` / review id for `comments:`. Only now clean up the worktree (or after the n/a-no-PR skip).
+5. Record `html_url` / review id for `comments:`, then save the local report (§ Local report archive). Only now clean up the worktree (or after the n/a-no-PR skip).
 6. **Batch:** each reviewer posts on **their own PRs** only. No second PM summary comment unless the Assignment says so.
 
 ### Report template (GitHub Review `body`)
@@ -289,6 +289,30 @@ Fold follow-up plans into the review body **only if** this review wrote them. Pu
 
 Never dump full plan files.
 
+### Local report archive
+
+The posted PR comment is the deliverable; the local report is the durable reference copy — the PR thread may be buried, locked, or deleted, and bare-branch/diff reviews have no thread at all. The review seat saves **one markdown file per reviewed PR** (or branch/diff) as part of the mandatory deliverable, before worktree cleanup:
+
+- **Path**: `{PROJECT_DIR}/reports/pr-review/` (`{PROJECT_DIR}` per `mstar-conventions`; project-less reviews use `_default`). Gitignored local SSOT, same posture as residuals; a finding that must survive across clones gets promoted to tracked `{KNOWLEDGE_DIR}` / `{SPECS_DIR}`, not by tracking this directory.
+- **Filename**: `<YYYY-MM-DD>-pr<N>.md`; bare branch → `<YYYY-MM-DD>-<branch-slug>.md`; arbitrary diff → `<YYYY-MM-DD>-diff-<short-head-sha>.md`. Same target twice in one day → append `-r2`, `-r3`, … (never overwrite a prior report).
+- **Frontmatter** (machine-readable metadata):
+  ```yaml
+  ---
+  type: pr-review
+  pr: <n>                # omit for bare branch / diff
+  url: <pr url>          # omit for bare branch / diff
+  head: <head sha>
+  base: <base ref>
+  verdict: ship it | needs fixes | blocked
+  score_pct: <n>
+  tally: { must-fix: <n>, should-fix: <n>, nit: <n>, unverified: <n> }
+  review_url: <posted review html_url>   # n/a-no-pr when skipped
+  generated_at: <YYYY-MM-DD>
+  ---
+  ```
+- **Body**: the exact text posted as the GitHub Review body — verbatim, not a paraphrase. When `comments: n/a-no-pr` or posting failed, the body is the chat display content instead (§ Display contract two lines + ranked findings + leftover AC), so the local copy is still complete.
+- Fix plans referenced by the Plan-to-fix section keep living in `{PLAN_DIR}/audit-<date>/` when written — the report links them, never duplicates them.
+
 ## Output shape
 
 - `- findings:` — list of evidence-backed findings (`none` when none). Each accepted finding includes **Merge class** (§ Merge class).
@@ -308,6 +332,8 @@ Never dump full plan files.
   - `review_url: <url>` when `posted: yes`; `n/a` when `n/a-no-pr` or `failed`
   - `inline: <N> posted / <M> attempted (<K> summary-only fallback)`
   - `plans_folded: yes` | `no`
+
+- `- report:` — local archive path (§ Local report archive), e.g. `{PROJECT_DIR}/reports/pr-review/2026-08-24-pr134.md`; `n/a` only when the harness dir is undiscoverable.
 
 ### Display contract (chat output)
 

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -338,7 +338,7 @@ The posted PR comment is the deliverable; the local report is the durable refere
   - `inline: <N> posted / <M> attempted (<K> summary-only fallback)`
   - `plans_folded: yes` | `no`
 
-- `- report:` — local archive path (§ Local report archive), e.g. `{PROJECT_DIR}/reports/pr-review/2026-08-24-pr134.md`; `n/a` only when the harness dir is undiscoverable.
+- `- report:` — local archive path (§ Local report archive), e.g. `{PROJECT_DIR}/<project-id>/reports/pr-review/2026-08-24-pr134.md` (`_default` when project-less); `n/a` only when the harness dir is undiscoverable.
 
 ### Display contract (chat output)
 


### PR DESCRIPTION
## What

Each `mstar-audit` § `pr` variant review now saves a durable local markdown report as part of the mandatory deliverable, in addition to the posted GitHub Review.

- **Path**: `{PROJECT_DIR}/reports/pr-review/` (`_default` when project-less) — project-scoped durable advisory record, gitignored local SSOT, mirroring the residuals-register posture. Cross-clone-persistent findings still promote to tracked `{KNOWLEDGE_DIR}` / `{SPECS_DIR}`.
- **Filename**: `<YYYY-MM-DD>-pr<N>.md` (bare branch: date + branch slug; arbitrary diff: date + `diff-<sha>`); same-day re-reviews append `-r2`, never overwrite.
- **Frontmatter**: machine-readable metadata — PR, head SHA, base ref, verdict, score_pct, tally, review URL, generated_at.
- **Body**: the exact posted GitHub Review body verbatim. When there is no PR (`n/a-no-pr`) or posting failed, archives the chat display content instead — precisely the case with no thread to refer back to.
- Fix plans stay in `{PLAN_DIR}/audit-<date>/`; the report links them, never duplicates them.

## Why

Today the detailed report lives only in the PR comment — buried in threads or absent entirely for bare branch/diff reviews. A local copy gives later sessions a referenceable record.

## Also

- Procedure step 5: save the local report **before** worktree cleanup.
- Completion Report output shape gains `- report: <path>`.
- `commands/pr-deep-review.md` Execute section points reviewers at § Local report archive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-procedure only; no runtime, auth, or data-handling code. Risk is process-compliance (reviewers must remember to write the file).
> 
> **Overview**
> Each `pr`-variant review now **must** write a durable local markdown copy under `{PROJECT_DIR}/reports/pr-review/` (`_default` when project-less), in addition to posting the GitHub Review.
> 
> The file is gitignored local SSOT: YAML frontmatter (PR, SHAs, verdict, score, tally, review URL) plus the posted review body verbatim. Bare branch/diff or failed posts archive the chat display instead. Same-day re-reviews append `-r2` rather than overwrite. Save happens **before** worktree cleanup.
> 
> Completion Report gains `- report:`; `pr-deep-review` points reviewers at the new § Local report archive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55ac2f38d34c75dd2cd0cdac0faee5c92a6d927. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->