### PR TITLE
docs+feat(audit): humanized audit/readme copy; pr-review lists every finding by default

### DIFF
--- a/.changes/unreleased/pr-review-full-by-default.md
+++ b/.changes/unreleased/pr-review-full-by-default.md
@@ -1,0 +1,8 @@
+---
+packages: root, opencode
+---
+
+- **PR deep-review lists every finding by default**: the `[full]` flag is removed from `/pr-deep-review` — complete findings (all merge classes, nits included) are now always listed in the chat output and GitHub Review; nothing is truncated. README command signature updated.
+
+<!-- CN -->
+- **PR 深审默认列出全部发现**：`/pr-deep-review` 移除 `[full]` 参数 —— 完整发现列表（含全部 merge class 与 nits）现在始终出现在 chat 输出与 GitHub Review 中，不再截断。README 命令签名同步更新。

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Two read-only, advisory commands under one roof — they never edit source; find
 | Command | When |
 |---------|------|
 | `/codebase-audit [keywords]` | Read-only survey of what's worth doing — bugs, security, perf, tech debt, direction — producing prioritized, ready-to-execute plans. |
-| `/pr-deep-review [pr\|branch\|scope] [full]` | Deep pre-merge review of a PR / branch / diff → one verdict (`ship it` / `needs fixes` / `blocked`), posted to GitHub when a PR number is given. |
+| `/pr-deep-review [pr\|branch\|scope]` | Deep pre-merge review of a PR / branch / diff → one verdict (`ship it` / `needs fixes` / `blocked`) and every finding, posted to GitHub when a PR number is given. |
 
 ## Harness Workflow
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)
 | Codex | `npx @mstar-harness/cli init --target codex`<br>then `codex plugin add morning-star-harness --marketplace personal` |
 | Generic (Agent Plugins v1) | point any Agent Plugins v1.0.0 conformant client at this repo root<br>(`plugin.json` + `skills/` are the portable package) |
 
-### Engine gate checks (optional)
+### Engine gate checks (Recommended)
 
 ```bash
 npm i -g @mstar-harness/cli
@@ -103,8 +103,8 @@ Two read-only, advisory commands under one roof — they never edit source; find
 
 | Command | When |
 |---------|------|
-| `/codebase-audit [keywords]` | Read-only survey → prioritized, self-contained plans in `{PLAN_DIR}/audit-<date>/`.<br>Never edits source. Output feeds `/iteration-start` Research or normal Prepare → Execute.<br>Effort: `quick` / `deep` (default `standard`).<br>Scope: category focus (`security`, `perf`, `tests`, …); `branch` (current-branch changes only); `next` / `roadmap` (direction candidates only); `simplify` (DEBT-focused deep pass). |
-| `/pr-deep-review [pr\|branch\|scope] [full]` | Deep, evidence-first review of a pull request / branch / diff before merge → one verdict (`ship it` / `needs fixes` / `blocked`).<br>Verdict is computed from the finding tally; `score_pct` is display-only and never overrides it.<br>Worktree-isolated, read-only; findings can turn into plans for Prepare → Execute.<br>With a PR number, a mandatory GitHub Review (comments on findings) is posted.<br>`full` — include all nits (default lists every must-fix/should-fix; nits truncated to top 1–3).|
+| `/codebase-audit [keywords]` | Read-only survey of what's worth doing — bugs, security, perf, tech debt, direction — producing prioritized, ready-to-execute plans. |
+| `/pr-deep-review [pr\|branch\|scope] [full]` | Deep pre-merge review of a PR / branch / diff → one verdict (`ship it` / `needs fixes` / `blocked`), posted to GitHub when a PR number is given. |
 
 ## Harness Workflow
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Two read-only, advisory commands under one roof — they never edit source; find
 
 | Command | When |
 |---------|------|
-| `/codebase-audit [keywords]` | Read-only survey of what's worth doing — bugs, security, perf, tech debt, direction — producing prioritized, ready-to-execute plans. |
+| `/codebase-audit [keywords]` | Read-only survey of what's worth doing — prioritized, ready-to-execute plans; narrow it with category focus (`bug`, `security`, `perf`, `tech-debt`, …) when you want a targeted pass. |
 | `/pr-deep-review [pr\|branch\|scope]` | Deep pre-merge review of a PR / branch / diff → one verdict (`ship it` / `needs fixes` / `blocked`) and every finding, posted to GitHub when a PR number is given. |
 
 ## Harness Workflow

--- a/README_CN.md
+++ b/README_CN.md
@@ -105,7 +105,7 @@ npm i -g @mstar-harness/cli
 | 命令 | 何时 |
 |------|------|
 | `/codebase-audit [关键词]` | 只读扫描代码库里值得做的事 —— bug、安全、性能、技术债、方向 —— 产出按优先级排序、可直接执行的改进计划。 |
-| `/pr-deep-review [pr\|branch\|scope] [full]` | 合并前对 PR / 分支 / diff 做深度审查 → 给出唯一结论（`ship it` / `needs fixes` / `blocked`）；有 PR 编号时自动发布 GitHub Review。 |
+| `/pr-deep-review [pr\|branch\|scope]` | 合并前对 PR / 分支 / diff 做深度审查 → 给出唯一结论（`ship it` / `needs fixes` / `blocked`）与全部发现；有 PR 编号时自动发布 GitHub Review。 |
 
 ## Harness Workflow（统一流程）
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -104,7 +104,7 @@ npm i -g @mstar-harness/cli
 
 | 命令 | 何时 |
 |------|------|
-| `/codebase-audit [关键词]` | 只读扫描代码库里值得做的事 —— bug、安全、性能、技术债、方向 —— 产出按优先级排序、可直接执行的改进计划。 |
+| `/codebase-audit [关键词]` | 只读扫描代码库里值得做的事 —— 产出按优先级排序、可直接执行的改进计划；可按类别聚焦（`bug`、`security`、`perf`、`tech-debt`、…）做定向深扫。 |
 | `/pr-deep-review [pr\|branch\|scope]` | 合并前对 PR / 分支 / diff 做深度审查 → 给出唯一结论（`ship it` / `needs fixes` / `blocked`）与全部发现；有 PR 编号时自动发布 GitHub Review。 |
 
 ## Harness Workflow（统一流程）

--- a/README_CN.md
+++ b/README_CN.md
@@ -51,7 +51,7 @@ Harness Workflow Engine · Agent Plugin
 | Codex | `npx @mstar-harness/cli init --target codex`<br>然后 `codex plugin add morning-star-harness --marketplace personal` |
 | Generic（Agent Plugins v1） | 任意 Agent Plugins v1.0.0 兼容客户端直接指向本仓库根<br>（`plugin.json` + `skills/` 即便携包） |
 
-### 引擎门禁校验（可选）
+### 引擎门禁校验（推荐）
 
 ```bash
 npm i -g @mstar-harness/cli
@@ -104,8 +104,8 @@ npm i -g @mstar-harness/cli
 
 | 命令 | 何时 |
 |------|------|
-| `/codebase-audit [关键词]` | 只读扫描 → 向 `{PLAN_DIR}/audit-<date>/` 写入优先级排序、自包含的改进计划。<br>不改源码。产出可喂给 `/iteration-start` Research 或常规 Prepare → Execute。<br>深度：`quick` / `deep`（默认 `standard`）。<br>范围：按类别聚焦（`security`、`perf`、`tests`、…）；`branch`（仅当前分支变更）；`next` / `roadmap`（仅方向候选）；`simplify`（聚焦技术债的深扫）。 |
-| `/pr-deep-review [pr\|branch\|scope] [full]` | 合并前对 PR / 分支 / diff 做证据先行的深度审查 → 单一结论（`ship it` / `needs fixes` / `blocked`）。<br>结论由 finding 计数（tally）计算；`score_pct` 仅为展示反馈，绝不覆盖结论。<br>worktree 隔离、只读；发现可转为 plan 进入 Prepare → Execute。<br>有 PR 编号时强制发布 GitHub Review（在发现对应的代码行上评论）。<br>`full` — 列出全部 nits（默认已列全部 must-fix/should-fix；nits 默认只列 top 1–3）。 |
+| `/codebase-audit [关键词]` | 只读扫描代码库里值得做的事 —— bug、安全、性能、技术债、方向 —— 产出按优先级排序、可直接执行的改进计划。 |
+| `/pr-deep-review [pr\|branch\|scope] [full]` | 合并前对 PR / 分支 / diff 做深度审查 → 给出唯一结论（`ship it` / `needs fixes` / `blocked`）；有 PR 编号时自动发布 GitHub Review。 |
 
 ## Harness Workflow（统一流程）
 

--- a/commands/pr-deep-review.md
+++ b/commands/pr-deep-review.md
@@ -2,7 +2,7 @@
 name: pr-deep-review
 description: Use when asked to deeply review a pull request, branch, or diff before merge — deciding whether a change is safe to ship with evidence-backed findings, rather than a shallow "looks good" pass. Produces a `ship it` / `needs fixes` / `blocked` verdict. Also for a batch of sibling PRs. Do not use for self-checking a change you just authored.
 agent: project-manager
-input: "[pr|branch|scope] [full]"
+input: "[pr|branch|scope]"
 ---
 
 # Deep PR Review

--- a/packages/dsh/tests/commands.spec.ts
+++ b/packages/dsh/tests/commands.spec.ts
@@ -46,7 +46,7 @@ const EXPECTED_HINTS: Readonly<Record<(typeof MSTAR_COMMANDS)[number], string>> 
   'iteration-loop': '[direction] [scale]',
   'iteration-drive': '[no args]',
   'codebase-audit': '[simplify]',
-  'pr-deep-review': '[pr|branch|scope] [full]',
+  'pr-deep-review': '[pr|branch|scope]',
 }
 
 /** One command's registered descriptor (the view the dsh web client resolves). */

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -87,7 +87,7 @@ Then open cited code yourself and dispose by-design / mis-attributed / duplicate
 ## Verdict synthesis
 
 - Order findings by impact-if-shipped; no padding, no invented requirements, no style grading.
-- List **every** `must-fix` and `should-fix` finding — the default top 1–3 cut (unless `full`) applies to nits only, and truncated nits are summarized in the display line (§ Output shape / Display contract).
+- List **every** accepted finding — `must-fix`, `should-fix`, and nits alike; nothing is truncated.
 - The verdict is **derived from the tally, not chosen**: classify every accepted finding (§ Merge class) → apply leftover `unmet` AC increments if any (§ Linked-issue hygiene) → apply **Verdict-from-tally** (§ Tally and derived score) → emit that one token. The reviewer does not pick a verdict by vibe.
 - Exactly one verdict:
   - `ship it` — evidence-backed, safe to ship.
@@ -250,7 +250,7 @@ The posted review body is a three-section report. Section order fixed; omit a su
 
 ### Findings
 
-<Ranked findings (§ List cut). Each finding keeps its normal format — title, evidence (`file:line`), impact, **Merge class**, **Confidence**, fix sketch — with its class emoji prefixing the title.>
+<Ranked findings. Each finding keeps its normal format — title, evidence (`file:line`), impact, **Merge class**, **Confidence**, fix sketch — with its class emoji prefixing the title.>
 
 ### Linked-issue AC
 
@@ -353,6 +353,3 @@ Then ranked findings / leftover AC summary. Do not put `score_pct%` on the `- ve
 
 The GitHub Review `body` no longer uses the two-line header — it follows § Report template, whose Verdict section carries the same facts structured (verdict token + Confidence + four-class emoji tally table).
 
-### List cut
-
-The default "top 1–3 unless `full`" applies to **nits only**: every `must-fix` and `should-fix` finding is listed. If nits are omitted from the narrative list, add one line `nits: <n> omitted from list (counted in tally)` — `tally.nit` stays complete.


### PR DESCRIPTION
## Two related changes

### 1. README copy (EN/CN parity)

- `Engine gate checks (optional)` → **(Recommended)** / 引擎门禁校验（推荐）— global CLI install is the intended setup.
- Audit & review `When` cells trimmed from feature enumerations to one-sentence human descriptions.

### 2. `/pr-deep-review` lists every finding by default

- The `[full]` flag is removed (`input: "[pr|branch|scope]"`). Chat output and the posted GitHub Review always list every accepted finding — must-fix, should-fix, nits alike; nothing truncated.
- Rationale: nits are counted in the tally either way, so hiding them from the narrative forced readers to trust a "nits omitted" line. Complete information is the cheaper default.
- `skills/mstar-audit/references/pr-review.md`: § Verdict synthesis mandates full listing; `### List cut` section deleted; Report template placeholder updated.
- Changelog fragment included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/skill-prompt only; no engine or auth changes. Residual risk: `packages/dsh/tests/commands.spec.ts` still expects `[pr|branch|scope] [full]` and is not updated in this PR.
> 
> **Overview**
> `/pr-deep-review` now always lists **every** accepted finding (`must-fix`, `should-fix`, and nits) in chat and the GitHub Review. The `[full]` flag and the nit truncation / `List cut` rules are gone.
> 
> Command input is `[pr|branch|scope]`. README (EN/CN) signatures match; audit command blurbs are shortened. Changelog fragment added.
> 
> Engine gate checks heading is retitled from optional to **Recommended** (unrelated docs tweak).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245796e89c8ab343a6b945347e560db4434d2361. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->