### PR TITLE
fix(audit): prevent placeholder-bracket leakage in pr-review report template

### DIFF
--- a/.changes/unreleased/pr-review-template-placeholder-hardening.md
+++ b/.changes/unreleased/pr-review-template-placeholder-hardening.md
@@ -1,0 +1,8 @@
+---
+packages: root, opencode
+---
+
+- **PR deep-review report template hardening**: the `Considered & rejected` placeholder no longer embeds the bullet dash inside angle brackets (a posted review rendered literal `<finding>` wrappers verbatim); rejected entries now use `- **<short title>**: rejected — <reason>` with an explicit "never render brackets" rule stated at the template top; empty Plan-to-fix sections collapse to a bare `none` instead of prose.
+
+<!-- CN -->
+- **PR 深审报告模板加固**：`Considered & rejected` 占位符不再把 bullet 短横线包进尖括号（此前一条已发布 review 逐字渲染了 `<finding>` 包裹）；拒绝条目改为 `- **<短标题>**: rejected — <理由>`，并在模板顶部显式声明“尖括号仅是填空槽、永不渲染”；无修复计划时 Plan to fix 整块折叠为单独一行 `none` 而非散文。

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -230,7 +230,7 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
 
 ### Report template (GitHub Review `body`)
 
-The posted review body is a three-section report. Section order fixed; omit a subsection only when its content is genuinely empty (write `none`, never delete the heading). The block below shows only **fill-in slots** — every `<...>` is a slot to replace with real content; never render `<` `>` themselves, and never copy the surrounding guidance into the posted body.
+The posted review body is a three-section report. Section order fixed; omit a subsection only when its content is genuinely empty (write `none`, never delete the heading). The block below shows only **fill-in slots**: a `<...>` that wraps descriptive text (`<verdict>`, `<n>`, `<finding title>`, …) is a slot — replace the whole bracket pair with real content and never render those brackets. The literal HTML tags in the template (`<details>`, `<summary>`, `<br>`) are **structural** — keep them verbatim so the collapsible block survives. The Slot rules below the template are guidance — never copy them into the posted body.
 
 **Section emoji map** — verdict: `ship it` ✅ · `needs fixes` ⚠️ · `blocked` ⛔. Finding classes: 🔴 must-fix · 🟠 should-fix · 🔵 nit · ❓ unverified.
 

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -230,7 +230,7 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
 
 ### Report template (GitHub Review `body`)
 
-The posted review body is a three-section report. Section order fixed; omit a subsection only when its content is genuinely empty (write `none`, never delete the heading).
+The posted review body is a three-section report. Section order fixed; omit a subsection only when its content is genuinely empty (write `none`, never delete the heading). **Angle brackets in the template mark fill-in slots — replace the bracketed text with real content and never render `<` `>` themselves.**
 
 **Section emoji map** — verdict: `ship it` ✅ · `needs fixes` ⚠️ · `blocked` ⛔. Finding classes: 🔴 must-fix · 🟠 should-fix · 🔵 nit · ❓ unverified.
 
@@ -262,7 +262,9 @@ The posted review body is a three-section report. Section order fixed; omit a su
 
 ### 🗑️ Considered & rejected
 
-<- <finding>: rejected because <one line>. Otherwise `none` — rejections come from the three-way attack / vet pass (§ Attack and vet), so the next reviewer does not re-chase them.>
+- **<short finding title>**: rejected — <one-line reason>.
+
+One bullet per rejected candidate from the three-way attack / vet pass (§ Attack and vet), so the next reviewer does not re-chase it. Write `none` (a bare line, no bullet) when nothing was rejected. Angle brackets mark slots to fill — never render them.
 
 ## 🛠️ Plan to fix
 
@@ -270,7 +272,7 @@ The posted review body is a three-section report. Section order fixed; omit a su
 <br>
 
 ```md
-<Fix plan in markdown when the audit produced one: ordered steps per finding, files touched, verification gates. Omit the block entirely only when no fix is proposed.>
+<Fix plan in markdown when the audit produced one: ordered steps per finding, files touched, verification gates. When there is no fix plan, replace the whole `<details>` block with a single line `none`.>
 ```
 
 </details>

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -273,7 +273,7 @@ The posted review body is a three-section report. Section order fixed; omit a su
 
 ## 🛠️ Plan to fix
 
-<details><summary>展开修复计划 / Expand fix plan</summary>
+<details><summary>Expand fix plan</summary>
 <br>
 
 ```md

--- a/skills/mstar-audit/references/pr-review.md
+++ b/skills/mstar-audit/references/pr-review.md
@@ -230,7 +230,7 @@ Posting the GitHub Review is a **mandatory deliverable** of the `pr` variant —
 
 ### Report template (GitHub Review `body`)
 
-The posted review body is a three-section report. Section order fixed; omit a subsection only when its content is genuinely empty (write `none`, never delete the heading). **Angle brackets in the template mark fill-in slots — replace the bracketed text with real content and never render `<` `>` themselves.**
+The posted review body is a three-section report. Section order fixed; omit a subsection only when its content is genuinely empty (write `none`, never delete the heading). The block below shows only **fill-in slots** — every `<...>` is a slot to replace with real content; never render `<` `>` themselves, and never copy the surrounding guidance into the posted body.
 
 **Section emoji map** — verdict: `ship it` ✅ · `needs fixes` ⚠️ · `blocked` ⛔. Finding classes: 🔴 must-fix · 🟠 should-fix · 🔵 nit · ❓ unverified.
 
@@ -246,25 +246,30 @@ The posted review body is a three-section report. Section order fixed; omit a su
 
 ## 📋 Review
 
-**What this PR does**: <2–3 sentences summarizing the diff's intent and surface — from the PR description plus your own read of the changed files, not copied marketing text.>
+**What this PR does**: <2–3 sentence summary of the diff's intent and surface>
 
 ### Findings
 
-<Ranked findings. Each finding keeps its normal format — title, evidence (`file:line`), impact, **Merge class**, **Confidence**, fix sketch — with its class emoji prefixing the title.>
+#### <class-emoji> <finding title>
+
+- **Evidence**: `file:line` — what the code does
+- **Impact**: why it matters
+- **Merge class**: must-fix | should-fix | nit
+- **Confidence**: HIGH | MEDIUM | LOW
+- **Fix sketch**: one-line suggestion
 
 ### Linked-issue AC
 
-<When § Linked-issue hygiene applied: per-criterion met / unmet / cut with one-line reasoning. Otherwise `none`.>
+<per-criterion: met / unmet / cut — one-line reasoning, or `none`>
 
 ### ✅ Verified
 
-<Concise what-checks-proved summary — the smallest runtime checks actually run and what they showed. Residual unverified leads go here as `- ❓ <lead>` lines, not into the findings table.>
+- <check or command> → <what it showed>
+- ❓ <unverified lead, if any>
 
 ### 🗑️ Considered & rejected
 
-- **<short finding title>**: rejected — <one-line reason>.
-
-One bullet per rejected candidate from the three-way attack / vet pass (§ Attack and vet), so the next reviewer does not re-chase it. Write `none` (a bare line, no bullet) when nothing was rejected. Angle brackets mark slots to fill — never render them.
+- **<short finding title>**: rejected — <one-line reason>
 
 ## 🛠️ Plan to fix
 
@@ -272,11 +277,20 @@ One bullet per rejected candidate from the three-way attack / vet pass (§ Attac
 <br>
 
 ```md
-<Fix plan in markdown when the audit produced one: ordered steps per finding, files touched, verification gates. When there is no fix plan, replace the whole `<details>` block with a single line `none`.>
+<fix plan in markdown>
 ```
 
 </details>
 ````
+
+**Slot rules (guidance — not part of the posted body):**
+
+- **What this PR does**: from the PR description plus your own read of the changed files, not copied marketing text.
+- **Findings**: ranked by impact-if-shipped (§ Verdict synthesis); every accepted finding listed, nothing truncated; repeat the `#### <class-emoji> <title>` block per finding.
+- **Linked-issue AC**: fill only when § Linked-issue hygiene applied; otherwise a bare `none`.
+- **Verified**: the smallest runtime checks actually run and what they showed; unverified leads as `❓` lines here, never in the findings table.
+- **Considered & rejected**: one bullet per rejected candidate from the three-way attack / vet pass (§ Attack and vet), so the next reviewer does not re-chase it; bare `none` when nothing was rejected.
+- **Plan to fix**: fix plan in markdown (ordered steps per finding, files touched, verification gates); follow-up plan index folds in above the ```md block (§ Folding plans); when there is no fix plan, replace the whole `<details>` block with a single line `none`.
 
 - The Verdict section replaces the old two-line tally header on GitHub: same facts (verdict token + `score_pct` as Confidence + four-class tally), structured. The chat display contract (§ Display contract) is unchanged.
 - When the fix plan itself contains fenced code blocks, open the outer fence with four backticks so the inner fences survive.


### PR DESCRIPTION
## Observed failure

[earn-os/earnos#3346 review](https://github.com/earn-os/earnos/pull/3346#pullrequestreview-5007829378) rendered literal angle brackets around every Considered-&-rejected entry:

```
- <formatter guard is fragile because it string-compares message equality>: rejected — ...
```

## Root cause

The template's placeholder line embedded the bullet dash and usage prose inside one pair of angle brackets:

```
<- <finding>: rejected because <one line>. Otherwise `none` — rejections come from ...>
```

The reviewer copied the whole bracketed structure as literal format.

## Fix

1. Template top: explicit rule — **angle brackets mark fill-in slots; never render `<` `>` themselves**.
2. `Considered & rejected`: bullet form `- **<short finding title>**: rejected — <reason>`, with the "write none when empty" guidance moved out of the bullet into surrounding prose.
3. `Plan to fix`: no-fix case now collapses the whole `<details>` block to a bare `none`, consistent with every other empty subsection (previously allowed free-prose deviation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only template wording for reviewer output; no runtime, auth, or data-path changes.
> 
> **Overview**
> Stops posted GitHub reviews from rendering literal `<finding>` wrappers by tightening the `pr-review` report template.
> 
> The template now states that **angle brackets are fill-in slots and must never appear in the posted body**. `Considered & rejected` uses a real bullet (`- **<title>**: rejected — <reason>`) with empty-state `none` moved out of the placeholder. Empty **Plan to fix** sections collapse the whole `<details>` block to a bare `none`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fbca04a676c1ef56d361cbf83e5854c928ec320. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->