### PR TITLE
docs(readme): engine gate recommended + humanized audit table

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)
 | Codex | `npx @mstar-harness/cli init --target codex`<br>then `codex plugin add morning-star-harness --marketplace personal` |
 | Generic (Agent Plugins v1) | point any Agent Plugins v1.0.0 conformant client at this repo root<br>(`plugin.json` + `skills/` are the portable package) |
 
-### Engine gate checks (optional)
+### Engine gate checks (Recommended)
 
 ```bash
 npm i -g @mstar-harness/cli
@@ -103,8 +103,8 @@ Two read-only, advisory commands under one roof — they never edit source; find
 
 | Command | When |
 |---------|------|
-| `/codebase-audit [keywords]` | Read-only survey → prioritized, self-contained plans in `{PLAN_DIR}/audit-<date>/`.<br>Never edits source. Output feeds `/iteration-start` Research or normal Prepare → Execute.<br>Effort: `quick` / `deep` (default `standard`).<br>Scope: category focus (`security`, `perf`, `tests`, …); `branch` (current-branch changes only); `next` / `roadmap` (direction candidates only); `simplify` (DEBT-focused deep pass). |
-| `/pr-deep-review [pr\|branch\|scope] [full]` | Deep, evidence-first review of a pull request / branch / diff before merge → one verdict (`ship it` / `needs fixes` / `blocked`).<br>Verdict is computed from the finding tally; `score_pct` is display-only and never overrides it.<br>Worktree-isolated, read-only; findings can turn into plans for Prepare → Execute.<br>With a PR number, a mandatory GitHub Review (comments on findings) is posted.<br>`full` — include all nits (default lists every must-fix/should-fix; nits truncated to top 1–3).|
+| `/codebase-audit [keywords]` | Read-only survey of what's worth doing — bugs, security, perf, tech debt, direction — producing prioritized, ready-to-execute plans. |
+| `/pr-deep-review [pr\|branch\|scope] [full]` | Deep pre-merge review of a PR / branch / diff → one verdict (`ship it` / `needs fixes` / `blocked`), posted to GitHub when a PR number is given. |
 
 ## Harness Workflow
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,7 +51,7 @@ Harness Workflow Engine · Agent Plugin
 | Codex | `npx @mstar-harness/cli init --target codex`<br>然后 `codex plugin add morning-star-harness --marketplace personal` |
 | Generic（Agent Plugins v1） | 任意 Agent Plugins v1.0.0 兼容客户端直接指向本仓库根<br>（`plugin.json` + `skills/` 即便携包） |
 
-### 引擎门禁校验（可选）
+### 引擎门禁校验（推荐）
 
 ```bash
 npm i -g @mstar-harness/cli
@@ -104,8 +104,8 @@ npm i -g @mstar-harness/cli
 
 | 命令 | 何时 |
 |------|------|
-| `/codebase-audit [关键词]` | 只读扫描 → 向 `{PLAN_DIR}/audit-<date>/` 写入优先级排序、自包含的改进计划。<br>不改源码。产出可喂给 `/iteration-start` Research 或常规 Prepare → Execute。<br>深度：`quick` / `deep`（默认 `standard`）。<br>范围：按类别聚焦（`security`、`perf`、`tests`、…）；`branch`（仅当前分支变更）；`next` / `roadmap`（仅方向候选）；`simplify`（聚焦技术债的深扫）。 |
-| `/pr-deep-review [pr\|branch\|scope] [full]` | 合并前对 PR / 分支 / diff 做证据先行的深度审查 → 单一结论（`ship it` / `needs fixes` / `blocked`）。<br>结论由 finding 计数（tally）计算；`score_pct` 仅为展示反馈，绝不覆盖结论。<br>worktree 隔离、只读；发现可转为 plan 进入 Prepare → Execute。<br>有 PR 编号时强制发布 GitHub Review（在发现对应的代码行上评论）。<br>`full` — 列出全部 nits（默认已列全部 must-fix/should-fix；nits 默认只列 top 1–3）。 |
+| `/codebase-audit [关键词]` | 只读扫描代码库里值得做的事 —— bug、安全、性能、技术债、方向 —— 产出按优先级排序、可直接执行的改进计划。 |
+| `/pr-deep-review [pr\|branch\|scope] [full]` | 合并前对 PR / 分支 / diff 做深度审查 → 给出唯一结论（`ship it` / `needs fixes` / `blocked`）；有 PR 编号时自动发布 GitHub Review。 |
 
 ## Harness Workflow（统一流程）
 


### PR DESCRIPTION
## What

1. `### Engine gate checks (optional)` → **(Recommended)** (EN) / 引擎门禁校验（可选）→（推荐）(CN). The global CLI install is the intended setup — without it the skills' engine-check commands stay advisory only.
2. Audit & review table: trimmed both `When` cells from feature enumerations (effort flags, scope variants, tally internals) to one-sentence human-oriented descriptions. Flag/scope details remain in `mstar-audit` and the commands — README stays a reader-facing entry point.

Both `README.md` and `README_CN.md` updated together per the bilingual parity rule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes in bilingual READMEs; no code, auth, or runtime behavior is affected.
> 
> **Overview**
> Marks global CLI install for engine gate checks as **Recommended** (was optional) in both `README.md` and `README_CN.md`, so readers treat `mstar-harness` on PATH as the intended setup.
> 
> Shortens the Audit & review command table to one-line, reader-facing descriptions of `/codebase-audit` and `/pr-deep-review`, dropping flag/scope/tally internals from the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8810faf5a38744f71e6db5a6c1a5f2a68482a794. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->