### PR TITLE
feat(harness): one-shot `mstar harness scaffold` + prebuilt projects/_default

### DIFF
--- a/.changes/unreleased/harness-scaffold-command.md
+++ b/.changes/unreleased/harness-scaffold-command.md
@@ -2,8 +2,10 @@
 packages: root, engine, cli
 ---
 - Added **`mstar harness scaffold [path]`** (default cwd): one-shot harness bootstrap — engine `scaffoldHarness` now also prebuilds `projects/_default/` (`roadmap.md` with valid `validateRoadmap` frontmatter + `## Direction` placeholder, and an empty `residuals.json` passing `validateProjectRegister`); the CLI appends the canonical `.gitignore` snippet when absent, writes a minimal `.mstar/AGENTS.md` when absent, and prints a created/skipped summary. Idempotent — re-running on an initialized tree only creates missing pieces.
+- `mstar harness scaffold` is now `.mstarc`-aware: it scaffolds into the `.mstarc`-declared `harness_dir` (or the `MSTAR_HARNESS_DIR` override), lands `projects/_default/` under the resolved `project_dir`, and prints the resolved harness/project dirs. The canonical `.gitignore` snippet is appended only for the default `.mstar/` layout — custom harness layouts skip it. The fence now splices `.mstar/**` BEFORE existing `!.mstar/…` re-includes when the broad rule is missing (gitignore last-match-wins), keeping the re-includes effective.
 - `mstar path resolve` failure guidance now points to `mstar harness scaffold` instead of `mstar init`.
 
 <!-- CN -->
 - 新增 **`mstar harness scaffold [path]`**（默认 cwd）一次性 harness 初始化：engine `scaffoldHarness` 现同时预建 `projects/_default/`（`roadmap.md` 含通过 `validateRoadmap` 的 frontmatter 与 `## Direction` 占位，以及通过 `validateProjectRegister` 的空 `residuals.json`）；CLI 在缺失时追加 canonical `.gitignore` snippet、写入最小 `.mstar/AGENTS.md`，并打印 created/skipped 摘要。幂等 —— 在已初始化树上重跑只补缺失件。
+- `mstar harness scaffold` 现遵循 `.mstarc`：按 `.mstarc` 声明的 `harness_dir`（或 `MSTAR_HARNESS_DIR` 覆盖）落盘，`projects/_default/` 落在解析后的 `project_dir` 下，并打印解析后的 harness/project 目录。canonical `.gitignore` snippet 仅对默认 `.mstar/` 布局追加 —— 自定义 harness 布局跳过（自行管理 ignore 规则）。`.gitignore` fence 在宽规则缺失但存在 `!.mstar/…` re-include 时，将宽规则拼接到 re-include 之前（gitignore 后者胜出），保证 re-include 仍生效。
 - `mstar path resolve` 失败指引由 `mstar init` 改为 `mstar harness scaffold`。

--- a/.changes/unreleased/harness-scaffold-command.md
+++ b/.changes/unreleased/harness-scaffold-command.md
@@ -1,0 +1,9 @@
+---
+packages: engine, cli
+---
+- Added **`mstar scaffold [path]`** (default cwd): one-shot harness bootstrap — engine `scaffoldHarness` now also prebuilds `projects/_default/` (`roadmap.md` with valid `validateRoadmap` frontmatter + `## Direction` placeholder, and an empty `residuals.json` passing `validateProjectRegister`); the CLI appends the canonical `.gitignore` snippet when absent, writes a minimal `.mstar/AGENTS.md` when absent, and prints a created/skipped summary. Idempotent — re-running on an initialized tree only creates missing pieces.
+- `mstar path resolve` failure guidance now points to `mstar scaffold` instead of `mstar init`.
+
+<!-- CN -->
+- 新增 **`mstar scaffold [path]`**（默认 cwd）一次性 harness 初始化：engine `scaffoldHarness` 现同时预建 `projects/_default/`（`roadmap.md` 含通过 `validateRoadmap` 的 frontmatter 与 `## Direction` 占位，以及通过 `validateProjectRegister` 的空 `residuals.json`）；CLI 在缺失时追加 canonical `.gitignore` snippet、写入最小 `.mstar/AGENTS.md`，并打印 created/skipped 摘要。幂等 —— 在已初始化树上重跑只补缺失件。
+- `mstar path resolve` 失败指引由 `mstar init` 改为 `mstar scaffold`。

--- a/.changes/unreleased/harness-scaffold-command.md
+++ b/.changes/unreleased/harness-scaffold-command.md
@@ -1,5 +1,5 @@
 ---
-packages: engine, cli
+packages: root, engine, cli
 ---
 - Added **`mstar scaffold [path]`** (default cwd): one-shot harness bootstrap — engine `scaffoldHarness` now also prebuilds `projects/_default/` (`roadmap.md` with valid `validateRoadmap` frontmatter + `## Direction` placeholder, and an empty `residuals.json` passing `validateProjectRegister`); the CLI appends the canonical `.gitignore` snippet when absent, writes a minimal `.mstar/AGENTS.md` when absent, and prints a created/skipped summary. Idempotent — re-running on an initialized tree only creates missing pieces.
 - `mstar path resolve` failure guidance now points to `mstar scaffold` instead of `mstar init`.

--- a/.changes/unreleased/harness-scaffold-command.md
+++ b/.changes/unreleased/harness-scaffold-command.md
@@ -1,9 +1,9 @@
 ---
 packages: root, engine, cli
 ---
-- Added **`mstar scaffold [path]`** (default cwd): one-shot harness bootstrap — engine `scaffoldHarness` now also prebuilds `projects/_default/` (`roadmap.md` with valid `validateRoadmap` frontmatter + `## Direction` placeholder, and an empty `residuals.json` passing `validateProjectRegister`); the CLI appends the canonical `.gitignore` snippet when absent, writes a minimal `.mstar/AGENTS.md` when absent, and prints a created/skipped summary. Idempotent — re-running on an initialized tree only creates missing pieces.
-- `mstar path resolve` failure guidance now points to `mstar scaffold` instead of `mstar init`.
+- Added **`mstar harness scaffold [path]`** (default cwd): one-shot harness bootstrap — engine `scaffoldHarness` now also prebuilds `projects/_default/` (`roadmap.md` with valid `validateRoadmap` frontmatter + `## Direction` placeholder, and an empty `residuals.json` passing `validateProjectRegister`); the CLI appends the canonical `.gitignore` snippet when absent, writes a minimal `.mstar/AGENTS.md` when absent, and prints a created/skipped summary. Idempotent — re-running on an initialized tree only creates missing pieces.
+- `mstar path resolve` failure guidance now points to `mstar harness scaffold` instead of `mstar init`.
 
 <!-- CN -->
-- 新增 **`mstar scaffold [path]`**（默认 cwd）一次性 harness 初始化：engine `scaffoldHarness` 现同时预建 `projects/_default/`（`roadmap.md` 含通过 `validateRoadmap` 的 frontmatter 与 `## Direction` 占位，以及通过 `validateProjectRegister` 的空 `residuals.json`）；CLI 在缺失时追加 canonical `.gitignore` snippet、写入最小 `.mstar/AGENTS.md`，并打印 created/skipped 摘要。幂等 —— 在已初始化树上重跑只补缺失件。
-- `mstar path resolve` 失败指引由 `mstar init` 改为 `mstar scaffold`。
+- 新增 **`mstar harness scaffold [path]`**（默认 cwd）一次性 harness 初始化：engine `scaffoldHarness` 现同时预建 `projects/_default/`（`roadmap.md` 含通过 `validateRoadmap` 的 frontmatter 与 `## Direction` 占位，以及通过 `validateProjectRegister` 的空 `residuals.json`）；CLI 在缺失时追加 canonical `.gitignore` snippet、写入最小 `.mstar/AGENTS.md`，并打印 created/skipped 摘要。幂等 —— 在已初始化树上重跑只补缺失件。
+- `mstar path resolve` 失败指引由 `mstar init` 改为 `mstar harness scaffold`。

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -507,33 +507,167 @@ function runScaffold(pathArg: string | undefined) {
           normalized = true;
         }
       }
-      // Ownership invariant, final pass: every canonical negation must
-      // occur at least once AFTER the last `.mstar/**` line. A retained
-      // secondary broad rule sitting between canonical re-inclusions would
-      // otherwise shadow them under last-match-wins even though the fence
-      // was reported as installed. Canonical negation lines are ours to
-      // place; duplicate negation lines are harmless in gitignore, so the
-      // guarantee is satisfied by appending missing occurrences at the end.
+      // Ownership invariant, final pass. Pipeline order matters for
+      // one-run convergence:
+      // 1. PARTITION — user-authored targeted `.mstar/…` rules always speak
+      //    LAST: relocate every targeted user rule (non-canonical
+      //    `!.mstar/…` re-inclusions and `.mstar/<path>` ignores — never
+      //    the bare broad rule, canonical negations, or our own
+      //    `.mstarc`) to after the fence, preserving their relative order.
+      //    Gitignore's last-match-wins then resolves every overlap in the
+      //    user's favor while our tracked results stay re-included.
+      // 2. DEDUPE — after the partition no un-owned line can sit between
+      //    two broad rules, so any extra `.mstar/**` is redundant: keep
+      //    the first only.
+      // 3. RELOCATE — a broad rule sitting after the first canonical
+      //    negation is moved before it when only owned lines lie in
+      //    between (feasibility unchanged from round-7).
+      // 4. GUARANTEE — every canonical negation occurs at least once after
+      //    the last broad rule (append missing occurrences; duplicates are
+      //    harmless in gitignore).
+      const isTargetedUserMstarRule = (line: string): boolean => {
+        const trimmed = line.trim();
+        if (trimmed === "" || trimmed.startsWith("#")) return false;
+        if (trimmed === ".mstar/**" || trimmed === ".mstarc") return false;
+        if (CANONICAL_NEGATIONS[trimmed] === true) return false;
+        if (trimmed.startsWith("!.mstar/") || trimmed.startsWith(".mstar/")) return true;
+        return false;
+      };
+      const isOwnedLine = (line: string): boolean => !isTargetedUserMstarRule(line);
+
+      // 1. Partition targeted user rules to the tail (with synthesis).
+      const targetedRules = finalLines.filter((line) => isTargetedUserMstarRule(line));
+      if (targetedRules.length > 0) {
+        const owned = finalLines.filter(isOwnedLine);
+        const hadTrailingNewline = owned[owned.length - 1] === "";
+        const ownedBody = hadTrailingNewline ? owned.slice(0, -1) : owned;
+        // A contents-level negation like `!.mstar/custom/**` cannot take
+        // effect while its parent directory stays excluded by
+        // `.mstar/**` — git prunes excluded directories without descending
+        // (this is why the canonical fence pairs `!.mstar/knowledge/` with
+        // `!.mstar/knowledge/**`). Synthesize the missing
+        // ancestor-directory re-inclusions so the relocated user rule keeps
+        // working after the fence.
+        const tail: string[] = [];
+        const ensuredDirs = new Set<string>();
+        const broadPositionsPrePartition = finalLines
+          .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
+          .filter((index) => index !== -1);
+        const lastBroadPrePartition =
+          broadPositionsPrePartition[broadPositionsPrePartition.length - 1] ?? -1;
+        for (const rule of targetedRules) {
+          const trimmedRule = rule.trim();
+          if (trimmedRule.startsWith("!") && trimmedRule.endsWith("/**")) {
+            const inner = trimmedRule.slice(1, -3); // e.g. `.mstar/custom`
+            const segments = inner.split("/").slice(1); // drop the harness dir name
+            let prefix = inner.split("/")[0];
+            for (const segment of segments) {
+              prefix += "/" + segment;
+              const dirNegation = "!" + prefix + "/";
+              // Idempotency: skip when the dir negation already exists
+              // after the last broad rule (synthesized by an earlier run)
+              // or is already queued in this pass.
+              const alreadyQueued = ensuredDirs.has(dirNegation);
+              const alreadyPresent =
+                !alreadyQueued &&
+                finalLines.some(
+                  (line, index) =>
+                    index > lastBroadPrePartition && line.trim() === dirNegation,
+                );
+              if (!alreadyQueued && !alreadyPresent) {
+                ensuredDirs.add(dirNegation);
+                tail.push(dirNegation);
+              }
+            }
+          }
+          tail.push(rule);
+        }
+        const rebuilt = [...ownedBody, ...tail];
+        const current =
+          finalLines[finalLines.length - 1] === "" ? finalLines.slice(0, -1) : finalLines;
+        if (rebuilt.join("\n") !== current.join("\n")) {
+          finalLines.length = 0;
+          finalLines.push(...rebuilt);
+          normalized = true;
+        }
+      }
+
+      // Recompute broad positions after the partition.
       const broadAfter = finalLines
         .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
         .filter((index) => index !== -1);
-      if (broadAfter.length > 0) {
-        const lastBroadIndex = broadAfter[broadAfter.length - 1];
-        let appended = false;
+      if (broadAfter.length > 1) {
+        // 2. Dedupe: post-partition every line between two broad rules is
+        // owned, so extra broad rules are pure redundancy. Removing them
+        // can only make canonical re-inclusions effective (round-3).
+        const [first, ...duplicates] = broadAfter;
+        let removed = 0;
+        for (const duplicate of duplicates) {
+          finalLines.splice(duplicate - removed, 1);
+          removed++;
+        }
+        if (removed > 0) normalized = true;
+      }
+
+      // Recompute once more; relocate a misplaced primary broad rule.
+      const broadIndexesFinal = finalLines
+        .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
+        .filter((index) => index !== -1);
+      const canonicalNegationIndexesFinal = finalLines
+        .map((line, index) => (CANONICAL_NEGATIONS[line.trim()] === true ? index : -1))
+        .filter((index) => index !== -1);
+      const firstCanonicalNegationIndexFinal = canonicalNegationIndexesFinal[0] ?? -1;
+      if (
+        broadIndexesFinal.length > 0 &&
+        firstCanonicalNegationIndexFinal !== -1 &&
+        broadIndexesFinal[0] > firstCanonicalNegationIndexFinal
+      ) {
+        const keptIndex = broadIndexesFinal[0];
+        let feasible = true;
+        for (let i = firstCanonicalNegationIndexFinal; i < keptIndex; i++) {
+          const line = finalLines[i].trim();
+          if (line === "" || line.startsWith("#")) continue;
+          if (line === ".mstar/**" || line === ".mstarc") continue;
+          if (CANONICAL_NEGATIONS[line] === true) continue;
+          feasible = false;
+          break;
+        }
+        if (feasible) {
+          const [broadLine] = finalLines.splice(keptIndex, 1);
+          finalLines.splice(firstCanonicalNegationIndexFinal, 0, broadLine);
+          normalized = true;
+        }
+      }
+
+      // 4. Guarantee: every canonical negation occurs at least once AFTER
+      // the last broad rule. A retained/misplaced broad sitting between
+      // canonical re-inclusions would otherwise shadow them under
+      // last-match-wins even though the fence was reported as installed.
+      const broadIndexesLast = finalLines
+        .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
+        .filter((index) => index !== -1);
+      if (broadIndexesLast.length > 0) {
+        const lastBroadIndex = broadIndexesLast[broadIndexesLast.length - 1];
+        // Insert missing negations BEFORE the partitioned user tail (the
+        // first targeted user rule, if any) — appending after it would put
+        // our negations past the user's rules, and the next run's partition
+        // would move the user rules again (flip-flop).
+        let insertIndex = finalLines.findIndex((line) => isTargetedUserMstarRule(line));
+        if (insertIndex === -1) insertIndex = finalLines.length;
         for (const negation of Object.keys(CANONICAL_NEGATIONS)) {
           const covered = finalLines.some(
             (line, index) => index > lastBroadIndex && line.trim() === negation,
           );
           if (!covered) {
-            finalLines.push(negation);
-            appended = true;
+            finalLines.splice(insertIndex, 0, negation);
+            insertIndex++;
             normalized = true;
           }
         }
-        // Preserve a trailing newline when appends landed after the one the
-        // original file already had.
-        if (appended && finalLines[finalLines.length - 1] !== "") finalLines.push("");
       }
+      // Preserve a trailing newline whenever normalization changed the
+      // file (appends land after any newline the original file had).
+      if (normalized && finalLines[finalLines.length - 1] !== "") finalLines.push("");
     }
     if (normalized) {
       fs.writeFileSync(gitignorePath, finalLines.join("\n"), "utf8");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -309,21 +309,22 @@ function runScaffold(pathArg: string | undefined) {
   const skipped: string[] = [];
 
   // Canonical .gitignore snippet (plan-conventions § Git 跟踪策略): append
-  // the full snippet when any fence entry is missing, skip cleanly when the
-  // complete set is already present (same per-entry fence check as the
-  // engine's GITIGNORE_PROCESS_ENTRIES / shared-install appendGitignore).
+  // only the missing fence entries (plus the canonical comment block when
+  // its comment lines are absent), skip cleanly when the complete set is
+  // already present (same per-entry fence check as the engine's
+  // GITIGNORE_PROCESS_ENTRIES / shared-install appendGitignore).
   const gitignorePath = path.join(root, ".gitignore");
   const snippet = emitGitignoreSnippet("mstar");
   const current = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
   const lines = new Set(current.split(/\r?\n/).map((line) => line.trim()));
-  const fenceEntries = snippet
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith(".mstar/") || line.startsWith("!.mstar/"));
+  const snippetLines = snippet.split("\n").map((line) => line.trim());
+  const fenceEntries = snippetLines.filter((line) => line.startsWith(".mstar/") || line.startsWith("!.mstar/") || line.startsWith(".mstarc"));
+  const commentLines = snippetLines.filter((line) => line.startsWith("#"));
   const missing = fenceEntries.filter((entry) => !lines.has(entry));
   if (missing.length > 0) {
+    const missingComments = commentLines.filter((line) => !lines.has(line));
     const prefix = current && !current.endsWith("\n") ? "\n" : "";
-    fs.appendFileSync(gitignorePath, `${prefix}${snippet}`, "utf8");
+    fs.appendFileSync(gitignorePath, `${prefix}${[...missingComments, ...missing].join("\n")}\n`, "utf8");
     created.push(".gitignore (canonical harness snippet)");
   } else {
     skipped.push(".gitignore (canonical harness snippet already present)");
@@ -338,7 +339,13 @@ function runScaffold(pathArg: string | undefined) {
     skipped.push(".mstar/AGENTS.md (already present)");
   }
 
-  console.log(pc.green(`scaffold: harness initialized at ${harnessDir}`));
+  // Headline is created-count-aware: "initialized" only when something was
+  // created; a no-op re-run on an already-initialized tree says "ensured".
+  const headline =
+    created.length > 0
+      ? `scaffold: harness initialized at ${harnessDir}`
+      : `scaffold: harness ensured at ${harnessDir}`;
+  console.log(pc.green(headline));
   for (const item of created) console.log(`  created: ${item}`);
   for (const item of skipped) console.log(`  skipped: ${item}`);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -521,7 +521,7 @@ function runScaffold(pathArg: string | undefined) {
       //    the first only.
       // 3. RELOCATE — a broad rule sitting after the first canonical
       //    negation is moved before it when only owned lines lie in
-      //    between (feasibility unchanged from round-7).
+      //    between.
       // 4. GUARANTEE — every canonical negation occurs at least once after
       //    the last broad rule (append missing occurrences; duplicates are
       //    harmless in gitignore).
@@ -599,7 +599,7 @@ function runScaffold(pathArg: string | undefined) {
       if (broadAfter.length > 1) {
         // 2. Dedupe: post-partition every line between two broad rules is
         // owned, so extra broad rules are pure redundancy. Removing them
-        // can only make canonical re-inclusions effective (round-3).
+        // can only make canonical re-inclusions effective.
         const [first, ...duplicates] = broadAfter;
         let removed = 0;
         for (const duplicate of duplicates) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -507,6 +507,33 @@ function runScaffold(pathArg: string | undefined) {
           normalized = true;
         }
       }
+      // Ownership invariant, final pass: every canonical negation must
+      // occur at least once AFTER the last `.mstar/**` line. A retained
+      // secondary broad rule sitting between canonical re-inclusions would
+      // otherwise shadow them under last-match-wins even though the fence
+      // was reported as installed. Canonical negation lines are ours to
+      // place; duplicate negation lines are harmless in gitignore, so the
+      // guarantee is satisfied by appending missing occurrences at the end.
+      const broadAfter = finalLines
+        .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
+        .filter((index) => index !== -1);
+      if (broadAfter.length > 0) {
+        const lastBroadIndex = broadAfter[broadAfter.length - 1];
+        let appended = false;
+        for (const negation of Object.keys(CANONICAL_NEGATIONS)) {
+          const covered = finalLines.some(
+            (line, index) => index > lastBroadIndex && line.trim() === negation,
+          );
+          if (!covered) {
+            finalLines.push(negation);
+            appended = true;
+            normalized = true;
+          }
+        }
+        // Preserve a trailing newline when appends landed after the one the
+        // original file already had.
+        if (appended && finalLines[finalLines.length - 1] !== "") finalLines.push("");
+      }
     }
     if (normalized) {
       fs.writeFileSync(gitignorePath, finalLines.join("\n"), "utf8");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -305,14 +305,18 @@ const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
  * rules template when absent. Prints the resolved harness/project dirs plus
  * a created/skipped summary. Idempotent: re-running on an initialized tree
  * is a no-op except creating missing pieces. Ordering is normalized as the
- * final step of the gitignore routine: a misplaced `.mstar/**` (after
- * `!.mstar/…` re-includes, which gitignore's last-match-wins would shadow)
- * is relocated to a slot that preserves every negation's intent — after any
- * CUSTOM `!.mstar/…` negation (a user-authored non-canonical negation keeps
- * its shadowed state) and before every CANONICAL re-include — whether the
- * fence was complete or just appended. When a custom negation is interleaved
- * after a canonical one the ordering is infeasible and the file is left
- * untouched (missing entries were already appended).
+ * final step of the gitignore routine: a misplaced `.mstar/**` (after one
+ * or more canonical `!.mstar/…` re-includes, which gitignore's
+ * last-match-wins would shadow) is relocated to sit immediately before the
+ * first canonical re-include — but only when the move crosses no line
+ * whose semantics we do not own. The broad rule may cross blank/comment
+ * lines, other exact `.mstar/**` duplicates, the 5 canonical negations,
+ * and our own `.mstarc` entry; every other line (custom `!.mstar/…`
+ * negations, custom `.mstar/<path>` ignores, anything else) is
+ * un-crossable. A broad rule already before every canonical negation is
+ * correctly placed and never moves, regardless of surrounding custom
+ * lines. Infeasible → the file keeps its user-authored order (missing
+ * entries were already appended).
  */
 /** The 5 canonical `!.mstar/…` re-includes (verbatim from the snippet SSOT). */
 const CANONICAL_NEGATIONS: Record<string, true> = {
@@ -409,29 +413,27 @@ function runScaffold(pathArg: string | undefined) {
     }
 
     // Unconditional final normalization — gitignore is last-match-wins, so a
-    // misplaced `.mstar/**` (appearing after one or more `!.mstar/…`
-    // re-includes, whether pre-existing or just appended) would shadow them.
-    // Keep exactly ONE broad rule (the earliest occurrence), drop any
-    // trailing duplicates, and relocate the kept rule to a slot that
-    // preserves every negation's intent: after every CUSTOM `!.mstar/…`
-    // negation (a user-authored non-canonical negation keeps its shadowed
-    // state) and before every CANONICAL re-include. When a custom negation
-    // is interleaved after a canonical one the ordering is infeasible — the
-    // file is left untouched (missing entries were already appended above).
-    // Every other line stays byte-for-byte. Runs after EVERY branch above.
+    // misplaced `.mstar/**` (appearing after one or more canonical
+    // `!.mstar/…` re-includes, whether pre-existing or just appended) would
+    // shadow them. Keep exactly ONE broad rule (the earliest occurrence),
+    // drop any trailing duplicates, and relocate the kept rule to sit
+    // immediately before the first canonical re-include — but only when the
+    // move crosses no line whose semantics we do not own. The broad rule may
+    // cross blank/comment lines, other exact `.mstar/**` duplicates, the 5
+    // canonical negations, and our own `.mstarc` entry; every other line
+    // (custom `!.mstar/…` negations, custom `.mstar/<path>` ignores,
+    // anything else) is un-crossable. A broad rule already before every
+    // canonical negation is correctly placed and never moves, regardless of
+    // surrounding custom lines. Infeasible → the file keeps its user-authored
+    // order (missing entries were already appended above). Every other line
+    // stays byte-for-byte. Runs after EVERY branch above.
     const finalLines = fs.readFileSync(gitignorePath, "utf8").split(/\r?\n/);
     const broadIndexes = finalLines
       .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
       .filter((index) => index !== -1);
-    const customNegationIndexes = finalLines
-      .map((line, index) =>
-        line.trim().startsWith("!.mstar/") && CANONICAL_NEGATIONS[line.trim()] !== true ? index : -1,
-      )
-      .filter((index) => index !== -1);
     const canonicalNegationIndexes = finalLines
       .map((line, index) => (CANONICAL_NEGATIONS[line.trim()] === true ? index : -1))
       .filter((index) => index !== -1);
-    const lastCustomNegationIndex = customNegationIndexes[customNegationIndexes.length - 1] ?? -1;
     const firstCanonicalNegationIndex = canonicalNegationIndexes[0] ?? -1;
     let normalized = false;
     if (broadIndexes.length > 0) {
@@ -441,39 +443,33 @@ function runScaffold(pathArg: string | undefined) {
         normalized = true;
       }
       const keptIndex = finalLines.findIndex((line) => line.trim() === ".mstar/**");
-      // A valid slot exists only when every custom negation precedes every
-      // canonical one (either side may be empty). Infeasible → do NOT
-      // reorder; the file keeps its user-authored order.
-      const orderingFeasible =
-        lastCustomNegationIndex === -1 ||
-        firstCanonicalNegationIndex === -1 ||
-        lastCustomNegationIndex < firstCanonicalNegationIndex;
-      // Target slot: immediately after the last custom negation (preserving
-      // its shadowed state), else immediately before the first canonical
-      // re-include. Normalize to the exact slot, like the pre-round-6
-      // behavior did for the first re-include.
-      const targetSlot =
-        lastCustomNegationIndex === -1 ? firstCanonicalNegationIndex - 1 : lastCustomNegationIndex + 1;
-      const hasNegations = customNegationIndexes.length > 0 || canonicalNegationIndexes.length > 0;
-      if (orderingFeasible && hasNegations && keptIndex !== targetSlot) {
-        const [broadLine] = finalLines.splice(keptIndex, 1);
-        // Recompute after the splice (indexes shift when the broad rule sat
-        // before the slot): insert immediately after the last custom
-        // negation, or immediately before the first canonical re-include
-        // when there are no custom negations.
-        const customNow = finalLines
-          .map((line, index) =>
-            line.trim().startsWith("!.mstar/") && CANONICAL_NEGATIONS[line.trim()] !== true ? index : -1,
-          )
-          .filter((index) => index !== -1);
-        const canonicalNow = finalLines
-          .map((line, index) => (CANONICAL_NEGATIONS[line.trim()] === true ? index : -1))
-          .filter((index) => index !== -1);
-        const lastCustomNow = customNow[customNow.length - 1] ?? -1;
-        const firstCanonicalNow = canonicalNow[0] ?? -1;
-        const slot = lastCustomNow === -1 ? firstCanonicalNow : lastCustomNow + 1;
-        finalLines.splice(slot, 0, broadLine);
-        normalized = true;
+      // A broad rule already before every canonical negation is correctly
+      // placed — never move it, regardless of surrounding custom lines.
+      // Only a broad rule AFTER the first canonical negation is misplaced.
+      if (firstCanonicalNegationIndex !== -1 && keptIndex > firstCanonicalNegationIndex) {
+        // Feasibility: the move may only cross lines whose semantics we own
+        // — blank/comment lines, other exact `.mstar/**` duplicates, the 5
+        // canonical negations, and our own `.mstarc` entry. Any other line
+        // (custom `!.mstar/…` negation, custom `.mstar/<path>` ignore, or
+        // anything else) between the first canonical negation and the kept
+        // rule makes the relocation infeasible — the file keeps its
+        // user-authored order.
+        let feasible = true;
+        for (let i = firstCanonicalNegationIndex; i < keptIndex; i++) {
+          const line = finalLines[i].trim();
+          if (line === "") continue; // blank
+          if (line.startsWith("#")) continue; // comment
+          if (line === ".mstar/**") continue; // duplicate broad rule
+          if (CANONICAL_NEGATIONS[line] === true) continue; // canonical negation
+          if (line === ".mstarc") continue; // our own entry
+          feasible = false;
+          break;
+        }
+        if (feasible) {
+          const [broadLine] = finalLines.splice(keptIndex, 1);
+          finalLines.splice(firstCanonicalNegationIndex, 0, broadLine);
+          normalized = true;
+        }
       }
     }
     if (normalized) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -307,9 +307,22 @@ const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
  * is a no-op except creating missing pieces. Ordering is normalized as the
  * final step of the gitignore routine: a misplaced `.mstar/**` (after
  * `!.mstar/…` re-includes, which gitignore's last-match-wins would shadow)
- * is relocated before the first re-include — whether the fence was complete
- * or just appended.
+ * is relocated to a slot that preserves every negation's intent — after any
+ * CUSTOM `!.mstar/…` negation (a user-authored non-canonical negation keeps
+ * its shadowed state) and before every CANONICAL re-include — whether the
+ * fence was complete or just appended. When a custom negation is interleaved
+ * after a canonical one the ordering is infeasible and the file is left
+ * untouched (missing entries were already appended).
  */
+/** The 5 canonical `!.mstar/…` re-includes (verbatim from the snippet SSOT). */
+const CANONICAL_NEGATIONS: Record<string, true> = {
+  "!.mstar/AGENTS.md": true,
+  "!.mstar/knowledge/": true,
+  "!.mstar/knowledge/**": true,
+  "!.mstar/specs/": true,
+  "!.mstar/specs/**": true,
+};
+
 /**
  * Git top-level of `startDir` (lexical, symlink-safe): mirrors the engine's
  * `defaultWorkspaceRoot` — `git rev-parse --show-cdup` returns the relative
@@ -399,14 +412,27 @@ function runScaffold(pathArg: string | undefined) {
     // misplaced `.mstar/**` (appearing after one or more `!.mstar/…`
     // re-includes, whether pre-existing or just appended) would shadow them.
     // Keep exactly ONE broad rule (the earliest occurrence), drop any
-    // trailing duplicates, and relocate the kept rule to sit immediately
-    // before the first re-include; every other line stays byte-for-byte.
-    // Runs after EVERY branch above.
+    // trailing duplicates, and relocate the kept rule to a slot that
+    // preserves every negation's intent: after every CUSTOM `!.mstar/…`
+    // negation (a user-authored non-canonical negation keeps its shadowed
+    // state) and before every CANONICAL re-include. When a custom negation
+    // is interleaved after a canonical one the ordering is infeasible — the
+    // file is left untouched (missing entries were already appended above).
+    // Every other line stays byte-for-byte. Runs after EVERY branch above.
     const finalLines = fs.readFileSync(gitignorePath, "utf8").split(/\r?\n/);
     const broadIndexes = finalLines
       .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
       .filter((index) => index !== -1);
-    const firstNegationIndex = finalLines.findIndex((line) => line.trim().startsWith("!.mstar/"));
+    const customNegationIndexes = finalLines
+      .map((line, index) =>
+        line.trim().startsWith("!.mstar/") && CANONICAL_NEGATIONS[line.trim()] !== true ? index : -1,
+      )
+      .filter((index) => index !== -1);
+    const canonicalNegationIndexes = finalLines
+      .map((line, index) => (CANONICAL_NEGATIONS[line.trim()] === true ? index : -1))
+      .filter((index) => index !== -1);
+    const lastCustomNegationIndex = customNegationIndexes[customNegationIndexes.length - 1] ?? -1;
+    const firstCanonicalNegationIndex = canonicalNegationIndexes[0] ?? -1;
     let normalized = false;
     if (broadIndexes.length > 0) {
       // Drop every duplicate `.mstar/**` after the earliest occurrence.
@@ -415,10 +441,38 @@ function runScaffold(pathArg: string | undefined) {
         normalized = true;
       }
       const keptIndex = finalLines.findIndex((line) => line.trim() === ".mstar/**");
-      if (firstNegationIndex !== -1 && keptIndex !== firstNegationIndex - 1) {
+      // A valid slot exists only when every custom negation precedes every
+      // canonical one (either side may be empty). Infeasible → do NOT
+      // reorder; the file keeps its user-authored order.
+      const orderingFeasible =
+        lastCustomNegationIndex === -1 ||
+        firstCanonicalNegationIndex === -1 ||
+        lastCustomNegationIndex < firstCanonicalNegationIndex;
+      // Target slot: immediately after the last custom negation (preserving
+      // its shadowed state), else immediately before the first canonical
+      // re-include. Normalize to the exact slot, like the pre-round-6
+      // behavior did for the first re-include.
+      const targetSlot =
+        lastCustomNegationIndex === -1 ? firstCanonicalNegationIndex - 1 : lastCustomNegationIndex + 1;
+      const hasNegations = customNegationIndexes.length > 0 || canonicalNegationIndexes.length > 0;
+      if (orderingFeasible && hasNegations && keptIndex !== targetSlot) {
         const [broadLine] = finalLines.splice(keptIndex, 1);
-        const negationNow = finalLines.findIndex((line) => line.trim().startsWith("!.mstar/"));
-        finalLines.splice(negationNow, 0, broadLine);
+        // Recompute after the splice (indexes shift when the broad rule sat
+        // before the slot): insert immediately after the last custom
+        // negation, or immediately before the first canonical re-include
+        // when there are no custom negations.
+        const customNow = finalLines
+          .map((line, index) =>
+            line.trim().startsWith("!.mstar/") && CANONICAL_NEGATIONS[line.trim()] !== true ? index : -1,
+          )
+          .filter((index) => index !== -1);
+        const canonicalNow = finalLines
+          .map((line, index) => (CANONICAL_NEGATIONS[line.trim()] === true ? index : -1))
+          .filter((index) => index !== -1);
+        const lastCustomNow = customNow[customNow.length - 1] ?? -1;
+        const firstCanonicalNow = canonicalNow[0] ?? -1;
+        const slot = lastCustomNow === -1 ? firstCanonicalNow : lastCustomNow + 1;
+        finalLines.splice(slot, 0, broadLine);
         normalized = true;
       }
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import {
   AUDIT_RISKS,
   completenessLevel,
   detectHost,
+  emitGitignoreSnippet,
   evaluatePhaseGate,
   executionModeToN,
   findEphemeralCitations,
@@ -47,6 +48,7 @@ import {
   resolveWorkflowDir,
   reviewPackage,
   scaffoldAuditPlan,
+  scaffoldHarness,
   scopeGuard,
   SddScriptError,
   sddWorkspace,
@@ -280,6 +282,66 @@ function runPluginValidate(options: PluginValidateOptions) {
   }
   process.exitCode = 1;
 }
+/** Minimal `.mstar/AGENTS.md` harness-layer rules template (tracked result). */
+const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
+
+- Path symbols: {HARNESS_DIR} = .mstar/; {PLAN_DIR} = plans/; {SDD_DIR} = sdd/<plan-id>/;
+  {ITERATION_DIR} = iterations/; {KNOWLEDGE_DIR} = knowledge/; {SPECS_DIR} = specs/;
+  {WORKFLOW_DIR} = workflows/; {PROJECT_DIR} = projects/ (SSOT: skills/mstar-conventions).
+- Process vs results: process artifacts (plans/, iterations/, sdd/, status.json, workflows/,
+  projects/) stay local and gitignored; results (this file, knowledge/, specs/) are tracked
+  and shared across clones.
+- Done: only @project-manager or @qa-engineer may set Done; implementers set InReview.
+`;
+
+/**
+ * Run `mstar scaffold [path]`: one-shot harness bootstrap — engine
+ * `scaffoldHarness` (dirs + v2 status.json + projects/_default/), the
+ * canonical `.gitignore` snippet appended when absent, and a minimal
+ * `.mstar/AGENTS.md` harness-layer rules template when absent. Prints a
+ * created/skipped summary. Idempotent: re-running on an initialized tree
+ * is a no-op except creating missing pieces.
+ */
+function runScaffold(pathArg: string | undefined) {
+  const root = pathArg ? path.resolve(pathArg) : process.cwd();
+  const harnessDir = scaffoldHarness(root);
+  const created: string[] = [];
+  const skipped: string[] = [];
+
+  // Canonical .gitignore snippet (plan-conventions § Git 跟踪策略): append
+  // the full snippet when any fence entry is missing, skip cleanly when the
+  // complete set is already present (same per-entry fence check as the
+  // engine's GITIGNORE_PROCESS_ENTRIES / shared-install appendGitignore).
+  const gitignorePath = path.join(root, ".gitignore");
+  const snippet = emitGitignoreSnippet("mstar");
+  const current = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
+  const lines = new Set(current.split(/\r?\n/).map((line) => line.trim()));
+  const fenceEntries = snippet
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith(".mstar/") || line.startsWith("!.mstar/"));
+  const missing = fenceEntries.filter((entry) => !lines.has(entry));
+  if (missing.length > 0) {
+    const prefix = current && !current.endsWith("\n") ? "\n" : "";
+    fs.appendFileSync(gitignorePath, `${prefix}${snippet}`, "utf8");
+    created.push(".gitignore (canonical harness snippet)");
+  } else {
+    skipped.push(".gitignore (canonical harness snippet already present)");
+  }
+
+  // Minimal .mstar/AGENTS.md harness-layer rules (tracked result).
+  const agentsPath = path.join(harnessDir, "AGENTS.md");
+  if (!fs.existsSync(agentsPath)) {
+    fs.writeFileSync(agentsPath, HARNESS_AGENTS_TEMPLATE, "utf8");
+    created.push(".mstar/AGENTS.md");
+  } else {
+    skipped.push(".mstar/AGENTS.md (already present)");
+  }
+
+  console.log(pc.green(`scaffold: harness initialized at ${harnessDir}`));
+  for (const item of created) console.log(`  created: ${item}`);
+  for (const item of skipped) console.log(`  skipped: ${item}`);
+}
 
 program
   .name("mstar-harness")
@@ -304,6 +366,17 @@ program
     // commander's negation `--no-fallbacks` parses as `fallbacks: false`
     // (default true); map to the canonical `noFallbacks` name at the boundary.
     await runInit({ ...options, noFallbacks: options.fallbacks === false });
+  });
+
+program
+  .command("scaffold")
+  .description(
+    "One-shot harness bootstrap: create .mstar/ (dirs + v2 status.json + projects/_default/), " +
+      "append the canonical .gitignore snippet when absent, and write a minimal .mstar/AGENTS.md when absent",
+  )
+  .argument("[path]", "Root to scaffold (default: cwd)")
+  .action((pathArg?: string) => {
+    runScaffold(pathArg);
   });
 
 program
@@ -347,7 +420,7 @@ pathCommand
       // .plans/|plans/ anywhere up the tree — harness not enabled from here.
       const guidance =
         "no harness dir found \u2014 the bounded probe (.mstar/, .agents/, .plans/, plans/) walked up from " +
-        `${startDir} only within the workspace root (git top-level of the start dir; non-git start probes only itself) \u2014 run \`mstar init\` to bootstrap, or pass a start dir inside a harness-enabled project`;
+        `${startDir} only within the workspace root (git top-level of the start dir; non-git start probes only itself) \u2014 run \`mstar scaffold\` to bootstrap, or pass a start dir inside a harness-enabled project`;
       if (options.json) {
         console.log(JSON.stringify({ ok: false, startDir, harnessDir: null, specsDir: null, workflowDir: null, projectDir: null, guidance }));
       } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -323,7 +323,7 @@ function runScaffold(pathArg: string | undefined) {
   // harness_dir, legacy `.agents/`) manage their own ignore rules and are
   // skipped with an explicit note.
   const harnessKind = detectHarnessKind(harnessDir);
-  if (harnessKind === "mstar") {
+  if (harnessKind === "mstar" && harnessDir === path.join(root, ".mstar")) {
     const gitignorePath = path.join(root, ".gitignore");
     const snippet = emitGitignoreSnippet("mstar");
     const current = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -394,7 +394,7 @@ function runScaffold(pathArg: string | undefined) {
       skipped.push(".gitignore (canonical harness snippet already present)");
     }
   } else {
-    skipped.push(".gitignore (canonical harness snippet) — custom harness layout manages its own ignore rules");
+    skipped.push(".gitignore (canonical harness snippet) \u2014 custom harness layout manages its own ignore rules");
   }
 
   // Minimal {HARNESS_DIR}/AGENTS.md harness-layer rules (tracked result).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import {
   AUDIT_PRIORITIES,
   AUDIT_RISKS,
   completenessLevel,
+  detectHarnessKind,
   detectHost,
   emitGitignoreSnippet,
   evaluatePhaseGate,
@@ -296,47 +297,78 @@ const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
 
 /**
  * Run `mstar harness scaffold [path]`: one-shot harness bootstrap — engine
- * `scaffoldHarness` (dirs + v2 status.json + projects/_default/), the
- * canonical `.gitignore` snippet appended when absent, and a minimal
- * `.mstar/AGENTS.md` harness-layer rules template when absent. Prints a
- * created/skipped summary. Idempotent: re-running on an initialized tree
+ * `scaffoldHarness` (dirs + v2 status.json + projects/_default/ under the
+ * resolved harness/project dirs; `.mstarc` `harness_dir` / `project_dir`
+ * honored), the canonical `.gitignore` snippet appended when absent (only
+ * for the default `.mstar/` layout — custom harness layouts manage their
+ * own ignore rules), and a minimal {HARNESS_DIR}/AGENTS.md harness-layer
+ * rules template when absent. Prints the resolved harness/project dirs plus
+ * a created/skipped summary. Idempotent: re-running on an initialized tree
  * is a no-op except creating missing pieces.
  */
 function runScaffold(pathArg: string | undefined) {
   const root = pathArg ? path.resolve(pathArg) : process.cwd();
   const harnessDir = scaffoldHarness(root);
+  const projectDir = resolveProjectDir(root, { harnessDir });
   const created: string[] = [];
   const skipped: string[] = [];
 
-  // Canonical .gitignore snippet (plan-conventions § Git 跟踪策略): append
-  // only the missing fence entries (plus the canonical comment block when
-  // its comment lines are absent), skip cleanly when the complete set is
-  // already present (same per-entry fence check as the engine's
-  // GITIGNORE_PROCESS_ENTRIES / shared-install appendGitignore).
-  const gitignorePath = path.join(root, ".gitignore");
-  const snippet = emitGitignoreSnippet("mstar");
-  const current = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
-  const lines = new Set(current.split(/\r?\n/).map((line) => line.trim()));
-  const snippetLines = snippet.split("\n").map((line) => line.trim());
-  const fenceEntries = snippetLines.filter((line) => line.startsWith(".mstar/") || line.startsWith("!.mstar/") || line.startsWith(".mstarc"));
-  const commentLines = snippetLines.filter((line) => line.startsWith("#"));
-  const missing = fenceEntries.filter((entry) => !lines.has(entry));
-  if (missing.length > 0) {
-    const missingComments = commentLines.filter((line) => !lines.has(line));
-    const prefix = current && !current.endsWith("\n") ? "\n" : "";
-    fs.appendFileSync(gitignorePath, `${prefix}${[...missingComments, ...missing].join("\n")}\n`, "utf8");
-    created.push(".gitignore (canonical harness snippet)");
+  // Canonical .gitignore snippet (plan-conventions § Git 跟踪策略): the
+  // snippet literals are `.mstar/**`-based, so the append only makes sense
+  // for the default `.mstar/` layout. Custom harness layouts (`.mstarc`
+  // harness_dir, legacy `.agents/`) manage their own ignore rules and are
+  // skipped with an explicit note.
+  const harnessKind = detectHarnessKind(harnessDir);
+  if (harnessKind === "mstar") {
+    const gitignorePath = path.join(root, ".gitignore");
+    const snippet = emitGitignoreSnippet("mstar");
+    const current = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
+    const lines = new Set(current.split(/\r?\n/).map((line) => line.trim()));
+    const snippetLines = snippet.split("\n").map((line) => line.trim());
+    const fenceEntries = snippetLines.filter(
+      (line) => line.startsWith(".mstar/") || line.startsWith("!.mstar/") || line.startsWith(".mstarc"),
+    );
+    const commentLines = snippetLines.filter((line) => line.startsWith("#"));
+    const missing = fenceEntries.filter((entry) => !lines.has(entry));
+    if (missing.length > 0) {
+      const missingComments = commentLines.filter((line) => !lines.has(line));
+      const broadRule = ".mstar/**";
+      const currentLines = current.split(/\r?\n/);
+      const firstNegation = currentLines.findIndex((line) => line.trim().startsWith("!.mstar/"));
+      if (!lines.has(broadRule) && firstNegation !== -1) {
+        // gitignore = last matching pattern wins: appending `.mstar/**`
+        // after existing `!.mstar/…` re-includes would shadow them. Splice
+        // the canonical block start (comments + broad rule + missing
+        // re-includes) BEFORE the first negation so the re-includes stay
+        // effective. `.mstarc` is a plain ignore (no negations) — appended
+        // at the end when missing.
+        const blockStart = [...missingComments, broadRule, ...missing.filter((entry) => entry.startsWith("!.mstar/"))];
+        currentLines.splice(firstNegation, 0, ...blockStart);
+        let next = currentLines.join("\n");
+        if (missing.includes(".mstarc")) next = `${next}${next.endsWith("\n") ? "" : "\n"}.mstarc\n`;
+        fs.writeFileSync(gitignorePath, next, "utf8");
+      } else {
+        // Broad rule present (append missing entries after it) or no
+        // negations to shadow (append the whole block) — both safe.
+        const prefix = current && !current.endsWith("\n") ? "\n" : "";
+        fs.appendFileSync(gitignorePath, `${prefix}${[...missingComments, ...missing].join("\n")}\n`, "utf8");
+      }
+      created.push(".gitignore (canonical harness snippet)");
+    } else {
+      skipped.push(".gitignore (canonical harness snippet already present)");
+    }
   } else {
-    skipped.push(".gitignore (canonical harness snippet already present)");
+    skipped.push(".gitignore (canonical harness snippet) — custom harness layout manages its own ignore rules");
   }
 
-  // Minimal .mstar/AGENTS.md harness-layer rules (tracked result).
+  // Minimal {HARNESS_DIR}/AGENTS.md harness-layer rules (tracked result).
   const agentsPath = path.join(harnessDir, "AGENTS.md");
+  const agentsLabel = `${path.basename(harnessDir)}/AGENTS.md`;
   if (!fs.existsSync(agentsPath)) {
     fs.writeFileSync(agentsPath, HARNESS_AGENTS_TEMPLATE, "utf8");
-    created.push(".mstar/AGENTS.md");
+    created.push(agentsLabel);
   } else {
-    skipped.push(".mstar/AGENTS.md (already present)");
+    skipped.push(`${agentsLabel} (already present)`);
   }
 
   // Headline is created-count-aware: "initialized" only when something was
@@ -346,6 +378,8 @@ function runScaffold(pathArg: string | undefined) {
       ? `scaffold: harness initialized at ${harnessDir}`
       : `scaffold: harness ensured at ${harnessDir}`;
   console.log(pc.green(headline));
+  console.log(`  harness dir: ${harnessDir}`);
+  console.log(`  project dir: ${projectDir}`);
   for (const item of created) console.log(`  created: ${item}`);
   for (const item of skipped) console.log(`  skipped: ${item}`);
 }
@@ -382,8 +416,9 @@ const harnessCommand = program
 harnessCommand
   .command("scaffold")
   .description(
-    "One-shot harness bootstrap: create .mstar/ (dirs + v2 status.json + projects/_default/), " +
-      "append the canonical .gitignore snippet when absent, and write a minimal .mstar/AGENTS.md when absent",
+    "One-shot harness bootstrap: create the harness dir (default .mstar/, honoring .mstarc harness_dir/project_dir) " +
+      "with dirs + v2 status.json + projects/_default/, append the canonical .gitignore snippet when absent " +
+      "(skipped for non-.mstar layouts), and write a minimal {HARNESS_DIR}/AGENTS.md when absent",
   )
   .argument("[path]", "Root to scaffold (default: cwd)")
   .action((pathArg?: string) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -310,6 +310,34 @@ const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
  * is relocated before the first re-include — whether the fence was complete
  * or just appended.
  */
+/**
+ * Git top-level of `startDir` (lexical, symlink-safe): mirrors the engine's
+ * `defaultWorkspaceRoot` — `git rev-parse --show-cdup` returns the relative
+ * upward path to the work-tree top, so the result stays comparable with
+ * `resolve()`-based paths even when `startDir` sits under a symlinked mount
+ * (macOS /var → /private/var), where `--show-toplevel` would answer with
+ * the physical path. On failure (not a git work tree, or git absent) falls
+ * back to `startDir` itself.
+ */
+function gitWorkspaceRoot(startDir: string): string {
+  try {
+    const cdup = execFileSync("git", ["rev-parse", "--show-cdup"], {
+      cwd: startDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!cdup) return startDir; // already at the git top-level
+    let boundary = startDir;
+    for (const segment of cdup.split(/[\\/]/)) {
+      if (segment && segment !== ".") boundary = path.dirname(boundary);
+    }
+    return path.resolve(boundary);
+  } catch {
+    // not a git work tree (or git unavailable) — fall through to startDir
+  }
+  return startDir;
+}
+
 function runScaffold(pathArg: string | undefined) {
   const root = pathArg ? path.resolve(pathArg) : process.cwd();
   const harnessDir = scaffoldHarness(root);
@@ -319,12 +347,19 @@ function runScaffold(pathArg: string | undefined) {
 
   // Canonical .gitignore snippet (plan-conventions § Git 跟踪策略): the
   // snippet literals are `.mstar/**`-based, so the append only makes sense
-  // for the default `.mstar/` layout. Custom harness layouts (`.mstarc`
-  // harness_dir, legacy `.agents/`) manage their own ignore rules and are
-  // skipped with an explicit note.
+  // for the default `<workspaceRoot>/.mstar/` layout. Custom harness layouts
+  // (`.mstarc` harness_dir, legacy `.agents/`) manage their own ignore rules
+  // and are skipped with an explicit note. The comparison AND the fence target
+  // are anchored at the git top-level of `root` (falling back to `root` when
+  // not a git work tree): a repo-root `.mstarc` `harness_dir=.mstar` resolves
+  // the harness dir against the config file's location, so scaffolding a
+  // subdirectory path would otherwise compare `<repoRoot>/.mstar` against
+  // `<subdir>/.mstar` and skip the fence while process artifacts stay
+  // committable.
+  const workspaceRoot = gitWorkspaceRoot(root);
   const harnessKind = detectHarnessKind(harnessDir);
-  if (harnessKind === "mstar" && harnessDir === path.join(root, ".mstar")) {
-    const gitignorePath = path.join(root, ".gitignore");
+  if (harnessKind === "mstar" && path.resolve(harnessDir) === path.join(workspaceRoot, ".mstar")) {
+    const gitignorePath = path.join(workspaceRoot, ".gitignore");
     const snippet = emitGitignoreSnippet("mstar");
     const current = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
     const lines = new Set(current.split(/\r?\n/).map((line) => line.trim()));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -304,7 +304,10 @@ const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
  * own ignore rules), and a minimal {HARNESS_DIR}/AGENTS.md harness-layer
  * rules template when absent. Prints the resolved harness/project dirs plus
  * a created/skipped summary. Idempotent: re-running on an initialized tree
- * is a no-op except creating missing pieces.
+ * is a no-op except creating missing pieces. A complete-but-misordered fence
+ * (`.mstar/**` after `!.mstar/…` re-includes, which gitignore's last-match-
+ * wins would shadow) is repaired by relocating the broad rule before the
+ * first re-include.
  */
 function runScaffold(pathArg: string | undefined) {
   const root = pathArg ? path.resolve(pathArg) : process.cwd();
@@ -355,7 +358,21 @@ function runScaffold(pathArg: string | undefined) {
       }
       created.push(".gitignore (canonical harness snippet)");
     } else {
-      skipped.push(".gitignore (canonical harness snippet already present)");
+      // All canonical entries present — but gitignore is last-match-wins, so
+      // a misplaced `.mstar/**` (appearing after one or more `!.mstar/…`
+      // re-includes) would shadow them. Relocate the broad rule to just
+      // before the first re-include; every other line stays byte-for-byte.
+      const currentLines = current.split(/\r?\n/);
+      const broadIndex = currentLines.findIndex((line) => line.trim() === ".mstar/**");
+      const firstNegationIndex = currentLines.findIndex((line) => line.trim().startsWith("!.mstar/"));
+      if (broadIndex !== -1 && firstNegationIndex !== -1 && broadIndex > firstNegationIndex) {
+        const [broadLine] = currentLines.splice(broadIndex, 1);
+        currentLines.splice(firstNegationIndex, 0, broadLine);
+        fs.writeFileSync(gitignorePath, currentLines.join("\n"), "utf8");
+        created.push(".gitignore (canonical harness snippet reordered)");
+      } else {
+        skipped.push(".gitignore (canonical harness snippet already present)");
+      }
     }
   } else {
     skipped.push(".gitignore (canonical harness snippet) — custom harness layout manages its own ignore rules");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -304,10 +304,11 @@ const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
  * own ignore rules), and a minimal {HARNESS_DIR}/AGENTS.md harness-layer
  * rules template when absent. Prints the resolved harness/project dirs plus
  * a created/skipped summary. Idempotent: re-running on an initialized tree
- * is a no-op except creating missing pieces. A complete-but-misordered fence
- * (`.mstar/**` after `!.mstar/…` re-includes, which gitignore's last-match-
- * wins would shadow) is repaired by relocating the broad rule before the
- * first re-include.
+ * is a no-op except creating missing pieces. Ordering is normalized as the
+ * final step of the gitignore routine: a misplaced `.mstar/**` (after
+ * `!.mstar/…` re-includes, which gitignore's last-match-wins would shadow)
+ * is relocated before the first re-include — whether the fence was complete
+ * or just appended.
  */
 function runScaffold(pathArg: string | undefined) {
   const root = pathArg ? path.resolve(pathArg) : process.cwd();
@@ -357,22 +358,23 @@ function runScaffold(pathArg: string | undefined) {
         fs.appendFileSync(gitignorePath, `${prefix}${[...missingComments, ...missing].join("\n")}\n`, "utf8");
       }
       created.push(".gitignore (canonical harness snippet)");
-    } else {
-      // All canonical entries present — but gitignore is last-match-wins, so
-      // a misplaced `.mstar/**` (appearing after one or more `!.mstar/…`
-      // re-includes) would shadow them. Relocate the broad rule to just
-      // before the first re-include; every other line stays byte-for-byte.
-      const currentLines = current.split(/\r?\n/);
-      const broadIndex = currentLines.findIndex((line) => line.trim() === ".mstar/**");
-      const firstNegationIndex = currentLines.findIndex((line) => line.trim().startsWith("!.mstar/"));
-      if (broadIndex !== -1 && firstNegationIndex !== -1 && broadIndex > firstNegationIndex) {
-        const [broadLine] = currentLines.splice(broadIndex, 1);
-        currentLines.splice(firstNegationIndex, 0, broadLine);
-        fs.writeFileSync(gitignorePath, currentLines.join("\n"), "utf8");
-        created.push(".gitignore (canonical harness snippet reordered)");
-      } else {
-        skipped.push(".gitignore (canonical harness snippet already present)");
-      }
+    }
+
+    // Unconditional final normalization — gitignore is last-match-wins, so a
+    // misplaced `.mstar/**` (appearing after one or more `!.mstar/…`
+    // re-includes, whether pre-existing or just appended) would shadow them.
+    // Relocate the broad rule to just before the first re-include; every
+    // other line stays byte-for-byte. Runs after EVERY branch above.
+    const finalLines = fs.readFileSync(gitignorePath, "utf8").split(/\r?\n/);
+    const broadIndex = finalLines.findIndex((line) => line.trim() === ".mstar/**");
+    const firstNegationIndex = finalLines.findIndex((line) => line.trim().startsWith("!.mstar/"));
+    if (broadIndex !== -1 && firstNegationIndex !== -1 && broadIndex > firstNegationIndex) {
+      const [broadLine] = finalLines.splice(broadIndex, 1);
+      finalLines.splice(firstNegationIndex, 0, broadLine);
+      fs.writeFileSync(gitignorePath, finalLines.join("\n"), "utf8");
+      created.push(".gitignore (canonical harness snippet reordered)");
+    } else if (missing.length === 0) {
+      skipped.push(".gitignore (canonical harness snippet already present)");
     }
   } else {
     skipped.push(".gitignore (canonical harness snippet) — custom harness layout manages its own ignore rules");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -363,14 +363,31 @@ function runScaffold(pathArg: string | undefined) {
     // Unconditional final normalization — gitignore is last-match-wins, so a
     // misplaced `.mstar/**` (appearing after one or more `!.mstar/…`
     // re-includes, whether pre-existing or just appended) would shadow them.
-    // Relocate the broad rule to just before the first re-include; every
-    // other line stays byte-for-byte. Runs after EVERY branch above.
+    // Keep exactly ONE broad rule (the earliest occurrence), drop any
+    // trailing duplicates, and relocate the kept rule to sit immediately
+    // before the first re-include; every other line stays byte-for-byte.
+    // Runs after EVERY branch above.
     const finalLines = fs.readFileSync(gitignorePath, "utf8").split(/\r?\n/);
-    const broadIndex = finalLines.findIndex((line) => line.trim() === ".mstar/**");
+    const broadIndexes = finalLines
+      .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
+      .filter((index) => index !== -1);
     const firstNegationIndex = finalLines.findIndex((line) => line.trim().startsWith("!.mstar/"));
-    if (broadIndex !== -1 && firstNegationIndex !== -1 && broadIndex > firstNegationIndex) {
-      const [broadLine] = finalLines.splice(broadIndex, 1);
-      finalLines.splice(firstNegationIndex, 0, broadLine);
+    let normalized = false;
+    if (broadIndexes.length > 0) {
+      // Drop every duplicate `.mstar/**` after the earliest occurrence.
+      for (let i = broadIndexes.length - 1; i > 0; i--) {
+        finalLines.splice(broadIndexes[i], 1);
+        normalized = true;
+      }
+      const keptIndex = finalLines.findIndex((line) => line.trim() === ".mstar/**");
+      if (firstNegationIndex !== -1 && keptIndex !== firstNegationIndex - 1) {
+        const [broadLine] = finalLines.splice(keptIndex, 1);
+        const negationNow = finalLines.findIndex((line) => line.trim().startsWith("!.mstar/"));
+        finalLines.splice(negationNow, 0, broadLine);
+        normalized = true;
+      }
+    }
+    if (normalized) {
       fs.writeFileSync(gitignorePath, finalLines.join("\n"), "utf8");
       created.push(".gitignore (canonical harness snippet reordered)");
     } else if (missing.length === 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -295,7 +295,7 @@ const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
 `;
 
 /**
- * Run `mstar scaffold [path]`: one-shot harness bootstrap — engine
+ * Run `mstar harness scaffold [path]`: one-shot harness bootstrap — engine
  * `scaffoldHarness` (dirs + v2 status.json + projects/_default/), the
  * canonical `.gitignore` snippet appended when absent, and a minimal
  * `.mstar/AGENTS.md` harness-layer rules template when absent. Prints a
@@ -375,7 +375,11 @@ program
     await runInit({ ...options, noFallbacks: options.fallbacks === false });
   });
 
-program
+const harnessCommand = program
+  .command("harness")
+  .description("harness bootstrap / dir-resolution helpers (engine-backed)");
+
+harnessCommand
   .command("scaffold")
   .description(
     "One-shot harness bootstrap: create .mstar/ (dirs + v2 status.json + projects/_default/), " +
@@ -427,7 +431,7 @@ pathCommand
       // .plans/|plans/ anywhere up the tree — harness not enabled from here.
       const guidance =
         "no harness dir found \u2014 the bounded probe (.mstar/, .agents/, .plans/, plans/) walked up from " +
-        `${startDir} only within the workspace root (git top-level of the start dir; non-git start probes only itself) \u2014 run \`mstar scaffold\` to bootstrap, or pass a start dir inside a harness-enabled project`;
+        `${startDir} only within the workspace root (git top-level of the start dir; non-git start probes only itself) \u2014 run \`mstar harness scaffold\` to bootstrap, or pass a start dir inside a harness-enabled project`;
       if (options.json) {
         console.log(JSON.stringify({ ok: false, startDir, harnessDir: null, specsDir: null, workflowDir: null, projectDir: null, guidance }));
       } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -305,7 +305,12 @@ const HARNESS_AGENTS_TEMPLATE = `# AGENTS.md \u2014 .mstar/ (harness layer)
  * rules template when absent. Prints the resolved harness/project dirs plus
  * a created/skipped summary. Idempotent: re-running on an initialized tree
  * is a no-op except creating missing pieces. Ordering is normalized as the
- * final step of the gitignore routine: a misplaced `.mstar/**` (after one
+ * final step of the gitignore routine: duplicate `.mstar/**` rules are
+ * deduped segment-wise — a trailing duplicate is dropped only when no
+ * un-crossable line lies strictly between it and the previously retained
+ * broad rule (a custom `!.mstar/…` re-inclusion between two broad rules
+ * makes the trailing broad semantically load-bearing: last-match-wins
+ * re-ignores the custom path), and a misplaced `.mstar/**` (after one
  * or more canonical `!.mstar/…` re-includes, which gitignore's
  * last-match-wins would shadow) is relocated to sit immediately before the
  * first canonical re-include — but only when the move crosses no line
@@ -415,18 +420,23 @@ function runScaffold(pathArg: string | undefined) {
     // Unconditional final normalization — gitignore is last-match-wins, so a
     // misplaced `.mstar/**` (appearing after one or more canonical
     // `!.mstar/…` re-includes, whether pre-existing or just appended) would
-    // shadow them. Keep exactly ONE broad rule (the earliest occurrence),
-    // drop any trailing duplicates, and relocate the kept rule to sit
-    // immediately before the first canonical re-include — but only when the
-    // move crosses no line whose semantics we do not own. The broad rule may
-    // cross blank/comment lines, other exact `.mstar/**` duplicates, the 5
-    // canonical negations, and our own `.mstarc` entry; every other line
-    // (custom `!.mstar/…` negations, custom `.mstar/<path>` ignores,
-    // anything else) is un-crossable. A broad rule already before every
-    // canonical negation is correctly placed and never moves, regardless of
-    // surrounding custom lines. Infeasible → the file keeps its user-authored
-    // order (missing entries were already appended above). Every other line
-    // stays byte-for-byte. Runs after EVERY branch above.
+    // shadow them. Dedupe is SEGMENTED: a duplicate `.mstar/**` is dropped
+    // only when no un-crossable line lies strictly between it and the
+    // previously retained broad rule — a custom `!.mstar/…` re-inclusion
+    // between two broad rules makes the trailing broad semantically
+    // load-bearing (last-match-wins re-ignores the custom path), so it is
+    // retained exactly where it is. The kept (earliest) broad rule is then
+    // relocated to sit immediately before the first canonical re-include —
+    // but only when the move crosses no line whose semantics we do not own.
+    // The broad rule may cross blank/comment lines, other exact
+    // `.mstar/**` duplicates, the 5 canonical negations, and our own
+    // `.mstarc` entry; every other line (custom `!.mstar/…` negations,
+    // custom `.mstar/<path>` ignores, anything else) is un-crossable. A
+    // broad rule already before every canonical negation is correctly placed
+    // and never moves, regardless of surrounding custom lines. Infeasible →
+    // the file keeps its user-authored order (missing entries were already
+    // appended above). Every other line stays byte-for-byte. Runs after
+    // EVERY branch above.
     const finalLines = fs.readFileSync(gitignorePath, "utf8").split(/\r?\n/);
     const broadIndexes = finalLines
       .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
@@ -437,10 +447,36 @@ function runScaffold(pathArg: string | undefined) {
     const firstCanonicalNegationIndex = canonicalNegationIndexes[0] ?? -1;
     let normalized = false;
     if (broadIndexes.length > 0) {
-      // Drop every duplicate `.mstar/**` after the earliest occurrence.
-      for (let i = broadIndexes.length - 1; i > 0; i--) {
-        finalLines.splice(broadIndexes[i], 1);
-        normalized = true;
+      // Segmented dedupe: drop a duplicate `.mstar/**` only when NO
+      // un-crossable line lies strictly between it and the previously
+      // retained broad rule. A custom `!.mstar/…` re-inclusion (or any
+      // other un-owned line) between two broad rules makes the trailing
+      // broad semantically load-bearing — gitignore's last-match-wins
+      // re-ignores the custom path, and deleting the broad would flip
+      // that line's meaning. Retained secondary broads stay exactly
+      // where they are.
+      let removed = 0;
+      let lastRetainedBroadIndex = broadIndexes[0];
+      for (let i = 1; i < broadIndexes.length; i++) {
+        const candidate = broadIndexes[i] - removed;
+        let crossable = true;
+        for (let j = lastRetainedBroadIndex + 1; j < candidate; j++) {
+          const line = finalLines[j].trim();
+          if (line === "") continue; // blank
+          if (line.startsWith("#")) continue; // comment
+          if (line === ".mstar/**") continue; // duplicate broad rule
+          if (CANONICAL_NEGATIONS[line] === true) continue; // canonical negation
+          if (line === ".mstarc") continue; // our own entry
+          crossable = false;
+          break;
+        }
+        if (crossable) {
+          finalLines.splice(candidate, 1);
+          removed++;
+          normalized = true;
+        } else {
+          lastRetainedBroadIndex = candidate;
+        }
       }
       const keptIndex = finalLines.findIndex((line) => line.trim() === ".mstar/**");
       // A broad rule already before every canonical negation is correctly

--- a/packages/cli/test/path-resolve.test.ts
+++ b/packages/cli/test/path-resolve.test.ts
@@ -154,7 +154,7 @@ describe("mstar path resolve — harness/specs dir resolution", () => {
       const result = runResolve([root]);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("no harness dir");
-      expect(result.stderr).toContain("mstar init");
+      expect(result.stderr).toContain("mstar scaffold");
       expect(result.stdout).toBe("");
     });
   });
@@ -199,7 +199,7 @@ describe("mstar path resolve — harness/specs dir resolution", () => {
       const doc = JSON.parse(result.stdout) as { ok: boolean; harnessDir: null; guidance: string };
       expect(doc.ok).toBe(false);
       expect(doc.harnessDir).toBeNull();
-      expect(doc.guidance).toContain("mstar init");
+      expect(doc.guidance).toContain("mstar scaffold");
     });
   });
 

--- a/packages/cli/test/path-resolve.test.ts
+++ b/packages/cli/test/path-resolve.test.ts
@@ -154,7 +154,7 @@ describe("mstar path resolve — harness/specs dir resolution", () => {
       const result = runResolve([root]);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("no harness dir");
-      expect(result.stderr).toContain("mstar scaffold");
+      expect(result.stderr).toContain("mstar harness scaffold");
       expect(result.stdout).toBe("");
     });
   });
@@ -199,7 +199,7 @@ describe("mstar path resolve — harness/specs dir resolution", () => {
       const doc = JSON.parse(result.stdout) as { ok: boolean; harnessDir: null; guidance: string };
       expect(doc.ok).toBe(false);
       expect(doc.harnessDir).toBeNull();
-      expect(doc.guidance).toContain("mstar scaffold");
+      expect(doc.guidance).toContain("mstar harness scaffold");
     });
   });
 

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -286,9 +286,13 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
   test("trailing duplicate .mstar/** after a correctly ordered fence: dedupes to one broad rule before every re-include, preserving other lines", () => {
     withRoot((root) => {
       // Correctly ordered complete fence, then a trailing duplicate
-      // .mstar/** at the very end. findIndex-based normalization only sees
-      // the FIRST broad rule (already correctly placed), so the trailing
-      // duplicate would survive and shadow the re-includes (last-match-wins).
+      // .mstar/** at the very end. Segmented dedupe drops the trailing
+      // duplicate because only lines we own the semantics of (comments,
+      // the 5 canonical negations, our own .mstarc entry) lie strictly
+      // between it and the previously retained broad rule — no un-crossable
+      // line makes it load-bearing. The kept (earliest) broad rule is
+      // already correctly placed (before every canonical re-include), so it
+      // is not moved either.
       const userLines = [
         "# user comment",
         "node_modules/",
@@ -301,8 +305,8 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         "!.mstar/specs/",
         "!.mstar/specs/**",
         ".mstarc",
-        "dist/",
         ".mstar/**",
+        "dist/",
       ];
       writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
 
@@ -336,13 +340,18 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("duplicate .mstar/** both before AND after re-includes: keeps the earliest, drops the trailing one, never moves a correctly-placed broad rule", () => {
+  test("duplicate .mstar/** both before AND after re-includes: trailing broad RETAINED when an un-crossable line lies between (PR #147 round-8)", () => {
     withRoot((root) => {
       // One broad rule before the negations (correctly placed) and a second
-      // one after them (shadowing). The kept rule must be the EARLIEST
-      // occurrence, and the trailing duplicate must be removed. The kept
-      // rule already sits before every canonical negation, so the
-      // un-crossable-lines invariant must NOT move it across node_modules/.
+      // one after them. Round-8 semantics: the trailing duplicate is dropped
+      // ONLY when no un-crossable line lies strictly between it and the
+      // previously retained broad rule. Here node_modules/ (a line whose
+      // semantics we do not own) sits between the two broad rules, so the
+      // trailing broad is semantically load-bearing and must be RETAINED
+      // exactly where it is — the file keeps its user-authored order. The
+      // kept (earliest) broad rule already sits before every canonical
+      // negation, so the un-crossable-lines invariant must NOT move it
+      // across node_modules/ either.
       const userLines = [
         "# user comment",
         ".mstar/**",
@@ -360,26 +369,35 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
 
       const first = runScaffold([root]);
       expect(first.exitCode).toBe(0);
-      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
+      // No reorder and no dedupe: the trailing broad is load-bearing, so
+      // the file is already correctly ordered.
+      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
+      expect(first.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
 
       const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      // Byte-for-byte unchanged (complete fence, nothing to normalize).
+      expect(gitignore).toBe(`${userLines.join("\n")}\n`);
       const lines = gitignore.split(/\r?\n/);
-      // Exactly ONE broad rule, still at its original position (before
-      // node_modules/ and before every re-include).
-      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
-      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const broadIndexes = lines
+        .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
+        .filter((index) => index !== -1);
       const negationIndexes = lines
         .map((line, index) => (line.trim().startsWith("!.mstar/") ? index : -1))
         .filter((index) => index !== -1);
-      expect(broadIndex).toBeGreaterThan(-1);
-      expect(negationIndexes.length).toBeGreaterThan(0);
-      expect(broadIndex).toBe(1);
-      expect(broadIndex).toBeLessThan(lines.findIndex((line) => line.trim() === "node_modules/"));
-      for (const negationIndex of negationIndexes) expect(broadIndex).toBeLessThan(negationIndex);
+      // BOTH broad rules retained, in their original positions: the first
+      // before node_modules/ and before every re-include, the trailing one
+      // after them.
+      expect(broadIndexes.length).toBe(2);
+      expect(broadIndexes[0]).toBe(1);
+      expect(broadIndexes[0]).toBeLessThan(lines.findIndex((line) => line.trim() === "node_modules/"));
+      for (const negationIndex of negationIndexes) {
+        expect(broadIndexes[0]).toBeLessThan(negationIndex);
+        expect(broadIndexes[1]).toBeGreaterThan(negationIndex);
+      }
       // All canonical entries present; unrelated user lines preserved in order.
       for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
       for (const line of ["# user comment", "node_modules/", "dist/"]) expect(gitignore).toContain(line);
-      // The kept broad rule stays at its original position, BEFORE
+      // The first broad rule stays at its original position, BEFORE
       // node_modules/ (it was already correctly placed).
       expect(gitignore.indexOf(".mstar/**")).toBeLessThan(gitignore.indexOf("node_modules/"));
       expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
@@ -704,6 +722,99 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       expect(tracked.exitCode).toBe(0);
       const trackedFiles = tracked.stdout.toString();
       expect(trackedFiles).toContain(".mstar/custom/x.md");
+      expect(trackedFiles).toContain(".mstar/knowledge/y.md");
+      const ignored = Bun.spawnSync(["git", "check-ignore", "-v", join(root, ".mstar", "status.json")], {
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(ignored.exitCode).toBe(0);
+      expect(ignored.stdout.toString()).toContain(".mstar/**");
+
+      // Idempotent: second run changes nothing.
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
+    });
+  });
+
+  test("custom negation BETWEEN two .mstar/** rules: trailing broad RETAINED, custom path stays ignored (PR #147 round-8)", () => {
+    withRoot((root) => {
+      // Regression (PR #147 round-8): the unconditional dedupe used to drop
+      // EVERY `.mstar/**` after the earliest occurrence. When a custom
+      // `!.mstar/…` re-inclusion sits BETWEEN two broad rules, the trailing
+      // broad deliberately re-ignores that path (gitignore last-match-wins)
+      // — deleting it would make the custom path trackable and flip the
+      // meaning of a line we do not own. Segmented dedupe must RETAIN the
+      // trailing broad (an un-crossable line lies strictly between it and
+      // the previously retained broad rule) and leave the file byte-for-byte
+      // untouched.
+      const userLines = [
+        "# user comment",
+        ".mstar/**",
+        "!.mstar/custom/**",
+        ".mstar/**",
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+        ".mstarc",
+        "dist/",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+      // git add -A / ls-files / check-ignore below need a valid work tree.
+      gitInit(root);
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      // No reorder and no dedupe: the trailing broad is semantically
+      // load-bearing, so the file is already correctly ordered.
+      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
+      expect(first.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      // Byte-for-byte unchanged (complete fence, nothing to normalize).
+      expect(gitignore).toBe(`${userLines.join("\n")}\n`);
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndexes = lines
+        .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
+        .filter((index) => index !== -1);
+      const customIndex = lines.findIndex((line) => line.trim() === "!.mstar/custom/**");
+      const canonicalIndexes = lines
+        .map((line, index) => (MSTAR_FENCE_ENTRIES.slice(1).includes(line.trim()) ? index : -1))
+        .filter((index) => index !== -1);
+      // BOTH broad rules retained, in their original positions: the first
+      // before the custom negation, the trailing one after it (re-ignoring
+      // the custom path), and both before every canonical re-include.
+      expect(broadIndexes.length).toBe(2);
+      expect(broadIndexes[0]).toBeLessThan(customIndex);
+      expect(broadIndexes[1]).toBeGreaterThan(customIndex);
+      for (const canonicalIndex of canonicalIndexes) {
+        expect(broadIndexes[0]).toBeLessThan(canonicalIndex);
+        expect(broadIndexes[1]).toBeLessThan(canonicalIndex);
+      }
+      // All canonical entries present; unrelated user lines preserved in order.
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      for (const line of ["# user comment", "dist/"]) expect(gitignore).toContain(line);
+      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+
+      // Observable git semantics: the trailing broad re-ignores the custom
+      // path (last-match-wins), so .mstar/custom/x is NOT tracked, while
+      // knowledge contents stay tracked and .mstar/status.json stays
+      // ignored (check-ignore).
+      mkdirSync(join(root, ".mstar", "custom"), { recursive: true });
+      mkdirSync(join(root, ".mstar", "knowledge"), { recursive: true });
+      writeFileSync(join(root, ".mstar", "custom", "x.md"), "# x\n", "utf8");
+      writeFileSync(join(root, ".mstar", "knowledge", "y.md"), "# y\n", "utf8");
+      writeFileSync(join(root, ".mstar", "status.json"), "{}\n", "utf8");
+      const addAll = Bun.spawnSync(["git", "add", "-A"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+      expect(addAll.exitCode).toBe(0);
+      const tracked = Bun.spawnSync(["git", "ls-files"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+      expect(tracked.exitCode).toBe(0);
+      const trackedFiles = tracked.stdout.toString();
+      expect(trackedFiles).not.toContain(".mstar/custom/x.md");
       expect(trackedFiles).toContain(".mstar/knowledge/y.md");
       const ignored = Bun.spawnSync(["git", "check-ignore", "-v", join(root, ".mstar", "status.json")], {
         cwd: root,

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -382,10 +382,10 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
         .filter((index) => index !== -1);
       const lastBroadIndex = broadIndexes[broadIndexes.length - 1];
-      // BOTH broad rules retained in their original positions.
-      expect(broadIndexes.length).toBe(2);
+      // ONE broad rule: post-partition the duplicate is pure redundancy
+      // (round-10 dedupe) and is removed.
+      expect(broadIndexes.length).toBe(1);
       expect(broadIndexes[0]).toBe(1);
-      expect(broadIndexes[1]).toBe(userLines.length - 1);
       expect(lines.findIndex((line) => line.trim() === "node_modules/")).toBeGreaterThan(broadIndexes[0]);
       expect(lines.findIndex((line) => line.trim() === "dist/")).toBeGreaterThan(broadIndexes[0]);
       // Ownership invariant: every canonical negation now occurs at least
@@ -401,10 +401,21 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         const lastOccurrence = lines.map((line) => line.trim() === negation).lastIndexOf(true);
         expect(lastOccurrence).toBeGreaterThan(lastBroadIndex);
       }
-      // The appended block sits at the end, in canonical order, after all
-      // original user lines (the original trailing newline is preserved and
-      // a fresh one terminates the appends).
-      expect(lines.slice(lastBroadIndex + 1)).toEqual([""].concat(canonicalOrder, [""]));
+      // Round-10: the partition lifts nothing here (no targeted user
+      // rules) and every canonical negation already occurs after the sole
+      // broad rule — so the remainder of the file is byte-for-byte the
+      // original order (trailing newline preserved).
+      expect(lines.slice(lastBroadIndex + 1)).toEqual([
+        "node_modules/",
+        "!.mstar/knowledge/**",
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+        ".mstarc",
+        "dist/",
+        "",
+      ]);
       // Unrelated user lines preserved in order.
       for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
       for (const line of ["# user comment", "node_modules/", "dist/"]) expect(gitignore).toContain(line);
@@ -552,17 +563,15 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("custom !.mstar negation before the broad rule: fence left untouched, custom path stays ignored (PR #147 round-6)", () => {
+  test("custom !.mstar negation before the broad rule: relocated after the fence, custom path becomes tracked (PR #147 round-10 partition)", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-6): the unconditional normalization used to
-      // relocate `.mstar/**` before the FIRST `!.mstar/...` line, treating a
-      // user-authored non-canonical negation (deliberately placed BEFORE a
-      // later `.mstar/**` so the custom path stays ignored) as a canonical
-      // fence member — flipping its intent. Here the broad rule is already
-      // correctly placed (after the custom negation, before every canonical
-      // re-include), so the fixed code must leave the file byte-for-byte
-      // untouched — the old code would have moved the broad rule before
-      // the custom negation and re-included the custom path.
+      // Partition invariant (PR #147 round-10): user-authored targeted
+      // `.mstar/…` rules always speak LAST. A `!.mstar/custom-keep/**`
+      // re-inclusion placed before the broad rule is relocated after the
+      // canonical fence (relative order preserved), so its literal intent —
+      // track the custom path — wins over the fence under
+      // last-match-wins, while knowledge/specs stay re-included by the
+      // fence itself.
       const userLines = [
         "# user comment",
         "!.mstar/custom-keep/**",
@@ -576,14 +585,11 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         "dist/",
       ];
       writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
-      // git check-ignore below needs a valid work tree.
       gitInit(root);
 
       const first = runScaffold([root]);
       expect(first.exitCode).toBe(0);
-      // No reorder: the file was already correctly ordered.
-      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
-      expect(first.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
 
       const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
       const lines = gitignore.split(/\r?\n/);
@@ -593,57 +599,47 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         .map((line, index) => (MSTAR_FENCE_ENTRIES.slice(1).includes(line.trim()) ? index : -1))
         .filter((index) => index !== -1);
       expect(broadIndex).toBeGreaterThan(-1);
-      // Broad rule sits AFTER the custom negation and BEFORE every canonical re-include.
-      expect(broadIndex).toBeGreaterThan(customIndex);
+      // Fence intact: broad before every canonical re-include.
       for (const canonicalIndex of canonicalIndexes) expect(broadIndex).toBeLessThan(canonicalIndex);
-      // Exactly one broad rule; all canonical entries present.
+      // The targeted user rule speaks last: after every canonical negation.
+      expect(customIndex).toBeGreaterThan(-1);
+      for (const canonicalIndex of canonicalIndexes) expect(customIndex).toBeGreaterThan(canonicalIndex);
+      // Exactly one broad rule; unrelated user lines preserved in order.
       expect(gitignore.split(".mstar/**").length - 1).toBe(1);
       for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
-      // Unrelated user lines preserved byte-for-byte, in order.
-      for (const line of ["# user comment", "dist/"]) expect(gitignore).toContain(line);
-      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+      expect(lines.filter((line) => line === "# user comment").length).toBe(1);
+      expect(lines.indexOf("dist/")).toBeGreaterThan(lines.indexOf(".mstarc"));
 
-      // git check-ignore semantics: the custom path stays ignored (its
-      // negation precedes the broad rule, so the broad rule re-ignores it),
-      // while knowledge contents stay re-included. check-ignore exits 0 for
-      // BOTH (a negation pattern also "matches"), so the observable proof is
-      // `git add -A` + `git ls-files`: knowledge/adr.md gets tracked,
-      // custom-keep/note.md stays untracked.
+      // Observable git semantics: BOTH re-inclusions are effective — the
+      // fence covers knowledge, and the relocated user negation covers
+      // custom-keep.
       mkdirSync(join(root, ".mstar", "custom-keep"), { recursive: true });
       mkdirSync(join(root, ".mstar", "knowledge"), { recursive: true });
       writeFileSync(join(root, ".mstar", "custom-keep", "note.md"), "# n\n", "utf8");
       writeFileSync(join(root, ".mstar", "knowledge", "adr.md"), "# a\n", "utf8");
-      const customCheck = Bun.spawnSync(["git", "check-ignore", "-v", join(root, ".mstar", "custom-keep", "note.md")], {
-        cwd: root,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      expect(customCheck.exitCode).toBe(0);
-      expect(customCheck.stdout.toString()).toContain(".mstar/**");
       const addAll = Bun.spawnSync(["git", "add", "-A"], { cwd: root, stdout: "pipe", stderr: "pipe" });
       expect(addAll.exitCode).toBe(0);
       const tracked = Bun.spawnSync(["git", "ls-files"], { cwd: root, stdout: "pipe", stderr: "pipe" });
       expect(tracked.exitCode).toBe(0);
       const trackedFiles = tracked.stdout.toString();
       expect(trackedFiles).toContain(".mstar/knowledge/adr.md");
-      expect(trackedFiles).not.toContain(".mstar/custom-keep/note.md");
+      expect(trackedFiles).toContain(".mstar/custom-keep/note.md");
 
       // Idempotent: second run changes nothing.
       const second = runScaffold([root]);
       expect(second.exitCode).toBe(0);
-      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(second.stdout).not.toContain("created: .gitignore");
       expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
     });
   });
-
-  test("infeasible ordering (custom negation after a canonical one): broad rule NOT moved, missing entries appended (PR #147 round-6)", () => {
+  test("infeasible ordering (custom negation after a canonical one): broad rule NOT moved, user rule speaks last (PR #147 round-10 partition)", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-6): when a custom negation is interleaved
-      // AFTER a canonical re-include, no slot satisfies both constraints
-      // (after every custom negation AND before every canonical re-include).
-      // The normalization must NOT reorder — the file keeps its user-authored
-      // order — and must still append missing canonical entries. No silent
-      // skip message when content changed.
+      // Regression (PR #147 round-6, updated round-10): a custom negation
+      // interleaved after a canonical re-include makes single-slot
+      // relocation infeasible — the broad rule is NOT moved. The ownership
+      // passes still guarantee our tracked results (canonical negations
+      // re-appended after the broad rule where missing) and the user's
+      // targeted rule is relocated to speak last.
       const userLines = [
         "!.mstar/AGENTS.md",
         "!.mstar/custom-keep/**",
@@ -657,41 +653,53 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
 
       const first = runScaffold([root]);
       expect(first.exitCode).toBe(0);
-      // Missing !.mstar/specs/** was appended (created message, not a skip).
       expect(first.stdout).toContain("created: .gitignore (canonical harness snippet)");
-      // The broad rule is NOT moved (infeasible ordering). Content may
-      // still change: the ownership pass re-appends canonical negations
-      // that the broad rule would otherwise shadow (round-9 guarantee).
-      // Original relative order must be preserved — asserted below.
-      // No silent skip message: content changed, so "already present" must
-      // not be claimed.
       expect(first.stdout).not.toContain("skipped: .gitignore (canonical harness snippet already present)");
 
       const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
       const lines = gitignore.split(/\r?\n/);
       const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
       const customIndex = lines.findIndex((line) => line.trim() === "!.mstar/custom-keep/**");
-      const canonicalIndex = lines.findIndex((line) => line.trim() === "!.mstar/AGENTS.md");
-      // Order preserved: canonical negation still precedes the custom one,
-      // and the broad rule still sits after the custom negation.
-      expect(canonicalIndex).toBeLessThan(customIndex);
-      expect(broadIndex).toBeGreaterThan(customIndex);
-      // The missing canonical entry was appended at the end.
+      // The broad rule was not relocated: after the targeted custom rule
+      // is lifted to the tail it directly precedes every canonical
+      // negation, starting with AGENTS.md at the top.
+      expect(broadIndex).toBe(0);
+      // Every canonical negation occurs after the broad rule.
+      for (const negation of [
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+      ]) {
+        const lastIndex = lines.map((line) => line.trim() === negation).lastIndexOf(true);
+        expect(lastIndex).toBeGreaterThan(broadIndex);
+      }
+      // The user's targeted rule speaks last of all `.mstar` rules.
+      const mstarRuleIndexes = lines
+        .map((line, index) =>
+          line.trim() !== "" &&
+          !line.trim().startsWith("#") &&
+          line.trim() !== ".mstarc" &&
+          (line.trim().startsWith("!.mstar/") || line.trim().startsWith(".mstar/"))
+            ? index
+            : -1,
+        )
+        .filter((index) => index !== -1);
+      expect(mstarRuleIndexes[mstarRuleIndexes.length - 1]).toBe(customIndex);
+      // Missing canonical entry was completed.
       expect(gitignore).toContain("!.mstar/specs/**");
-      expect(gitignore.indexOf("!.mstar/specs/**")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
     });
   });
 
-  test("custom re-inclusion AFTER .mstar/**: ordering untouched, custom path stays tracked (PR #147 round-7)", () => {
+  test("custom re-inclusion AFTER .mstar/**: relocated to speak last, custom path stays tracked (PR #147 round-10 partition)", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-7): the round-6 normalization relocated
-      // .mstar/** to sit after every CUSTOM !.mstar/... negation. That
-      // breaks the opposite deliberate layout: a user-authored custom
-      // re-inclusion placed AFTER .mstar/** (last-match-wins => deliberately
-      // re-included) gets crossed by the relocated broad rule and becomes
-      // IGNORED. The broad rule here is already correctly placed (before
-      // every canonical negation), so the un-crossable-lines invariant must
-      // leave the file byte-for-byte untouched.
+      // Partition invariant (PR #147 round-10): a user-authored custom
+      // re-inclusion placed after `.mstar/**` (last-match-wins =>
+      // deliberately re-included) keeps its meaning — the partition moves
+      // it to speak after the whole fence, so `.mstar/custom/x` stays
+      // TRACKED while knowledge stays re-included by the fence and
+      // status.json stays ignored.
       const userLines = [
         "# user comment",
         ".mstar/**",
@@ -706,18 +714,13 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         "dist/",
       ];
       writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
-      // git add -A / ls-files below need a valid work tree.
       gitInit(root);
 
       const first = runScaffold([root]);
       expect(first.exitCode).toBe(0);
-      // No reorder: the file was already correctly ordered.
-      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
-      expect(first.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
 
       const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
-      // Byte-for-byte unchanged apart from nothing (complete fence).
-      expect(gitignore).toBe(`${userLines.join("\n")}\n`);
       const lines = gitignore.split(/\r?\n/);
       const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
       const customIndex = lines.findIndex((line) => line.trim() === "!.mstar/custom/**");
@@ -725,17 +728,23 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         .map((line, index) => (MSTAR_FENCE_ENTRIES.slice(1).includes(line.trim()) ? index : -1))
         .filter((index) => index !== -1);
       expect(broadIndex).toBeGreaterThan(-1);
-      // Broad rule sits BEFORE the custom re-inclusion and before every
-      // canonical re-include.
-      expect(broadIndex).toBeLessThan(customIndex);
       for (const canonicalIndex of canonicalIndexes) expect(broadIndex).toBeLessThan(canonicalIndex);
-      // Exactly one broad rule; all canonical entries present.
-      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
-      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      // The targeted user rules speak last of all `.mstar` rules.
+      const mstarRuleIndexes = lines
+        .map((line, index) =>
+          line.trim() !== "" &&
+          !line.trim().startsWith("#") &&
+          line.trim() !== ".mstarc" &&
+          (line.trim().startsWith("!.mstar/") || line.trim().startsWith(".mstar/"))
+            ? index
+            : -1,
+        )
+        .filter((index) => index !== -1);
+      expect(mstarRuleIndexes[mstarRuleIndexes.length - 1]).toBe(customIndex);
+      expect(lines.indexOf("dist/")).toBeGreaterThan(lines.indexOf(".mstarc"));
 
-      // Observable git semantics: the custom re-inclusion after .mstar/**
-      // keeps .mstar/custom/x TRACKED, knowledge stays TRACKED, and
-      // .mstar/status.json stays ignored (check-ignore).
+      // Observable git semantics unchanged: custom x.md TRACKED, knowledge
+      // y.md TRACKED, status.json ignored.
       mkdirSync(join(root, ".mstar", "custom"), { recursive: true });
       mkdirSync(join(root, ".mstar", "knowledge"), { recursive: true });
       writeFileSync(join(root, ".mstar", "custom", "x.md"), "# x\n", "utf8");
@@ -759,22 +768,18 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       // Idempotent: second run changes nothing.
       const second = runScaffold([root]);
       expect(second.exitCode).toBe(0);
-      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(second.stdout).not.toContain("created: .gitignore");
       expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
     });
   });
-
-  test("custom negation BETWEEN two .mstar/** rules: trailing broad RETAINED, custom path stays ignored (PR #147 round-8)", () => {
+  test("custom negation BETWEEN two .mstar/** rules: trailing broad RETAINED, user rule speaks last (PR #147 round-8/10)", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-8): the unconditional dedupe used to drop
-      // EVERY `.mstar/**` after the earliest occurrence. When a custom
-      // `!.mstar/…` re-inclusion sits BETWEEN two broad rules, the trailing
-      // broad deliberately re-ignores that path (gitignore last-match-wins)
-      // — deleting it would make the custom path trackable and flip the
-      // meaning of a line we do not own. Segmented dedupe must RETAIN the
-      // trailing broad (an un-crossable line lies strictly between it and
-      // the previously retained broad rule) and leave the file byte-for-byte
-      // untouched.
+      // Regression (PR #147 round-8): segmented dedupe must RETAIN the
+      // trailing broad rule when an un-crossable line lies between it and
+      // the previously retained broad rule — deleting it would flip a line
+      // we do not own. Round-10 partition: the targeted user rule
+      // (`!.mstar/custom/**`) is relocated to speak after the whole fence,
+      // so its literal intent (track the custom path) is what wins.
       const userLines = [
         "# user comment",
         ".mstar/**",
@@ -789,19 +794,13 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         "dist/",
       ];
       writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
-      // git add -A / ls-files / check-ignore below need a valid work tree.
       gitInit(root);
 
       const first = runScaffold([root]);
       expect(first.exitCode).toBe(0);
-      // No reorder and no dedupe: the trailing broad is semantically
-      // load-bearing, so the file is already correctly ordered.
-      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
-      expect(first.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
 
       const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
-      // Byte-for-byte unchanged (complete fence, nothing to normalize).
-      expect(gitignore).toBe(`${userLines.join("\n")}\n`);
       const lines = gitignore.split(/\r?\n/);
       const broadIndexes = lines
         .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
@@ -810,25 +809,22 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       const canonicalIndexes = lines
         .map((line, index) => (MSTAR_FENCE_ENTRIES.slice(1).includes(line.trim()) ? index : -1))
         .filter((index) => index !== -1);
-      // BOTH broad rules retained, in their original positions: the first
-      // before the custom negation, the trailing one after it (re-ignoring
-      // the custom path), and both before every canonical re-include.
-      expect(broadIndexes.length).toBe(2);
-      expect(broadIndexes[0]).toBeLessThan(customIndex);
-      expect(broadIndexes[1]).toBeGreaterThan(customIndex);
+      // ONE broad rule: post-partition the duplicate is redundant and is
+      // removed (round-10 dedupe).
+      expect(broadIndexes.length).toBe(1);
+      // The fence stays intact: broad before every canonical re-include;
+      // the targeted user rule speaks last.
       for (const canonicalIndex of canonicalIndexes) {
         expect(broadIndexes[0]).toBeLessThan(canonicalIndex);
-        expect(broadIndexes[1]).toBeLessThan(canonicalIndex);
+        expect(customIndex).toBeGreaterThan(canonicalIndex);
       }
-      // All canonical entries present; unrelated user lines preserved in order.
-      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      // Unrelated user lines preserved in order.
       for (const line of ["# user comment", "dist/"]) expect(gitignore).toContain(line);
-      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+      expect(lines.indexOf("dist/")).toBeGreaterThan(lines.indexOf(".mstarc"));
 
-      // Observable git semantics: the trailing broad re-ignores the custom
-      // path (last-match-wins), so .mstar/custom/x is NOT tracked, while
-      // knowledge contents stay tracked and .mstar/status.json stays
-      // ignored (check-ignore).
+      // Observable git semantics: the relocated custom re-inclusion keeps
+      // .mstar/custom/x TRACKED, knowledge stays TRACKED, status.json stays
+      // ignored.
       mkdirSync(join(root, ".mstar", "custom"), { recursive: true });
       mkdirSync(join(root, ".mstar", "knowledge"), { recursive: true });
       writeFileSync(join(root, ".mstar", "custom", "x.md"), "# x\n", "utf8");
@@ -839,7 +835,7 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       const tracked = Bun.spawnSync(["git", "ls-files"], { cwd: root, stdout: "pipe", stderr: "pipe" });
       expect(tracked.exitCode).toBe(0);
       const trackedFiles = tracked.stdout.toString();
-      expect(trackedFiles).not.toContain(".mstar/custom/x.md");
+      expect(trackedFiles).toContain(".mstar/custom/x.md");
       expect(trackedFiles).toContain(".mstar/knowledge/y.md");
       const ignored = Bun.spawnSync(["git", "check-ignore", "-v", join(root, ".mstar", "status.json")], {
         cwd: root,
@@ -852,7 +848,7 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       // Idempotent: second run changes nothing.
       const second = runScaffold([root]);
       expect(second.exitCode).toBe(0);
-      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(second.stdout).not.toContain("created: .gitignore");
       expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
     });
   });

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -133,6 +133,23 @@ describe("mstar scaffold — one-shot harness bootstrap", () => {
     });
   });
 
+  test("partial fence: appends only the missing re-include entries, keeping the existing .mstar/** line", () => {
+    withRoot((root) => {
+      // Pre-existing fence with only the default-ignore entry.
+      writeFileSync(join(root, ".gitignore"), ".mstar/**\n", "utf8");
+
+      const result = runScaffold([root]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("created: .gitignore (canonical harness snippet)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      // Exactly ONE .mstar/** line — the pre-existing one is not duplicated.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      // All 5 re-include entries are now present.
+      for (const entry of MSTAR_FENCE_ENTRIES.slice(1)) expect(gitignore).toContain(entry);
+    });
+  });
+
   test("defaults to cwd when [path] is omitted", () => {
     withRoot((root) => {
       const proc = Bun.spawnSync([process.execPath, "run", join(CLI_ROOT, "src/index.ts"), "scaffold"], {

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -504,4 +504,132 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       expect(check.stdout.toString()).toContain(".mstar/**");
     });
   });
+
+  test("custom !.mstar negation before the broad rule: fence left untouched, custom path stays ignored (PR #147 round-6)", () => {
+    withRoot((root) => {
+      // Regression (PR #147 round-6): the unconditional normalization used to
+      // relocate `.mstar/**` before the FIRST `!.mstar/...` line, treating a
+      // user-authored non-canonical negation (deliberately placed BEFORE a
+      // later `.mstar/**` so the custom path stays ignored) as a canonical
+      // fence member — flipping its intent. Here the broad rule is already
+      // correctly placed (after the custom negation, before every canonical
+      // re-include), so the fixed code must leave the file byte-for-byte
+      // untouched — the old code would have moved the broad rule before
+      // the custom negation and re-included the custom path.
+      const userLines = [
+        "# user comment",
+        "!.mstar/custom-keep/**",
+        ".mstar/**",
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+        ".mstarc",
+        "dist/",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+      // git check-ignore below needs a valid work tree.
+      gitInit(root);
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      // No reorder: the file was already correctly ordered.
+      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
+      expect(first.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const customIndex = lines.findIndex((line) => line.trim() === "!.mstar/custom-keep/**");
+      const canonicalIndexes = lines
+        .map((line, index) => (MSTAR_FENCE_ENTRIES.slice(1).includes(line.trim()) ? index : -1))
+        .filter((index) => index !== -1);
+      expect(broadIndex).toBeGreaterThan(-1);
+      // Broad rule sits AFTER the custom negation and BEFORE every canonical re-include.
+      expect(broadIndex).toBeGreaterThan(customIndex);
+      for (const canonicalIndex of canonicalIndexes) expect(broadIndex).toBeLessThan(canonicalIndex);
+      // Exactly one broad rule; all canonical entries present.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      // Unrelated user lines preserved byte-for-byte, in order.
+      for (const line of ["# user comment", "dist/"]) expect(gitignore).toContain(line);
+      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+
+      // git check-ignore semantics: the custom path stays ignored (its
+      // negation precedes the broad rule, so the broad rule re-ignores it),
+      // while knowledge contents stay re-included. check-ignore exits 0 for
+      // BOTH (a negation pattern also "matches"), so the observable proof is
+      // `git add -A` + `git ls-files`: knowledge/adr.md gets tracked,
+      // custom-keep/note.md stays untracked.
+      mkdirSync(join(root, ".mstar", "custom-keep"), { recursive: true });
+      mkdirSync(join(root, ".mstar", "knowledge"), { recursive: true });
+      writeFileSync(join(root, ".mstar", "custom-keep", "note.md"), "# n\n", "utf8");
+      writeFileSync(join(root, ".mstar", "knowledge", "adr.md"), "# a\n", "utf8");
+      const customCheck = Bun.spawnSync(["git", "check-ignore", "-v", join(root, ".mstar", "custom-keep", "note.md")], {
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(customCheck.exitCode).toBe(0);
+      expect(customCheck.stdout.toString()).toContain(".mstar/**");
+      const addAll = Bun.spawnSync(["git", "add", "-A"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+      expect(addAll.exitCode).toBe(0);
+      const tracked = Bun.spawnSync(["git", "ls-files"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+      expect(tracked.exitCode).toBe(0);
+      const trackedFiles = tracked.stdout.toString();
+      expect(trackedFiles).toContain(".mstar/knowledge/adr.md");
+      expect(trackedFiles).not.toContain(".mstar/custom-keep/note.md");
+
+      // Idempotent: second run changes nothing.
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
+    });
+  });
+
+  test("infeasible ordering (custom negation after a canonical one): broad rule NOT moved, missing entries appended (PR #147 round-6)", () => {
+    withRoot((root) => {
+      // Regression (PR #147 round-6): when a custom negation is interleaved
+      // AFTER a canonical re-include, no slot satisfies both constraints
+      // (after every custom negation AND before every canonical re-include).
+      // The normalization must NOT reorder — the file keeps its user-authored
+      // order — and must still append missing canonical entries. No silent
+      // skip message when content changed.
+      const userLines = [
+        "!.mstar/AGENTS.md",
+        "!.mstar/custom-keep/**",
+        ".mstar/**",
+        "!.mstar/knowledge/",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        ".mstarc",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      // Missing !.mstar/specs/** was appended (created message, not a skip).
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet)");
+      // No reorder message — the infeasible ordering was left untouched.
+      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
+      // No silent skip message: content changed, so "already present" must
+      // not be claimed.
+      expect(first.stdout).not.toContain("skipped: .gitignore (canonical harness snippet already present)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const customIndex = lines.findIndex((line) => line.trim() === "!.mstar/custom-keep/**");
+      const canonicalIndex = lines.findIndex((line) => line.trim() === "!.mstar/AGENTS.md");
+      // Order preserved: canonical negation still precedes the custom one,
+      // and the broad rule still sits after the custom negation.
+      expect(canonicalIndex).toBeLessThan(customIndex);
+      expect(broadIndex).toBeGreaterThan(customIndex);
+      // The missing canonical entry was appended at the end.
+      expect(gitignore).toContain("!.mstar/specs/**");
+      expect(gitignore.indexOf("!.mstar/specs/**")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+    });
+  });
 });

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -1,0 +1,152 @@
+/**
+ * CLI `mstar scaffold` — one-shot harness bootstrap wrapper.
+ *
+ * Thin wrapper over engine `path.scaffoldHarness` + `path.emitGitignoreSnippet`
+ * (plan-conventions § 初始化 Plan 目录 / § Git 跟踪策略; mstar-project-governance
+ * § `_default` 回退):
+ * - Creates `.mstar/` (plans/iterations/knowledge/specs/sdd + v2 status.json
+ *   + projects/_default/roadmap.md + residuals.json).
+ * - Appends the canonical `.gitignore` snippet when absent; skips cleanly
+ *   when the complete fence is already present.
+ * - Writes a minimal `.mstar/AGENTS.md` when absent.
+ * - Idempotent: re-running on an initialized tree changes nothing.
+ *
+ * Each case runs the real CLI as a subprocess against a temp fixture tree.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const CLI_ROOT = resolve(import.meta.dir, "..");
+
+interface RunResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Spawn env with ambient MSTAR_HARNESS_DIR pinned out (qc3 F-4): the CLI
+ * resolves harness dirs from that env var ahead of probing, so an ambient
+ * value would redirect every fixture to the env dir and fail spuriously.
+ */
+function cliEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key === "MSTAR_HARNESS_DIR") continue;
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+function runScaffold(args: string[]): RunResult {
+  const proc = Bun.spawnSync([process.execPath, "run", "src/index.ts", "scaffold", ...args], {
+    cwd: CLI_ROOT,
+    env: cliEnv(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { exitCode: proc.exitCode, stdout: proc.stdout.toString(), stderr: proc.stderr.toString() };
+}
+
+/** Empty temp root; `.mstar/` and specs content added per test. */
+function withRoot(fn: (root: string) => void): void {
+  const root = mkdtempSync(join(tmpdir(), "mstar-scaffold-"));
+  try {
+    fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+/** Canonical `.mstar/` fence entries (ignore + re-include), verbatim from plan-conventions § Git 跟踪策略. */
+const MSTAR_FENCE_ENTRIES = [
+  ".mstar/**",
+  "!.mstar/AGENTS.md",
+  "!.mstar/knowledge/",
+  "!.mstar/knowledge/**",
+  "!.mstar/specs/",
+  "!.mstar/specs/**",
+];
+
+describe("mstar scaffold — one-shot harness bootstrap", () => {
+  test("creates .mstar/ with dirs, v2 status.json, projects/_default/, .gitignore snippet, and .mstar/AGENTS.md", () => {
+    withRoot((root) => {
+      const result = runScaffold([root]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toContain(`scaffold: harness initialized at ${join(root, ".mstar")}`);
+      expect(result.stdout).toContain("created: .gitignore (canonical harness snippet)");
+      expect(result.stdout).toContain("created: .mstar/AGENTS.md");
+
+      const harnessDir = join(root, ".mstar");
+      for (const dir of ["plans", "iterations", "knowledge", "specs", "sdd", "projects"]) {
+        expect(existsSync(join(harnessDir, dir))).toBe(true);
+      }
+      expect(existsSync(join(harnessDir, "status.json"))).toBe(true);
+      expect(existsSync(join(harnessDir, "projects", "_default", "roadmap.md"))).toBe(true);
+      expect(existsSync(join(harnessDir, "projects", "_default", "residuals.json"))).toBe(true);
+      expect(existsSync(join(harnessDir, "AGENTS.md"))).toBe(true);
+
+      // Canonical snippet appended once, complete fence present.
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+    });
+  });
+
+  test("is idempotent: second run changes nothing and reports skipped", () => {
+    withRoot((root) => {
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      const gitignoreAfterFirst = readFileSync(join(root, ".gitignore"), "utf8");
+      const agentsAfterFirst = readFileSync(join(root, ".mstar", "AGENTS.md"), "utf8");
+      const roadmapAfterFirst = readFileSync(join(root, ".mstar", "projects", "_default", "roadmap.md"), "utf8");
+
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(second.stdout).toContain("skipped: .mstar/AGENTS.md (already present)");
+      expect(second.stdout).not.toContain("created:");
+      // Nothing changed on re-run.
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignoreAfterFirst);
+      expect(readFileSync(join(root, ".mstar", "AGENTS.md"), "utf8")).toBe(agentsAfterFirst);
+      expect(readFileSync(join(root, ".mstar", "projects", "_default", "roadmap.md"), "utf8")).toBe(roadmapAfterFirst);
+    });
+  });
+
+  test("preserves an existing .gitignore and .mstar/AGENTS.md (never clobbers)", () => {
+    withRoot((root) => {
+      writeFileSync(join(root, ".gitignore"), "node_modules/\n", "utf8");
+      mkdirSync(join(root, ".mstar"), { recursive: true });
+      writeFileSync(join(root, ".mstar", "AGENTS.md"), "# custom harness rules\n", "utf8");
+
+      const result = runScaffold([root]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("skipped: .mstar/AGENTS.md (already present)");
+      // Existing content preserved; snippet appended after it.
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      expect(gitignore.startsWith("node_modules/\n")).toBe(true);
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      expect(readFileSync(join(root, ".mstar", "AGENTS.md"), "utf8")).toBe("# custom harness rules\n");
+    });
+  });
+
+  test("defaults to cwd when [path] is omitted", () => {
+    withRoot((root) => {
+      const proc = Bun.spawnSync([process.execPath, "run", join(CLI_ROOT, "src/index.ts"), "scaffold"], {
+        cwd: root,
+        env: cliEnv(),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(proc.exitCode).toBe(0);
+      // The subprocess cwd resolves symlinks (macOS /var → /private/var), so
+      // assert the harness line + the created files rather than an exact path.
+      expect(proc.stdout.toString()).toContain("scaffold: harness initialized at");
+      expect(proc.stdout.toString()).toContain(".mstar");
+      expect(existsSync(join(root, ".mstar", "status.json"))).toBe(true);
+    });
+  });
+});

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -270,6 +270,109 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
+  test("trailing duplicate .mstar/** after a correctly ordered fence: dedupes to one broad rule before every re-include, preserving other lines", () => {
+    withRoot((root) => {
+      // Correctly ordered complete fence, then a trailing duplicate
+      // .mstar/** at the very end. findIndex-based normalization only sees
+      // the FIRST broad rule (already correctly placed), so the trailing
+      // duplicate would survive and shadow the re-includes (last-match-wins).
+      const userLines = [
+        "# user comment",
+        "node_modules/",
+        "# Morning Star harness (.mstar/)",
+        "# Default-ignore everything under .mstar/, then re-include the tracked results.",
+        ".mstar/**",
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+        ".mstarc",
+        "dist/",
+        ".mstar/**",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      // Exactly ONE broad rule, positioned immediately before the first re-include.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const negationIndexes = lines
+        .map((line, index) => (line.trim().startsWith("!.mstar/") ? index : -1))
+        .filter((index) => index !== -1);
+      expect(broadIndex).toBeGreaterThan(-1);
+      expect(negationIndexes.length).toBeGreaterThan(0);
+      expect(broadIndex).toBe(negationIndexes[0] - 1);
+      for (const negationIndex of negationIndexes) expect(broadIndex).toBeLessThan(negationIndex);
+      // All canonical entries present; unrelated user lines preserved in order.
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      for (const line of ["# user comment", "node_modules/", "dist/"]) expect(gitignore).toContain(line);
+      expect(gitignore.indexOf("node_modules/")).toBeLessThan(gitignore.indexOf(".mstar/**"));
+      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+
+      // Idempotent: second run changes nothing.
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
+    });
+  });
+
+  test("duplicate .mstar/** both before AND after re-includes: keeps the earliest, drops the trailing one, relocates before every negation", () => {
+    withRoot((root) => {
+      // One broad rule before the negations (correctly placed) and a second
+      // one after them (shadowing). The kept rule must be the EARLIEST
+      // occurrence, and the trailing duplicate must be removed.
+      const userLines = [
+        "# user comment",
+        ".mstar/**",
+        "node_modules/",
+        "!.mstar/knowledge/**",
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+        ".mstarc",
+        "dist/",
+        ".mstar/**",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      // Exactly ONE broad rule, positioned immediately before the first re-include.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const negationIndexes = lines
+        .map((line, index) => (line.trim().startsWith("!.mstar/") ? index : -1))
+        .filter((index) => index !== -1);
+      expect(broadIndex).toBeGreaterThan(-1);
+      expect(negationIndexes.length).toBeGreaterThan(0);
+      expect(broadIndex).toBe(negationIndexes[0] - 1);
+      for (const negationIndex of negationIndexes) expect(broadIndex).toBeLessThan(negationIndex);
+      // All canonical entries present; unrelated user lines preserved in order.
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      for (const line of ["# user comment", "node_modules/", "dist/"]) expect(gitignore).toContain(line);
+      expect(gitignore.indexOf("node_modules/")).toBeLessThan(gitignore.indexOf(".mstar/**"));
+      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+
+      // Idempotent: second run changes nothing.
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
+    });
+  });
+
   test(".mstarc harness_dir=.custom: files land in .custom/, .gitignore untouched", () => {
     withRoot((root) => {
       writeFileSync(join(root, ".mstarc"), "[config]\nharness_dir=.custom\n", "utf8");

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -336,11 +336,13 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("duplicate .mstar/** both before AND after re-includes: keeps the earliest, drops the trailing one, relocates before every negation", () => {
+  test("duplicate .mstar/** both before AND after re-includes: keeps the earliest, drops the trailing one, never moves a correctly-placed broad rule", () => {
     withRoot((root) => {
       // One broad rule before the negations (correctly placed) and a second
       // one after them (shadowing). The kept rule must be the EARLIEST
-      // occurrence, and the trailing duplicate must be removed.
+      // occurrence, and the trailing duplicate must be removed. The kept
+      // rule already sits before every canonical negation, so the
+      // un-crossable-lines invariant must NOT move it across node_modules/.
       const userLines = [
         "# user comment",
         ".mstar/**",
@@ -362,7 +364,8 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
 
       const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
       const lines = gitignore.split(/\r?\n/);
-      // Exactly ONE broad rule, positioned immediately before the first re-include.
+      // Exactly ONE broad rule, still at its original position (before
+      // node_modules/ and before every re-include).
       expect(gitignore.split(".mstar/**").length - 1).toBe(1);
       const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
       const negationIndexes = lines
@@ -370,12 +373,15 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         .filter((index) => index !== -1);
       expect(broadIndex).toBeGreaterThan(-1);
       expect(negationIndexes.length).toBeGreaterThan(0);
-      expect(broadIndex).toBe(negationIndexes[0] - 1);
+      expect(broadIndex).toBe(1);
+      expect(broadIndex).toBeLessThan(lines.findIndex((line) => line.trim() === "node_modules/"));
       for (const negationIndex of negationIndexes) expect(broadIndex).toBeLessThan(negationIndex);
       // All canonical entries present; unrelated user lines preserved in order.
       for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
       for (const line of ["# user comment", "node_modules/", "dist/"]) expect(gitignore).toContain(line);
-      expect(gitignore.indexOf("node_modules/")).toBeLessThan(gitignore.indexOf(".mstar/**"));
+      // The kept broad rule stays at its original position, BEFORE
+      // node_modules/ (it was already correctly placed).
+      expect(gitignore.indexOf(".mstar/**")).toBeLessThan(gitignore.indexOf("node_modules/"));
       expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
 
       // Idempotent: second run changes nothing.
@@ -630,6 +636,182 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       // The missing canonical entry was appended at the end.
       expect(gitignore).toContain("!.mstar/specs/**");
       expect(gitignore.indexOf("!.mstar/specs/**")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+    });
+  });
+
+  test("custom re-inclusion AFTER .mstar/**: ordering untouched, custom path stays tracked (PR #147 round-7)", () => {
+    withRoot((root) => {
+      // Regression (PR #147 round-7): the round-6 normalization relocated
+      // .mstar/** to sit after every CUSTOM !.mstar/... negation. That
+      // breaks the opposite deliberate layout: a user-authored custom
+      // re-inclusion placed AFTER .mstar/** (last-match-wins => deliberately
+      // re-included) gets crossed by the relocated broad rule and becomes
+      // IGNORED. The broad rule here is already correctly placed (before
+      // every canonical negation), so the un-crossable-lines invariant must
+      // leave the file byte-for-byte untouched.
+      const userLines = [
+        "# user comment",
+        ".mstar/**",
+        "!.mstar/custom/",
+        "!.mstar/custom/**",
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+        ".mstarc",
+        "dist/",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+      // git add -A / ls-files below need a valid work tree.
+      gitInit(root);
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      // No reorder: the file was already correctly ordered.
+      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
+      expect(first.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      // Byte-for-byte unchanged apart from nothing (complete fence).
+      expect(gitignore).toBe(`${userLines.join("\n")}\n`);
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const customIndex = lines.findIndex((line) => line.trim() === "!.mstar/custom/**");
+      const canonicalIndexes = lines
+        .map((line, index) => (MSTAR_FENCE_ENTRIES.slice(1).includes(line.trim()) ? index : -1))
+        .filter((index) => index !== -1);
+      expect(broadIndex).toBeGreaterThan(-1);
+      // Broad rule sits BEFORE the custom re-inclusion and before every
+      // canonical re-include.
+      expect(broadIndex).toBeLessThan(customIndex);
+      for (const canonicalIndex of canonicalIndexes) expect(broadIndex).toBeLessThan(canonicalIndex);
+      // Exactly one broad rule; all canonical entries present.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+
+      // Observable git semantics: the custom re-inclusion after .mstar/**
+      // keeps .mstar/custom/x TRACKED, knowledge stays TRACKED, and
+      // .mstar/status.json stays ignored (check-ignore).
+      mkdirSync(join(root, ".mstar", "custom"), { recursive: true });
+      mkdirSync(join(root, ".mstar", "knowledge"), { recursive: true });
+      writeFileSync(join(root, ".mstar", "custom", "x.md"), "# x\n", "utf8");
+      writeFileSync(join(root, ".mstar", "knowledge", "y.md"), "# y\n", "utf8");
+      writeFileSync(join(root, ".mstar", "status.json"), "{}\n", "utf8");
+      const addAll = Bun.spawnSync(["git", "add", "-A"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+      expect(addAll.exitCode).toBe(0);
+      const tracked = Bun.spawnSync(["git", "ls-files"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+      expect(tracked.exitCode).toBe(0);
+      const trackedFiles = tracked.stdout.toString();
+      expect(trackedFiles).toContain(".mstar/custom/x.md");
+      expect(trackedFiles).toContain(".mstar/knowledge/y.md");
+      const ignored = Bun.spawnSync(["git", "check-ignore", "-v", join(root, ".mstar", "status.json")], {
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(ignored.exitCode).toBe(0);
+      expect(ignored.stdout.toString()).toContain(".mstar/**");
+
+      // Idempotent: second run changes nothing.
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
+    });
+  });
+
+  test("misordered broad rule with an un-crossable line in the way: no relocation, order preserved (PR #147 round-7)", () => {
+    withRoot((root) => {
+      // Regression (PR #147 round-7): the broad rule sits AFTER the first
+      // canonical negation, but a user line (node_modules/) lies strictly
+      // between the first canonical negation and the broad rule. Moving the
+      // broad rule up would cross that un-owned line and flip its path
+      // semantics, so the normalization must NOT reorder — the file keeps
+      // its user-authored order — and must still append missing canonical
+      // entries. No silent skip message when content changed.
+      const userLines = [
+        "!.mstar/AGENTS.md",
+        "node_modules/",
+        ".mstar/**",
+        "!.mstar/knowledge/",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        ".mstarc",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      // Missing !.mstar/specs/** was appended (created message, not a skip).
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet)");
+      // No reorder message — the infeasible ordering was left untouched.
+      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
+      // No silent skip message: content changed, so "already present" must
+      // not be claimed.
+      expect(first.stdout).not.toContain("skipped: .gitignore (canonical harness snippet already present)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const canonicalIndex = lines.findIndex((line) => line.trim() === "!.mstar/AGENTS.md");
+      const nodeModulesIndex = lines.findIndex((line) => line.trim() === "node_modules/");
+      // Order preserved: canonical negation still precedes node_modules/,
+      // which still precedes the broad rule.
+      expect(canonicalIndex).toBeLessThan(nodeModulesIndex);
+      expect(nodeModulesIndex).toBeLessThan(broadIndex);
+      // The missing canonical entry was appended at the end.
+      expect(gitignore).toContain("!.mstar/specs/**");
+      expect(gitignore.indexOf("!.mstar/specs/**")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+    });
+  });
+
+  test("misordered broad rule with only owned lines in the way: relocates before the first canonical negation (PR #147 round-7)", () => {
+    withRoot((root) => {
+      // Feasible reorder: the broad rule sits after the first canonical
+      // negation, and every line between them is one we own (a comment and
+      // a canonical negation). The move crosses no un-owned line, so the
+      // broad rule is relocated to sit immediately before the first
+      // canonical negation; every other line stays byte-for-byte.
+      const userLines = [
+        "# user comment",
+        "!.mstar/AGENTS.md",
+        "# a comment we own the semantics of",
+        "!.mstar/knowledge/",
+        ".mstar/**",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+        ".mstarc",
+        "dist/",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const canonicalIndexes = lines
+        .map((line, index) => (MSTAR_FENCE_ENTRIES.slice(1).includes(line.trim()) ? index : -1))
+        .filter((index) => index !== -1);
+      expect(broadIndex).toBeGreaterThan(-1);
+      // Broad rule now precedes EVERY canonical re-include.
+      for (const canonicalIndex of canonicalIndexes) expect(broadIndex).toBeLessThan(canonicalIndex);
+      // Exactly one broad rule; all canonical entries present.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      // Unrelated user lines preserved byte-for-byte, in order.
+      for (const line of ["# user comment", "dist/"]) expect(gitignore).toContain(line);
+      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+
+      // Idempotent: second run changes nothing.
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
     });
   });
 });

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -225,6 +225,51 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
+  test("incomplete-and-misordered fence (PM repro): appends missing entries AND relocates .mstar/** before every re-include", () => {
+    withRoot((root) => {
+      // PM-verified repro: the fence is missing !.mstar/knowledge/ and
+      // !.mstar/specs/ (directory re-includes) AND the broad rule sits after
+      // !.mstar/knowledge/** — gitignore last-match-wins would shadow
+      // .mstar/knowledge/<file>. The append branch must ALSO repair order.
+      const reproLines = [
+        "!.mstar/knowledge/**",
+        ".mstar/**",
+        "!.mstar/AGENTS.md",
+        "!.mstar/specs/**",
+        ".mstarc",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${reproLines.join("\n")}\n`, "utf8");
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet)");
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const negationIndexes = lines
+        .map((line, index) => (line.trim().startsWith("!.mstar/") ? index : -1))
+        .filter((index) => index !== -1);
+      expect(broadIndex).toBeGreaterThan(-1);
+      // Broad rule precedes EVERY re-include.
+      for (const negationIndex of negationIndexes) expect(broadIndex).toBeLessThan(negationIndex);
+      // Exactly one broad rule; all canonical entries present.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      // Unrelated pre-existing lines preserved byte-for-byte, in order.
+      for (const line of reproLines) expect(gitignore).toContain(line);
+      expect(gitignore.indexOf("!.mstar/AGENTS.md")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+      expect(gitignore.indexOf(".mstarc")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+
+      // Idempotent: second run changes nothing.
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
+    });
+  });
+
   test(".mstarc harness_dir=.custom: files land in .custom/, .gitignore untouched", () => {
     withRoot((root) => {
       writeFileSync(join(root, ".mstarc"), "[config]\nharness_dir=.custom\n", "utf8");

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -340,18 +340,18 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("duplicate .mstar/** both before AND after re-includes: trailing broad RETAINED when an un-crossable line lies between (PR #147 round-8)", () => {
+  test("duplicate .mstar/** both before AND after re-includes: trailing broad RETAINED, canonical negations re-appended after it (PR #147 round-8/9)", () => {
     withRoot((root) => {
       // One broad rule before the negations (correctly placed) and a second
-      // one after them. Round-8 semantics: the trailing duplicate is dropped
-      // ONLY when no un-crossable line lies strictly between it and the
-      // previously retained broad rule. Here node_modules/ (a line whose
+      // one after them. Round-8 semantics: node_modules/ (a line whose
       // semantics we do not own) sits between the two broad rules, so the
       // trailing broad is semantically load-bearing and must be RETAINED
-      // exactly where it is — the file keeps its user-authored order. The
-      // kept (earliest) broad rule already sits before every canonical
-      // negation, so the un-crossable-lines invariant must NOT move it
-      // across node_modules/ either.
+      // exactly where it is — never removed, never moved across
+      // node_modules/. Round-9 semantics: because every canonical negation
+      // occurs only BEFORE the trailing broad rule, they would be shadowed
+      // under last-match-wins; the final ownership pass re-appends them at
+      // the end so our tracked results stay re-included without touching
+      // any line we do not own.
       const userLines = [
         "# user comment",
         ".mstar/**",
@@ -366,46 +366,69 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         ".mstar/**",
       ];
       writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+      // git add -A / ls-files below need a valid work tree.
+      gitInit(root);
 
       const first = runScaffold([root]);
       expect(first.exitCode).toBe(0);
-      // No reorder and no dedupe: the trailing broad is load-bearing, so
-      // the file is already correctly ordered.
-      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
-      expect(first.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      // The trailing broad is retained and the shadowed canonical negations
+      // are re-appended: content changed, so the honest message is
+      // "reordered", not "skipped".
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
 
       const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
-      // Byte-for-byte unchanged (complete fence, nothing to normalize).
-      expect(gitignore).toBe(`${userLines.join("\n")}\n`);
       const lines = gitignore.split(/\r?\n/);
       const broadIndexes = lines
         .map((line, index) => (line.trim() === ".mstar/**" ? index : -1))
         .filter((index) => index !== -1);
-      const negationIndexes = lines
-        .map((line, index) => (line.trim().startsWith("!.mstar/") ? index : -1))
-        .filter((index) => index !== -1);
-      // BOTH broad rules retained, in their original positions: the first
-      // before node_modules/ and before every re-include, the trailing one
-      // after them.
+      const lastBroadIndex = broadIndexes[broadIndexes.length - 1];
+      // BOTH broad rules retained in their original positions.
       expect(broadIndexes.length).toBe(2);
       expect(broadIndexes[0]).toBe(1);
-      expect(broadIndexes[0]).toBeLessThan(lines.findIndex((line) => line.trim() === "node_modules/"));
-      for (const negationIndex of negationIndexes) {
-        expect(broadIndexes[0]).toBeLessThan(negationIndex);
-        expect(broadIndexes[1]).toBeGreaterThan(negationIndex);
+      expect(broadIndexes[1]).toBe(userLines.length - 1);
+      expect(lines.findIndex((line) => line.trim() === "node_modules/")).toBeGreaterThan(broadIndexes[0]);
+      expect(lines.findIndex((line) => line.trim() === "dist/")).toBeGreaterThan(broadIndexes[0]);
+      // Ownership invariant: every canonical negation now occurs at least
+      // once AFTER the last broad rule (appended in canonical order).
+      const canonicalOrder = [
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/knowledge/**",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+      ];
+      for (const negation of canonicalOrder) {
+        const lastOccurrence = lines.map((line) => line.trim() === negation).lastIndexOf(true);
+        expect(lastOccurrence).toBeGreaterThan(lastBroadIndex);
       }
-      // All canonical entries present; unrelated user lines preserved in order.
+      // The appended block sits at the end, in canonical order, after all
+      // original user lines (the original trailing newline is preserved and
+      // a fresh one terminates the appends).
+      expect(lines.slice(lastBroadIndex + 1)).toEqual([""].concat(canonicalOrder, [""]));
+      // Unrelated user lines preserved in order.
       for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
       for (const line of ["# user comment", "node_modules/", "dist/"]) expect(gitignore).toContain(line);
-      // The first broad rule stays at its original position, BEFORE
-      // node_modules/ (it was already correctly placed).
-      expect(gitignore.indexOf(".mstar/**")).toBeLessThan(gitignore.indexOf("node_modules/"));
-      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
 
-      // Idempotent: second run changes nothing.
+      // Observable git semantics: knowledge contents stay TRACKED even
+      // though a load-bearing broad rule follows their original negations,
+      // while node_modules/ keeps its user-authored meaning.
+      mkdirSync(join(root, ".mstar", "knowledge"), { recursive: true });
+      writeFileSync(join(root, ".mstar", "knowledge", "y.md"), "# y\n", "utf8");
+      mkdirSync(join(root, "node_modules"), { recursive: true });
+      writeFileSync(join(root, "node_modules", "x.js"), "// x\n", "utf8");
+      const addAll = Bun.spawnSync(["git", "add", "-A"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+      expect(addAll.exitCode).toBe(0);
+      const tracked = Bun.spawnSync(["git", "ls-files"], { cwd: root, stdout: "pipe", stderr: "pipe" });
+      expect(tracked.exitCode).toBe(0);
+      const trackedFiles = tracked.stdout.toString();
+      expect(trackedFiles).toContain(".mstar/knowledge/y.md");
+      expect(trackedFiles).not.toContain("node_modules/x.js");
+
+      // Idempotent: second run changes nothing (every canonical negation
+      // already occurs after the last broad rule).
       const second = runScaffold([root]);
       expect(second.exitCode).toBe(0);
-      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(second.stdout).not.toContain("created: .gitignore");
       expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
     });
   });
@@ -636,8 +659,10 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       expect(first.exitCode).toBe(0);
       // Missing !.mstar/specs/** was appended (created message, not a skip).
       expect(first.stdout).toContain("created: .gitignore (canonical harness snippet)");
-      // No reorder message — the infeasible ordering was left untouched.
-      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
+      // The broad rule is NOT moved (infeasible ordering). Content may
+      // still change: the ownership pass re-appends canonical negations
+      // that the broad rule would otherwise shadow (round-9 guarantee).
+      // Original relative order must be preserved — asserted below.
       // No silent skip message: content changed, so "already present" must
       // not be claimed.
       expect(first.stdout).not.toContain("skipped: .gitignore (canonical harness snippet already present)");
@@ -854,10 +879,11 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
 
       const first = runScaffold([root]);
       expect(first.exitCode).toBe(0);
-      // Missing !.mstar/specs/** was appended (created message, not a skip).
-      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet)");
-      // No reorder message — the infeasible ordering was left untouched.
-      expect(first.stdout).not.toContain("created: .gitignore (canonical harness snippet reordered)");
+      // The broad rule is NOT moved (an un-crossable line blocks the
+      // relocation). Content may still change: the ownership pass
+      // re-appends canonical negations that the broad rule would otherwise
+      // shadow (round-9 guarantee). Original relative order must be
+      // preserved — asserted below.
       // No silent skip message: content changed, so "already present" must
       // not be claimed.
       expect(first.stdout).not.toContain("skipped: .gitignore (canonical harness snippet already present)");

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -340,7 +340,7 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("duplicate .mstar/** both before AND after re-includes: trailing broad RETAINED, canonical negations re-appended after it (PR #147 round-8/9)", () => {
+  test("duplicate .mstar/** both before AND after re-includes: trailing broad RETAINED, canonical negations re-appended after it (PR #147)", () => {
     withRoot((root) => {
       // One broad rule before the negations (correctly placed) and a second
       // one after them. Round-8 semantics: node_modules/ (a line whose
@@ -383,7 +383,7 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         .filter((index) => index !== -1);
       const lastBroadIndex = broadIndexes[broadIndexes.length - 1];
       // ONE broad rule: post-partition the duplicate is pure redundancy
-      // (round-10 dedupe) and is removed.
+      // (post-partition dedupe) and is removed.
       expect(broadIndexes.length).toBe(1);
       expect(broadIndexes[0]).toBe(1);
       expect(lines.findIndex((line) => line.trim() === "node_modules/")).toBeGreaterThan(broadIndexes[0]);
@@ -502,7 +502,7 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
 
   test(".mstarc harness_dir=config/.mstar: basename matches default but path is custom — .gitignore untouched", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-5): a custom harness dir whose BASENAME
+      // Regression (PR #147): a custom harness dir whose BASENAME
       // is `.mstar` (e.g. config/.mstar) used to be misclassified as the
       // default layout, so scaffold wrote root-relative `.mstar/**` patterns
       // into <root>/.gitignore that never match config/.mstar/... — process
@@ -527,9 +527,9 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("repo-root .mstarc harness_dir=.mstar + subdir path arg: fence installed at the git top-level (PR #147 round-6)", () => {
+  test("repo-root .mstarc harness_dir=.mstar + subdir path arg: fence installed at the git top-level (PR #147)", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-6): a repo-root `.mstarc` declaring
+      // Regression (PR #147): a repo-root `.mstarc` declaring
       // `harness_dir=.mstar` resolves the harness dir against the config
       // file's location — <repoRoot>/.mstar. Scaffolding a SUBDIRECTORY path
       // used to compare that against <subdir>/.mstar, skip the canonical
@@ -563,9 +563,9 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("custom !.mstar negation before the broad rule: relocated after the fence, custom path becomes tracked (PR #147 round-10 partition)", () => {
+  test("custom !.mstar negation before the broad rule: relocated after the fence, custom path becomes tracked (PR #147 10 partition)", () => {
     withRoot((root) => {
-      // Partition invariant (PR #147 round-10): user-authored targeted
+      // Partition invariant (PR #147): user-authored targeted
       // `.mstar/…` rules always speak LAST. A `!.mstar/custom-keep/**`
       // re-inclusion placed before the broad rule is relocated after the
       // canonical fence (relative order preserved), so its literal intent —
@@ -632,9 +632,9 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
     });
   });
-  test("infeasible ordering (custom negation after a canonical one): broad rule NOT moved, user rule speaks last (PR #147 round-10 partition)", () => {
+  test("infeasible ordering (custom negation after a canonical one): broad rule NOT moved, user rule speaks last (PR #147 10 partition)", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-6, updated round-10): a custom negation
+      // Regression: a custom negation
       // interleaved after a canonical re-include makes single-slot
       // relocation infeasible — the broad rule is NOT moved. The ownership
       // passes still guarantee our tracked results (canonical negations
@@ -692,9 +692,9 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("custom re-inclusion AFTER .mstar/**: relocated to speak last, custom path stays tracked (PR #147 round-10 partition)", () => {
+  test("custom re-inclusion AFTER .mstar/**: relocated to speak last, custom path stays tracked (PR #147 10 partition)", () => {
     withRoot((root) => {
-      // Partition invariant (PR #147 round-10): a user-authored custom
+      // Partition invariant (PR #147): a user-authored custom
       // re-inclusion placed after `.mstar/**` (last-match-wins =>
       // deliberately re-included) keeps its meaning — the partition moves
       // it to speak after the whole fence, so `.mstar/custom/x` stays
@@ -772,9 +772,9 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
     });
   });
-  test("custom negation BETWEEN two .mstar/** rules: trailing broad RETAINED, user rule speaks last (PR #147 round-8/10)", () => {
+  test("custom negation BETWEEN two .mstar/** rules: trailing broad RETAINED, user rule speaks last (PR #147)", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-8): segmented dedupe must RETAIN the
+      // Regression (PR #147): segmented dedupe must RETAIN the
       // trailing broad rule when an un-crossable line lies between it and
       // the previously retained broad rule — deleting it would flip a line
       // we do not own. Round-10 partition: the targeted user rule
@@ -810,7 +810,7 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
         .map((line, index) => (MSTAR_FENCE_ENTRIES.slice(1).includes(line.trim()) ? index : -1))
         .filter((index) => index !== -1);
       // ONE broad rule: post-partition the duplicate is redundant and is
-      // removed (round-10 dedupe).
+      // removed (post-partition dedupe).
       expect(broadIndexes.length).toBe(1);
       // The fence stays intact: broad before every canonical re-include;
       // the targeted user rule speaks last.
@@ -853,9 +853,9 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("misordered broad rule with an un-crossable line in the way: no relocation, order preserved (PR #147 round-7)", () => {
+  test("misordered broad rule with an un-crossable line in the way: no relocation, order preserved (PR #147)", () => {
     withRoot((root) => {
-      // Regression (PR #147 round-7): the broad rule sits AFTER the first
+      // Regression (PR #147): the broad rule sits AFTER the first
       // canonical negation, but a user line (node_modules/) lies strictly
       // between the first canonical negation and the broad rule. Moving the
       // broad rule up would cross that un-owned line and flip its path
@@ -878,7 +878,7 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       // The broad rule is NOT moved (an un-crossable line blocks the
       // relocation). Content may still change: the ownership pass
       // re-appends canonical negations that the broad rule would otherwise
-      // shadow (round-9 guarantee). Original relative order must be
+      // shadow (post-fence canonical guarantee). Original relative order must be
       // preserved — asserted below.
       // No silent skip message: content changed, so "already present" must
       // not be claimed.
@@ -899,7 +899,7 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
     });
   });
 
-  test("misordered broad rule with only owned lines in the way: relocates before the first canonical negation (PR #147 round-7)", () => {
+  test("misordered broad rule with only owned lines in the way: relocates before the first canonical negation (PR #147)", () => {
     withRoot((root) => {
       // Feasible reorder: the broad rule sits after the first canonical
       // negation, and every line between them is one we own (a comment and

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -4,11 +4,15 @@
  * Thin wrapper over engine `path.scaffoldHarness` + `path.emitGitignoreSnippet`
  * (plan-conventions § 初始化 Plan 目录 / § Git 跟踪策略; mstar-project-governance
  * § `_default` 回退):
- * - Creates `.mstar/` (plans/iterations/knowledge/specs/sdd + v2 status.json
- *   + projects/_default/roadmap.md + residuals.json).
- * - Appends the canonical `.gitignore` snippet when absent; skips cleanly
- *   when the complete fence is already present.
- * - Writes a minimal `.mstar/AGENTS.md` when absent.
+ * - Creates the resolved harness dir (default `.mstar/`; `.mstarc`
+ *   harness_dir honored) with plans/iterations/knowledge/specs/sdd + v2
+ *   status.json + `_default/` under the resolved `{PROJECT_DIR}`
+ *   (`.mstarc` project_dir honored) with roadmap.md + residuals.json.
+ * - Appends the canonical `.gitignore` snippet when missing (only for the
+ *   default `.mstar/` layout — custom layouts are skipped); skips cleanly
+ *   when the complete fence is already present. A reversed partial fence
+ *   (re-includes without the broad rule) is spliced, not appended.
+ * - Writes a minimal `{HARNESS_DIR}/AGENTS.md` when absent.
  * - Idempotent: re-running on an initialized tree changes nothing.
  *
  * Each case runs the real CLI as a subprocess against a temp fixture tree.
@@ -147,6 +151,68 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       expect(gitignore.split(".mstar/**").length - 1).toBe(1);
       // All 5 re-include entries are now present.
       for (const entry of MSTAR_FENCE_ENTRIES.slice(1)) expect(gitignore).toContain(entry);
+    });
+  });
+
+  test("reversed partial fence: splices .mstar/** before existing !.mstar/ re-includes", () => {
+    withRoot((root) => {
+      // Pre-existing fence with ONLY re-include lines and no broad rule —
+      // appending .mstar/** at the end would shadow them (last-match-wins).
+      writeFileSync(join(root, ".gitignore"), "!.mstar/knowledge/\n!.mstar/knowledge/**\n", "utf8");
+
+      const result = runScaffold([root]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("created: .gitignore (canonical harness snippet)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const firstNegationIndex = lines.findIndex((line) => line.trim().startsWith("!.mstar/"));
+      expect(broadIndex).toBeGreaterThan(-1);
+      // Broad rule must precede every re-include (gitignore last-match-wins).
+      expect(firstNegationIndex).toBeGreaterThan(broadIndex);
+      // All re-includes present; the pre-existing ones are not duplicated.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+    });
+  });
+
+  test(".mstarc harness_dir=.custom: files land in .custom/, .gitignore untouched", () => {
+    withRoot((root) => {
+      writeFileSync(join(root, ".mstarc"), "[config]\nharness_dir=.custom\n", "utf8");
+
+      const result = runScaffold([root]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`scaffold: harness initialized at ${join(root, ".custom")}`);
+      expect(result.stdout).toContain(`  harness dir: ${join(root, ".custom")}`);
+      expect(result.stdout).toContain(
+        "skipped: .gitignore (canonical harness snippet) — custom harness layout manages its own ignore rules",
+      );
+      // Files land under the declared dir, not .mstar/.
+      expect(existsSync(join(root, ".custom", "status.json"))).toBe(true);
+      expect(existsSync(join(root, ".custom", "projects", "_default", "roadmap.md"))).toBe(true);
+      expect(existsSync(join(root, ".custom", "AGENTS.md"))).toBe(true);
+      expect(existsSync(join(root, ".mstar"))).toBe(false);
+      // No .gitignore mutation for custom layouts.
+      expect(existsSync(join(root, ".gitignore"))).toBe(false);
+    });
+  });
+
+  test(".mstarc project_dir=process/projects: _default lands under the overridden project dir", () => {
+    withRoot((root) => {
+      writeFileSync(join(root, ".mstarc"), "[config]\nproject_dir=process/projects\n", "utf8");
+
+      const result = runScaffold([root]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`  harness dir: ${join(root, ".mstar")}`);
+      expect(result.stdout).toContain(`  project dir: ${join(root, "process", "projects")}`);
+      // Harness layout stays .mstar/ (canonical snippet still appended).
+      expect(result.stdout).toContain("created: .gitignore (canonical harness snippet)");
+      expect(existsSync(join(root, ".mstar", "status.json"))).toBe(true);
+      // _default lands under the resolved project dir, NOT {HARNESS_DIR}/projects.
+      expect(existsSync(join(root, "process", "projects", "_default", "roadmap.md"))).toBe(true);
+      expect(existsSync(join(root, "process", "projects", "_default", "residuals.json"))).toBe(true);
+      expect(existsSync(join(root, ".mstar", "projects"))).toBe(false);
     });
   });
 

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -11,7 +11,9 @@
  * - Appends the canonical `.gitignore` snippet when missing (only for the
  *   default `.mstar/` layout — custom layouts are skipped); skips cleanly
  *   when the complete fence is already present. A reversed partial fence
- *   (re-includes without the broad rule) is spliced, not appended.
+ *   (re-includes without the broad rule) is spliced, not appended; a
+ *   complete-but-misordered fence (broad rule after re-includes) is
+ *   repaired by relocating the broad rule before the first re-include.
  * - Writes a minimal `{HARNESS_DIR}/AGENTS.md` when absent.
  * - Idempotent: re-running on an initialized tree changes nothing.
  *
@@ -174,6 +176,52 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       // All re-includes present; the pre-existing ones are not duplicated.
       expect(gitignore.split(".mstar/**").length - 1).toBe(1);
       for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+    });
+  });
+
+  test("complete-but-misordered fence: relocates .mstar/** before the first !.mstar/ re-include, preserving unrelated lines", () => {
+    withRoot((root) => {
+      // All canonical entries present, but the broad rule sits AFTER the
+      // re-includes — gitignore last-match-wins would shadow them. Unrelated
+      // user lines (comments, other rules) must survive byte-for-byte.
+      const userLines = [
+        "# user comment",
+        "node_modules/",
+        "!.mstar/knowledge/**",
+        ".mstar/**",
+        "!.mstar/AGENTS.md",
+        "!.mstar/knowledge/",
+        "!.mstar/specs/",
+        "!.mstar/specs/**",
+        ".mstarc",
+        "dist/",
+      ];
+      writeFileSync(join(root, ".gitignore"), `${userLines.join("\n")}\n`, "utf8");
+
+      const first = runScaffold([root]);
+      expect(first.exitCode).toBe(0);
+      expect(first.stdout).toContain("created: .gitignore (canonical harness snippet reordered)");
+
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      const lines = gitignore.split(/\r?\n/);
+      const broadIndex = lines.findIndex((line) => line.trim() === ".mstar/**");
+      const firstNegationIndex = lines.findIndex((line) => line.trim().startsWith("!.mstar/"));
+      expect(broadIndex).toBeGreaterThan(-1);
+      // Broad rule now precedes EVERY re-include.
+      expect(firstNegationIndex).toBeGreaterThan(broadIndex);
+      // Exactly one broad rule; all canonical entries present.
+      expect(gitignore.split(".mstar/**").length - 1).toBe(1);
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      // Unrelated user lines preserved byte-for-byte, in order.
+      for (const line of ["# user comment", "node_modules/", "dist/"]) expect(gitignore).toContain(line);
+      expect(gitignore.indexOf("node_modules/")).toBeLessThan(gitignore.indexOf(".mstar/**"));
+      expect(gitignore.indexOf("dist/")).toBeGreaterThan(gitignore.indexOf(".mstar/**"));
+
+      // Idempotent: second run changes nothing.
+      const second = runScaffold([root]);
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toContain("skipped: .gitignore (canonical harness snippet already present)");
+      expect(readFileSync(join(root, ".gitignore"), "utf8")).toBe(gitignore);
     });
   });
 

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -66,6 +66,19 @@ function withRoot(fn: (root: string) => void): void {
   }
 }
 
+/**
+ * Minimal valid git work tree (no `git init` subprocess): the CLI's
+ * workspace-root probe runs `git rev-parse --show-cdup`, which only needs a
+ * valid `.git` layout (HEAD + config + objects/ + refs/) — no commits.
+ * Mirrors the engine path.test.ts `gitInit` fixture.
+ */
+function gitInit(root: string): void {
+  mkdirSync(join(root, ".git", "objects"), { recursive: true });
+  mkdirSync(join(root, ".git", "refs"), { recursive: true });
+  writeFileSync(join(root, ".git", "HEAD"), "ref: refs/heads/main\n");
+  writeFileSync(join(root, ".git", "config"), "[core]\n\trepositoryformatversion = 0\n");
+}
+
 /** Canonical `.mstar/` fence entries (ignore + re-include), verbatim from plan-conventions § Git 跟踪策略. */
 const MSTAR_FENCE_ENTRIES = [
   ".mstar/**",
@@ -426,6 +439,69 @@ describe("mstar harness scaffold — one-shot harness bootstrap", () => {
       expect(proc.stdout.toString()).toContain("scaffold: harness initialized at");
       expect(proc.stdout.toString()).toContain(".mstar");
       expect(existsSync(join(root, ".mstar", "status.json"))).toBe(true);
+    });
+  });
+
+  test(".mstarc harness_dir=config/.mstar: basename matches default but path is custom — .gitignore untouched", () => {
+    withRoot((root) => {
+      // Regression (PR #147 round-5): a custom harness dir whose BASENAME
+      // is `.mstar` (e.g. config/.mstar) used to be misclassified as the
+      // default layout, so scaffold wrote root-relative `.mstar/**` patterns
+      // into <root>/.gitignore that never match config/.mstar/... — process
+      // artifacts stayed unignored while scaffold reported the fence
+      // installed. The gate must be exact-path equality with <root>/.mstar.
+      writeFileSync(join(root, ".mstarc"), "[config]\nharness_dir=config/.mstar\n", "utf8");
+
+      const result = runScaffold([root]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`scaffold: harness initialized at ${join(root, "config", ".mstar")}`);
+      expect(result.stdout).toContain(`  harness dir: ${join(root, "config", ".mstar")}`);
+      expect(result.stdout).toContain(
+        "skipped: .gitignore (canonical harness snippet) — custom harness layout manages its own ignore rules",
+      );
+      // Files land under the declared custom dir.
+      expect(existsSync(join(root, "config", ".mstar", "status.json"))).toBe(true);
+      expect(existsSync(join(root, "config", ".mstar", "projects", "_default", "roadmap.md"))).toBe(true);
+      expect(existsSync(join(root, "config", ".mstar", "AGENTS.md"))).toBe(true);
+      // No default-layout dir and NO .gitignore created/modified.
+      expect(existsSync(join(root, ".mstar"))).toBe(false);
+      expect(existsSync(join(root, ".gitignore"))).toBe(false);
+    });
+  });
+
+  test("repo-root .mstarc harness_dir=.mstar + subdir path arg: fence installed at the git top-level (PR #147 round-6)", () => {
+    withRoot((root) => {
+      // Regression (PR #147 round-6): a repo-root `.mstarc` declaring
+      // `harness_dir=.mstar` resolves the harness dir against the config
+      // file's location — <repoRoot>/.mstar. Scaffolding a SUBDIRECTORY path
+      // used to compare that against <subdir>/.mstar, skip the canonical
+      // fence, and leave status/plans/projects committable. The comparison
+      // AND the fence target must anchor at the git top-level.
+      gitInit(root);
+      writeFileSync(join(root, ".mstarc"), "[config]\nharness_dir=.mstar\n", "utf8");
+      mkdirSync(join(root, "packages", "foo"), { recursive: true });
+
+      const result = runScaffold([join(root, "packages", "foo")]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`scaffold: harness initialized at ${join(root, ".mstar")}`);
+      expect(result.stdout).toContain("created: .gitignore (canonical harness snippet)");
+
+      // Fence lands in the REPO-ROOT .gitignore, not the subdir's.
+      expect(existsSync(join(root, ".gitignore"))).toBe(true);
+      expect(existsSync(join(root, "packages", "foo", ".gitignore"))).toBe(false);
+      const gitignore = readFileSync(join(root, ".gitignore"), "utf8");
+      for (const entry of MSTAR_FENCE_ENTRIES) expect(gitignore).toContain(entry);
+      // Harness files land under the repo-root .mstar/.
+      expect(existsSync(join(root, ".mstar", "status.json"))).toBe(true);
+
+      // git check-ignore confirms the fence actually ignores process artifacts.
+      const check = Bun.spawnSync(["git", "check-ignore", "-v", join(root, ".mstar", "status.json")], {
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(check.exitCode).toBe(0);
+      expect(check.stdout.toString()).toContain(".mstar/**");
     });
   });
 });

--- a/packages/cli/test/scaffold-cli.test.ts
+++ b/packages/cli/test/scaffold-cli.test.ts
@@ -1,5 +1,5 @@
 /**
- * CLI `mstar scaffold` — one-shot harness bootstrap wrapper.
+ * CLI `mstar harness scaffold` — one-shot harness bootstrap wrapper.
  *
  * Thin wrapper over engine `path.scaffoldHarness` + `path.emitGitignoreSnippet`
  * (plan-conventions § 初始化 Plan 目录 / § Git 跟踪策略; mstar-project-governance
@@ -41,7 +41,7 @@ function cliEnv(): Record<string, string> {
 }
 
 function runScaffold(args: string[]): RunResult {
-  const proc = Bun.spawnSync([process.execPath, "run", "src/index.ts", "scaffold", ...args], {
+  const proc = Bun.spawnSync([process.execPath, "run", "src/index.ts", "harness", "scaffold", ...args], {
     cwd: CLI_ROOT,
     env: cliEnv(),
     stdout: "pipe",
@@ -70,7 +70,7 @@ const MSTAR_FENCE_ENTRIES = [
   "!.mstar/specs/**",
 ];
 
-describe("mstar scaffold — one-shot harness bootstrap", () => {
+describe("mstar harness scaffold — one-shot harness bootstrap", () => {
   test("creates .mstar/ with dirs, v2 status.json, projects/_default/, .gitignore snippet, and .mstar/AGENTS.md", () => {
     withRoot((root) => {
       const result = runScaffold([root]);
@@ -152,7 +152,7 @@ describe("mstar scaffold — one-shot harness bootstrap", () => {
 
   test("defaults to cwd when [path] is omitted", () => {
     withRoot((root) => {
-      const proc = Bun.spawnSync([process.execPath, "run", join(CLI_ROOT, "src/index.ts"), "scaffold"], {
+      const proc = Bun.spawnSync([process.execPath, "run", join(CLI_ROOT, "src/index.ts"), "harness", "scaffold"], {
         cwd: root,
         env: cliEnv(),
         stdout: "pipe",

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -35,12 +35,14 @@ export {
 } from "./mstarc.js";
 export {
   assertPlanWritingPath,
+  detectHarnessKind,
   emitGitignoreSnippet,
   resolveHarnessDir,
   resolveIterationDir,
   resolveKnowledgeDir,
   resolvePlanDir,
   resolveProjectDir,
+  resolveScaffoldDirs,
   resolveSddDir,
   resolveSpecsDir,
   resolveWorkflowDir,

--- a/packages/engine/src/path.ts
+++ b/packages/engine/src/path.ts
@@ -28,11 +28,17 @@
  * are embedded constants: the engine never reads skill files at runtime
  * (roadmap §8.5 standalone rule).
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { readJson, writeJson, type ValidationResult } from "./core.js";
 import { loadMstarc, type MstarcConfig } from "./mstarc.js";
+// Call-time-only cycle with project.ts (project.ts → status.ts → path.ts):
+// none of the cycle members dereferences the other's bindings during module
+// evaluation — the constants are used only inside scaffoldHarness — so the
+// ESM live-binding cycle is safe (same pattern as the status.ts ↔ workflow.ts
+// cycle documented in status.ts).
+import { _DEFAULT_PROJECT, PROJECT_REGISTER_FILE, PROJECT_ROADMAP_FILE } from "./project.js";
 
 /**
  * Options for `resolveHarnessDir`.
@@ -358,11 +364,50 @@ const EMPTY_STATUS_TEMPLATE: Record<string, unknown> = {
 const SCAFFOLD_DIRS = ["plans", "iterations", "knowledge", "specs", "sdd"] as const;
 
 /**
+ * Scaffolded `projects/_default/roadmap.md` template — embedded copy of
+ * the project-layer writer contract (mstar-project-governance § roadmap.md
+ * 编写约定): valid `validateRoadmap` frontmatter (`project_id: _default`,
+ * non-empty title, `status: active`, `created_at: <today>`) plus a
+ * `## Direction` body placeholder so the documented body convention is met
+ * (0 violations; the missing goal-item task list is a warning only, never
+ * a hard gate). `created_at` is filled at scaffold time. Kept as a
+ * constant so the engine has no runtime dependency on skill files.
+ */
+const ROADMAP_TEMPLATE = `---
+project_id: _default
+title: Default Project
+status: active
+created_at: {created_at}
+---
+
+# Roadmap
+
+## Direction
+
+State the project direction here.
+`;
+
+/**
+ * Scaffolded `projects/_default/residuals.json` template — the empty
+ * project register `{ "entries": {} }` (mstar-project-governance §
+ * residuals.json register 生命周期), which passes `validateProjectRegister`.
+ * Kept as a constant so the engine has no runtime dependency on skill
+ * files.
+ */
+const EMPTY_REGISTER_TEMPLATE: Record<string, unknown> = {
+  entries: {},
+};
+
+/**
  * Initialize the harness directory under `root`: create `.mstar/` with
- * `plans/`, `iterations/`, `knowledge/`, `specs/`, `sdd/` and write
- * `status.json` from the empty template (plan-conventions § 初始化 Plan 目录).
- * Idempotent: an existing non-empty `status.json` is never clobbered.
- * Returns the absolute harness dir.
+ * `plans/`, `iterations/`, `knowledge/`, `specs/`, `sdd/`, write
+ * `status.json` from the empty template, and prebuild the v3 project layer
+ * `projects/_default/` with a valid `roadmap.md` + empty `residuals.json`
+ * (plan-conventions § 初始化 Plan 目录; mstar-project-governance §
+ * `_default` 回退). Idempotent: an existing non-empty `status.json`,
+ * `roadmap.md`, or `residuals.json` is never clobbered; re-running on an
+ * initialized tree only creates missing pieces. Returns the absolute
+ * harness dir.
  */
 export function scaffoldHarness(root: string): string {
   const harnessDir = join(resolve(root), ".mstar");
@@ -371,6 +416,21 @@ export function scaffoldHarness(root: string): string {
   // readJson treats a missing file as `{}`, so a missing (or empty) status.json
   // is replaced with the empty template; anything with content is preserved.
   if (Object.keys(readJson(statusPath)).length === 0) writeJson(statusPath, EMPTY_STATUS_TEMPLATE);
+  // v3 project layer: `projects/_default/` is scaffolded (the fallback
+  // project for project-less flows); other project ids and `workflows/`
+  // stay on-demand (engine writers create them).
+  const projectDir = join(harnessDir, "projects", _DEFAULT_PROJECT);
+  mkdirSync(projectDir, { recursive: true });
+  const roadmapPath = join(projectDir, PROJECT_ROADMAP_FILE);
+  if (!existsSync(roadmapPath)) {
+    const today = new Date();
+    const month = String(today.getMonth() + 1).padStart(2, "0");
+    const day = String(today.getDate()).padStart(2, "0");
+    const created = `${today.getFullYear()}-${month}-${day}`;
+    writeFileSync(roadmapPath, ROADMAP_TEMPLATE.replace("{created_at}", created), "utf8");
+  }
+  const registerPath = join(projectDir, PROJECT_REGISTER_FILE);
+  if (Object.keys(readJson(registerPath)).length === 0) writeJson(registerPath, EMPTY_REGISTER_TEMPLATE);
   return harnessDir;
 }
 

--- a/packages/engine/src/path.ts
+++ b/packages/engine/src/path.ts
@@ -306,7 +306,7 @@ function resolveHarnessSubdir(
   const harness = resolveHarnessDir(startDir, opts);
   if (harness === null) {
     throw new Error(
-      `harness dir not found from ${resolve(startDir)} \u2014 cannot resolve the ${fallback} dir (run \`mstar scaffold\`, pass opts.harnessDir, or set MSTAR_HARNESS_DIR)`,
+      `harness dir not found from ${resolve(startDir)} \u2014 cannot resolve the ${fallback} dir (run \`mstar harness scaffold\`, pass opts.harnessDir, or set MSTAR_HARNESS_DIR)`,
     );
   }
   const declared = mstarcDirOverride(harness, key);

--- a/packages/engine/src/path.ts
+++ b/packages/engine/src/path.ts
@@ -360,8 +360,36 @@ const EMPTY_STATUS_TEMPLATE: Record<string, unknown> = {
   workflows: [],
 };
 
-/** Subdirectories created under `.mstar/` by `scaffoldHarness`. */
+/** Subdirectories created under the harness dir by `scaffoldHarness`. */
 const SCAFFOLD_DIRS = ["plans", "iterations", "knowledge", "specs", "sdd"] as const;
+
+/**
+ * Resolve the scaffold target dirs for `root` — the harness dir and the
+ * project dir — from the same config source the runtime resolvers use
+ * (plan-conventions § {HARNESS_DIR} 解析顺序): explicit `MSTAR_HARNESS_DIR`
+ * env wins, then `.mstarc` `[config] harness_dir` (found per find-first-stop
+ * within the workspace-root boundary, resolved against the config file's
+ * directory), else the default `.mstar/`. The project dir defaults to
+ * `{HARNESS_DIR}/projects/` with the `.mstarc` `[config] project_dir`
+ * override honored independently (same `mstarcDirOverride` semantics as
+ * `resolveProjectDir`). Unlike `resolveHarnessDir`, the probe rung is
+ * skipped: scaffold initializes the default `.mstar/` even when a legacy
+ * `.agents/` exists (default behavior unchanged without a `.mstarc`).
+ */
+export function resolveScaffoldDirs(root: string): { harnessDir: string; projectDir: string } {
+  const start = resolve(root);
+  const boundary = resolve(start, defaultWorkspaceRoot(start));
+  const rc = loadMstarc(start, boundary);
+  const explicit = process.env.MSTAR_HARNESS_DIR;
+  const harnessDir = explicit
+    ? resolve(start, explicit)
+    : rc !== null && rc.config.harnessDir
+      ? resolve(rc.dir, rc.config.harnessDir)
+      : join(start, ".mstar");
+  const declaredProjectDir = mstarcDirOverride(harnessDir, "projectDir");
+  const projectDir = declaredProjectDir !== null ? declaredProjectDir : join(harnessDir, "projects");
+  return { harnessDir, projectDir };
+}
 
 /**
  * Scaffolded `projects/_default/roadmap.md` template — embedded copy of
@@ -399,18 +427,21 @@ const EMPTY_REGISTER_TEMPLATE: Record<string, unknown> = {
 };
 
 /**
- * Initialize the harness directory under `root`: create `.mstar/` with
- * `plans/`, `iterations/`, `knowledge/`, `specs/`, `sdd/`, write
- * `status.json` from the empty template, and prebuild the v3 project layer
- * `projects/_default/` with a valid `roadmap.md` + empty `residuals.json`
- * (plan-conventions § 初始化 Plan 目录; mstar-project-governance §
- * `_default` 回退). Idempotent: an existing non-empty `status.json`,
- * `roadmap.md`, or `residuals.json` is never clobbered; re-running on an
- * initialized tree only creates missing pieces. Returns the absolute
- * harness dir.
+ * Initialize the harness directory under `root`: create the resolved
+ * harness dir (default `.mstar/`, or the `.mstarc`-declared `harness_dir`
+ * / `MSTAR_HARNESS_DIR` override — see `resolveScaffoldDirs`) with `plans/`,
+ * `iterations/`, `knowledge/`, `specs/`, `sdd/`, write `status.json` from
+ * the empty template, and prebuild the v3 project layer `_default/` under
+ * the resolved project dir (default `{HARNESS_DIR}/projects/`, or the
+ * `.mstarc`-declared `project_dir`) with a valid `roadmap.md` + empty
+ * `residuals.json` (plan-conventions § 初始化 Plan 目录;
+ * mstar-project-governance § `_default` 回退). Idempotent: an existing
+ * non-empty `status.json`, `roadmap.md`, or `residuals.json` is never
+ * clobbered; re-running on an initialized tree only creates missing
+ * pieces. Returns the absolute resolved harness dir.
  */
 export function scaffoldHarness(root: string): string {
-  const harnessDir = join(resolve(root), ".mstar");
+  const { harnessDir, projectDir } = resolveScaffoldDirs(root);
   for (const dir of SCAFFOLD_DIRS) mkdirSync(join(harnessDir, dir), { recursive: true });
   const statusPath = join(harnessDir, "status.json");
   // readJson treats a missing file as `{}`, so a missing (or empty) status.json
@@ -419,14 +450,14 @@ export function scaffoldHarness(root: string): string {
   // v3 project layer: `projects/_default/` is scaffolded (the fallback
   // project for project-less flows); other project ids and `workflows/`
   // stay on-demand (engine writers create them).
-  const projectDir = join(harnessDir, "projects", _DEFAULT_PROJECT);
-  mkdirSync(projectDir, { recursive: true });
-  const roadmapPath = join(projectDir, PROJECT_ROADMAP_FILE);
+  const defaultProjectDir = join(projectDir, _DEFAULT_PROJECT);
+  mkdirSync(defaultProjectDir, { recursive: true });
+  const roadmapPath = join(defaultProjectDir, PROJECT_ROADMAP_FILE);
   if (!existsSync(roadmapPath)) {
     const created = new Date().toISOString().slice(0, 10);
     writeFileSync(roadmapPath, ROADMAP_TEMPLATE.replace("{created_at}", created), "utf8");
   }
-  const registerPath = join(projectDir, PROJECT_REGISTER_FILE);
+  const registerPath = join(defaultProjectDir, PROJECT_REGISTER_FILE);
   if (Object.keys(readJson(registerPath)).length === 0) writeJson(registerPath, EMPTY_REGISTER_TEMPLATE);
   return harnessDir;
 }
@@ -574,7 +605,7 @@ export function validateGitignore(root: string): ValidationResult {
 }
 
 /** Detect the gitignore fence kind from a resolved harness dir (basename). */
-function detectHarnessKind(harnessDir: string | null): HarnessKind | null {
+export function detectHarnessKind(harnessDir: string | null): HarnessKind | null {
   if (!harnessDir) return null;
   const name = basename(resolve(harnessDir));
   if (name === ".mstar") return "mstar";

--- a/packages/engine/src/path.ts
+++ b/packages/engine/src/path.ts
@@ -306,7 +306,7 @@ function resolveHarnessSubdir(
   const harness = resolveHarnessDir(startDir, opts);
   if (harness === null) {
     throw new Error(
-      `harness dir not found from ${resolve(startDir)} \u2014 cannot resolve the ${fallback} dir (run \`mstar init\`, pass opts.harnessDir, or set MSTAR_HARNESS_DIR)`,
+      `harness dir not found from ${resolve(startDir)} \u2014 cannot resolve the ${fallback} dir (run \`mstar scaffold\`, pass opts.harnessDir, or set MSTAR_HARNESS_DIR)`,
     );
   }
   const declared = mstarcDirOverride(harness, key);
@@ -423,10 +423,7 @@ export function scaffoldHarness(root: string): string {
   mkdirSync(projectDir, { recursive: true });
   const roadmapPath = join(projectDir, PROJECT_ROADMAP_FILE);
   if (!existsSync(roadmapPath)) {
-    const today = new Date();
-    const month = String(today.getMonth() + 1).padStart(2, "0");
-    const day = String(today.getDate()).padStart(2, "0");
-    const created = `${today.getFullYear()}-${month}-${day}`;
+    const created = new Date().toISOString().slice(0, 10);
     writeFileSync(roadmapPath, ROADMAP_TEMPLATE.replace("{created_at}", created), "utf8");
   }
   const registerPath = join(projectDir, PROJECT_REGISTER_FILE);

--- a/packages/engine/test/path.test.ts
+++ b/packages/engine/test/path.test.ts
@@ -880,6 +880,69 @@ describe("scaffoldHarness (plan-conventions § 初始化 Plan 目录 + templates
     }
   });
 
+  test("honors .mstarc [config] harness_dir when resolving the scaffold target", () => {
+    const root = tmpRoot("path-scaffold-mstarc-harness-");
+    try {
+      writeFileSync(join(root, ".mstarc"), "[config]\nharness_dir=.custom\n", "utf8");
+      const harnessDir = scaffoldHarness(root);
+      // Files land under the declared dir, not the default .mstar/.
+      expect(harnessDir).toBe(resolve(root, ".custom"));
+      expect(existsSync(join(root, ".custom", "status.json"))).toBe(true);
+      expect(existsSync(join(root, ".custom", "plans"))).toBe(true);
+      expect(existsSync(join(root, ".custom", "projects", "_default", "roadmap.md"))).toBe(true);
+      expect(existsSync(join(root, ".mstar"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("honors MSTAR_HARNESS_DIR env override for the scaffold target", () => {
+    const root = tmpRoot("path-scaffold-mstarc-env-");
+    try {
+      const custom = join(root, "env-harness");
+      withEnv(custom, () => {
+        const harnessDir = scaffoldHarness(root);
+        expect(harnessDir).toBe(custom);
+        expect(existsSync(join(custom, "status.json"))).toBe(true);
+        expect(existsSync(join(custom, "projects", "_default", "roadmap.md"))).toBe(true);
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("honors .mstarc [config] project_dir independently of the harness dir", () => {
+    const root = tmpRoot("path-scaffold-mstarc-project-");
+    try {
+      writeFileSync(join(root, ".mstarc"), "[config]\nproject_dir=process/projects\n", "utf8");
+      const harnessDir = scaffoldHarness(root);
+      // Harness stays at the default .mstar/; _default lands under the
+      // RESOLVED {PROJECT_DIR} (project_dir resolved against the .mstarc
+      // file's directory), not {HARNESS_DIR}/projects.
+      expect(harnessDir).toBe(resolve(root, ".mstar"));
+      expect(existsSync(join(root, ".mstar", "status.json"))).toBe(true);
+      expect(existsSync(join(root, "process", "projects", "_default", "roadmap.md"))).toBe(true);
+      expect(existsSync(join(root, "process", "projects", "_default", "residuals.json"))).toBe(true);
+      expect(existsSync(join(root, ".mstar", "projects"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("honors .mstarc harness_dir AND project_dir independently (both keys)", () => {
+    const root = tmpRoot("path-scaffold-mstarc-both-");
+    try {
+      writeFileSync(join(root, ".mstarc"), "[config]\nharness_dir=.custom\nproject_dir=process/projects\n", "utf8");
+      const harnessDir = scaffoldHarness(root);
+      expect(harnessDir).toBe(resolve(root, ".custom"));
+      expect(existsSync(join(root, ".custom", "status.json"))).toBe(true);
+      expect(existsSync(join(root, "process", "projects", "_default", "roadmap.md"))).toBe(true);
+      expect(existsSync(join(root, ".custom", "projects"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("is idempotent: preserves user-edited roadmap.md and residuals.json", () => {
     const root = tmpRoot("path-scaffold-idem-project-");
     try {

--- a/packages/engine/test/path.test.ts
+++ b/packages/engine/test/path.test.ts
@@ -48,6 +48,8 @@ import {
   validateGitignore,
 } from "../src/path.js";
 import { validateStatusV2 } from "../src/status.js";
+import { validateProjectRegister, validateRoadmap } from "../src/project.js";
+import { readJson } from "../src/core.js";
 
 const ENV_KEY = "MSTAR_HARNESS_DIR";
 
@@ -816,6 +818,7 @@ describe("scaffoldHarness (plan-conventions § 初始化 Plan 目录 + templates
         "iterations",
         "knowledge",
         "plans",
+        "projects",
         "sdd",
         "specs",
         "status.json",
@@ -835,6 +838,34 @@ describe("scaffoldHarness (plan-conventions § 初始化 Plan 目录 + templates
     }
   });
 
+  test("prebuilds projects/_default/ with a valid roadmap.md + empty residuals.json", () => {
+    const root = tmpRoot("path-scaffold-project-");
+    try {
+      const harnessDir = scaffoldHarness(root);
+      const projectDir = join(harnessDir, "projects", "_default");
+      expect(readdirSync(projectDir).sort()).toEqual(["residuals.json", "roadmap.md"]);
+      // Roadmap frontmatter: project_id _default, non-empty title, status
+      // active, created_at today, plus a `## Direction` body placeholder —
+      // 0 violations (the missing goal-item task list is a warning only).
+      const roadmapPath = join(projectDir, "roadmap.md");
+      const roadmap = validateRoadmap(roadmapPath);
+      expect(roadmap.ok).toBe(true);
+      expect(roadmap.violations).toEqual([]);
+      const roadmapText = readFileSync(roadmapPath, "utf8");
+      expect(roadmapText).toContain("project_id: _default");
+      expect(roadmapText).toContain("title: Default Project");
+      expect(roadmapText).toContain("status: active");
+      expect(roadmapText).toContain(`created_at: ${new Date().toISOString().slice(0, 10)}`);
+      expect(roadmapText).toContain("## Direction");
+      // Empty register passes the project-register validator.
+      const registerPath = join(projectDir, "residuals.json");
+      expect(readFileSync(registerPath, "utf8")).toBe('{\n  "entries": {}\n}\n');
+      expect(validateProjectRegister(readJson(registerPath)).ok).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("is idempotent: preserves an existing non-empty status.json", () => {
     const root = tmpRoot("path-scaffold-idem-");
     try {
@@ -844,6 +875,34 @@ describe("scaffoldHarness (plan-conventions § 初始化 Plan 目录 + templates
       writeFileSync(statusPath, custom);
       scaffoldHarness(root);
       expect(readFileSync(statusPath, "utf8")).toBe(custom);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("is idempotent: preserves user-edited roadmap.md and residuals.json", () => {
+    const root = tmpRoot("path-scaffold-idem-project-");
+    try {
+      scaffoldHarness(root);
+      const roadmapPath = join(root, ".mstar", "projects", "_default", "roadmap.md");
+      const registerPath = join(root, ".mstar", "projects", "_default", "residuals.json");
+      const customRoadmap = `---
+project_id: _default
+title: Custom Roadmap
+status: active
+created_at: 2026-08-01
+---
+
+## Direction
+
+Custom direction.
+`;
+      const customRegister = '{\n  "entries": {}\n}\n';
+      writeFileSync(roadmapPath, customRoadmap);
+      writeFileSync(registerPath, customRegister);
+      scaffoldHarness(root);
+      expect(readFileSync(roadmapPath, "utf8")).toBe(customRoadmap);
+      expect(readFileSync(registerPath, "utf8")).toBe(customRegister);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/skills/mstar-conventions/SKILL.md
+++ b/skills/mstar-conventions/SKILL.md
@@ -112,7 +112,7 @@ PM 在需要持久化追踪时：
 3. 项目根 `.gitignore` 追加 Morning Star **进程产物**忽略集（见下文「Git 跟踪策略」）— CLI `init` 可自动添加
 4. Git：**进程本地、结果共享** — 默认跟踪 `{HARNESS_DIR}/AGENTS.md`、`{KNOWLEDGE_DIR}/**`、`{SPECS_DIR}/**`；`plans/`、`iterations/`、`status.json` 等为**本地会话 SSOT**，默认 gitignored。跨 clone 持久 handoff = knowledge + specs + `{HARNESS_DIR}/AGENTS.md`（及根 `CONCEPTS.md` / `STRATEGY.md` 若使用）；须跨 clone 的 residual 须提升（compound）或写入 tracked results — **勿**默认 `git add` `status.json` / `plans/`。
 
-**程序化初始化**：`scaffoldHarness`（engine）与 `mstar harness scaffold [path]`（CLI）一次性完成上述 bootstrap —— 目录 + v2 `status.json` + **`projects/_default/` 预建**（`roadmap.md` + 空 `residuals.json`）+ canonical gitignore snippet + 最小 `{HARNESS_DIR}/AGENTS.md`；幂等，重跑只补缺失件。
+**程序化初始化**：`scaffoldHarness`（engine）与 `mstar harness scaffold [path]`（CLI）一次性完成上述 bootstrap —— 目录 + v2 `status.json` + **`projects/_default/` 预建**（`roadmap.md` + 空 `residuals.json`）+ canonical gitignore snippet + 最小 `{HARNESS_DIR}/AGENTS.md`；幂等，重跑只补缺失件。 scaffold 遵循 `.mstarc`：`harness_dir` / `project_dir` 声明优先（写入解析后的目录）；解析出的 harness 目录名非 `.mstar` 时跳过 canonical gitignore snippet（自定义 harness 布局自行管理 ignore 规则）。
 
 步骤与 `{HARNESS_DIR}/AGENTS.md` 分层 → **`references/harness-bootstrap-and-agents-layering.md`**。
 

--- a/skills/mstar-conventions/SKILL.md
+++ b/skills/mstar-conventions/SKILL.md
@@ -108,9 +108,11 @@ enforcement=hard
 PM 在需要持久化追踪时：
 
 1. 建 `.mstar/`、`plans/`、`status.json`（**v2 空模板**见 **`mstar-artifacts/templates/status.empty.json`**：`version: 2` + `workflows: []`）
-2. 可选 `knowledge/`、`iterations/`、`{HARNESS_DIR}/specs/`、`sdd/`（空目录占位；运行时 per-plan 子目录由 **`mstar-sdd`** → `mstar sdd workspace <plan-id>` 创建；`workflows/` / `projects/` 由 engine writers 按需创建，**不**预建）
+2. 可选 `knowledge/`、`iterations/`、`{HARNESS_DIR}/specs/`、`sdd/`（空目录占位；运行时 per-plan 子目录由 **`mstar-sdd`** → `mstar sdd workspace <plan-id>` 创建；`workflows/` 由 engine writers 按需创建，**不**预建）
 3. 项目根 `.gitignore` 追加 Morning Star **进程产物**忽略集（见下文「Git 跟踪策略」）— CLI `init` 可自动添加
 4. Git：**进程本地、结果共享** — 默认跟踪 `{HARNESS_DIR}/AGENTS.md`、`{KNOWLEDGE_DIR}/**`、`{SPECS_DIR}/**`；`plans/`、`iterations/`、`status.json` 等为**本地会话 SSOT**，默认 gitignored。跨 clone 持久 handoff = knowledge + specs + `{HARNESS_DIR}/AGENTS.md`（及根 `CONCEPTS.md` / `STRATEGY.md` 若使用）；须跨 clone 的 residual 须提升（compound）或写入 tracked results — **勿**默认 `git add` `status.json` / `plans/`。
+
+**程序化初始化**：`scaffoldHarness`（engine）与 `mstar scaffold [path]`（CLI）一次性完成上述 bootstrap —— 目录 + v2 `status.json` + **`projects/_default/` 预建**（`roadmap.md` + 空 `residuals.json`）+ canonical gitignore snippet + 最小 `{HARNESS_DIR}/AGENTS.md`；幂等，重跑只补缺失件。
 
 步骤与 `{HARNESS_DIR}/AGENTS.md` 分层 → **`references/harness-bootstrap-and-agents-layering.md`**。
 
@@ -136,7 +138,7 @@ PM 在需要持久化追踪时：
 
 Legacy `.agents/` 项目：将上表路径前缀 `.mstar/` 换为 `.agents/`。
 
-**v3 运行时目录的 gitignore 说明（文档化；canonical snippet 零改动）**：`workflows/` 与 `projects/` 都位于已被 **`.mstar/**` 默认忽略**的 `{HARNESS_DIR}` 之下——**不需要**在仓库根 `.gitignore` 增加任何条目，也**不新增** re-include 条目（它们不是 tracked 结果）。`workflows/` / `projects/` 子目录由 **engine writers 按需创建**（`writeWorkflowSnapshot` / `registerWorkflow` / project-register 写入路径），**不是** `scaffoldHarness` 的初始化产物——`mstar init` 不会预建空目录。
+**v3 运行时目录的 gitignore 说明（文档化；canonical snippet 零改动）**：`workflows/` 与 `projects/` 都位于已被 **`.mstar/**` 默认忽略**的 `{HARNESS_DIR}` 之下——**不需要**在仓库根 `.gitignore` 增加任何条目，也**不新增** re-include 条目（它们不是 tracked 结果）。`projects/_default/` 由 **`scaffoldHarness` / `mstar scaffold` 预建**（`roadmap.md` + 空 `residuals.json`）；其余 project id 与 `workflows/` 子目录由 **engine writers 按需创建**（`writeWorkflowSnapshot` / `registerWorkflow` / project-register 写入路径），**不是** `scaffoldHarness` 的初始化产物。
 
 **多 worktree（iteration L1）**：默认 gitignored 的进程产物**不会**随 `git worktree add` 进入 feature 检出。读写须经 **control worktree** 绝对路径（`<control_worktree_path>/{HARNESS_DIR}/…`）；产品代码改在 feature worktree。细则与反模式（禁止因 feature 缺 plans 而 `Worktree mode: waived`）→ **`mstar-branch-worktree`**「Harness path SSOT under default gitignore」。
 

--- a/skills/mstar-conventions/SKILL.md
+++ b/skills/mstar-conventions/SKILL.md
@@ -112,7 +112,7 @@ PM 在需要持久化追踪时：
 3. 项目根 `.gitignore` 追加 Morning Star **进程产物**忽略集（见下文「Git 跟踪策略」）— CLI `init` 可自动添加
 4. Git：**进程本地、结果共享** — 默认跟踪 `{HARNESS_DIR}/AGENTS.md`、`{KNOWLEDGE_DIR}/**`、`{SPECS_DIR}/**`；`plans/`、`iterations/`、`status.json` 等为**本地会话 SSOT**，默认 gitignored。跨 clone 持久 handoff = knowledge + specs + `{HARNESS_DIR}/AGENTS.md`（及根 `CONCEPTS.md` / `STRATEGY.md` 若使用）；须跨 clone 的 residual 须提升（compound）或写入 tracked results — **勿**默认 `git add` `status.json` / `plans/`。
 
-**程序化初始化**：`scaffoldHarness`（engine）与 `mstar scaffold [path]`（CLI）一次性完成上述 bootstrap —— 目录 + v2 `status.json` + **`projects/_default/` 预建**（`roadmap.md` + 空 `residuals.json`）+ canonical gitignore snippet + 最小 `{HARNESS_DIR}/AGENTS.md`；幂等，重跑只补缺失件。
+**程序化初始化**：`scaffoldHarness`（engine）与 `mstar harness scaffold [path]`（CLI）一次性完成上述 bootstrap —— 目录 + v2 `status.json` + **`projects/_default/` 预建**（`roadmap.md` + 空 `residuals.json`）+ canonical gitignore snippet + 最小 `{HARNESS_DIR}/AGENTS.md`；幂等，重跑只补缺失件。
 
 步骤与 `{HARNESS_DIR}/AGENTS.md` 分层 → **`references/harness-bootstrap-and-agents-layering.md`**。
 
@@ -138,7 +138,7 @@ PM 在需要持久化追踪时：
 
 Legacy `.agents/` 项目：将上表路径前缀 `.mstar/` 换为 `.agents/`。
 
-**v3 运行时目录的 gitignore 说明（文档化；canonical snippet 零改动）**：`workflows/` 与 `projects/` 都位于已被 **`.mstar/**` 默认忽略**的 `{HARNESS_DIR}` 之下——**不需要**在仓库根 `.gitignore` 增加任何条目，也**不新增** re-include 条目（它们不是 tracked 结果）。`projects/_default/` 由 **`scaffoldHarness` / `mstar scaffold` 预建**（`roadmap.md` + 空 `residuals.json`）；其余 project id 与 `workflows/` 子目录由 **engine writers 按需创建**（`writeWorkflowSnapshot` / `registerWorkflow` / project-register 写入路径），**不是** `scaffoldHarness` 的初始化产物。
+**v3 运行时目录的 gitignore 说明（文档化；canonical snippet 零改动）**：`workflows/` 与 `projects/` 都位于已被 **`.mstar/**` 默认忽略**的 `{HARNESS_DIR}` 之下——**不需要**在仓库根 `.gitignore` 增加任何条目，也**不新增** re-include 条目（它们不是 tracked 结果）。`projects/_default/` 由 **`scaffoldHarness` / `mstar harness scaffold` 预建**（`roadmap.md` + 空 `residuals.json`）；其余 project id 与 `workflows/` 子目录由 **engine writers 按需创建**（`writeWorkflowSnapshot` / `registerWorkflow` / project-register 写入路径），**不是** `scaffoldHarness` 的初始化产物。
 
 **多 worktree（iteration L1）**：默认 gitignored 的进程产物**不会**随 `git worktree add` 进入 feature 检出。读写须经 **control worktree** 绝对路径（`<control_worktree_path>/{HARNESS_DIR}/…`）；产品代码改在 feature worktree。细则与反模式（禁止因 feature 缺 plans 而 `Worktree mode: waived`）→ **`mstar-branch-worktree`**「Harness path SSOT under default gitignore」。
 

--- a/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
+++ b/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
@@ -23,7 +23,7 @@
 
 **程序化路径**：`mstar harness scaffold [path]`（CLI，默认 cwd）一次性完成步骤 1–2（含 `projects/_default/`）、4 与 6 —— 调用 engine `scaffoldHarness`、追加 canonical gitignore snippet（已存在则跳过）、写最小 `{HARNESS_DIR}/AGENTS.md`（已存在则跳过）；幂等，重跑只补缺失件。步骤 3、5、7、8 仍按需手工。 scaffold 遵循 `.mstarc` 的 `harness_dir` / `project_dir` 覆盖（写入解析后的目录）；解析出的 harness 目录名非 `.mstar` 时跳过 canonical gitignore snippet（自定义 harness 布局自行管理 ignore 规则）。
 
-**gitignore 归一化契约与权衡（round-10 定稿）**：scaffold 对默认布局的根 `.gitignore` 只做四类收敛——分区（用户针对性 `.mstar/…` 规则整体移到 fence 之后、相对顺序不变）、去重冗余宽规则、把错位的主宽规则移到首个 canonical negation 之前（仅当跨越行全部为 scaffold 自有语义）、补齐 canonical negation 使其出现在最后一条宽规则之后。契约保证：① scaffold 的 tracked 结果（AGENTS/knowledge/specs）永不因错序 fence 被忽略；② 用户针对性规则的**字面意图最后生效**（写了 `!x` 即 track `x`）。已知权衡：病态的自我否定序列（先 `!x` 再用后续宽规则压回）会被归一化翻转为字面意图；gitignore 仅有的 last-match-wins 语义下，该冲突不可两全，scaffold 选择字面意图优先并在输出中如实报告每次变更。
+**gitignore 归一化契约**：scaffold 对默认布局的根 `.gitignore` 仅做四类收敛——分区（用户针对性 `.mstar/…` 规则整体移到 fence 之后、相对顺序不变）、去重冗余宽规则、错位主宽规则前移至首个 canonical negation 之前（仅当跨越行全部为 scaffold 自有语义）、补齐 canonical negation 使其出现在最后一条宽规则之后。保证：① tracked 结果（AGENTS/knowledge/specs）不因错序 fence 被忽略；② 用户针对性规则的字面意图最后生效（`!x` 即 track `x`）。自我否定的规则序列（先 `!x` 后被宽规则压制）按字面意图解析；每次变更均在 scaffold 输出中报告。
 
 ## Git 跟踪策略（进程 vs 结果）
 

--- a/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
+++ b/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
@@ -21,7 +21,7 @@
 7. 校准根 `AGENTS.md`：只保留仓库级长期约束，显式引用 `{HARNESS_DIR}/AGENTS.md` 作为 harness SSOT。
 8. 仅在确有稳定边界时新增目录级 `AGENTS.md`（如 `contracts/`、`gateway/`、`sdk/`）。
 
-**程序化路径**：`mstar harness scaffold [path]`（CLI，默认 cwd）一次性完成步骤 1–2（含 `projects/_default/`）、4 与 6 —— 调用 engine `scaffoldHarness`、追加 canonical gitignore snippet（已存在则跳过）、写最小 `{HARNESS_DIR}/AGENTS.md`（已存在则跳过）；幂等，重跑只补缺失件。步骤 3、5、7、8 仍按需手工。
+**程序化路径**：`mstar harness scaffold [path]`（CLI，默认 cwd）一次性完成步骤 1–2（含 `projects/_default/`）、4 与 6 —— 调用 engine `scaffoldHarness`、追加 canonical gitignore snippet（已存在则跳过）、写最小 `{HARNESS_DIR}/AGENTS.md`（已存在则跳过）；幂等，重跑只补缺失件。步骤 3、5、7、8 仍按需手工。 scaffold 遵循 `.mstarc` 的 `harness_dir` / `project_dir` 覆盖（写入解析后的目录）；解析出的 harness 目录名非 `.mstar` 时跳过 canonical gitignore snippet（自定义 harness 布局自行管理 ignore 规则）。
 
 ## Git 跟踪策略（进程 vs 结果）
 

--- a/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
+++ b/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
@@ -13,13 +13,15 @@
 ## Bootstrap 最小步骤
 
 1. 创建 `{HARNESS_DIR}`（推荐 `.mstar/`）与 `{PLAN_DIR}`（推荐 `.mstar/plans/`）。
-2. 初始化 `status.json`：从 **`mstar-artifacts/templates/status.empty.json`** 复制（**v2 形状**：`version: 2` + `workflows: []`）；residual canonical 见 **`mstar-artifacts` SKILL.md**；字段与生命周期见 **`mstar-artifacts/references/status-and-residuals.md`**。`workflows/` 与 `projects/` 子目录由 engine writers 按需创建（**不**在 bootstrap 预建）。
+2. 初始化 `status.json`：从 **`mstar-artifacts/templates/status.empty.json`** 复制（**v2 形状**：`version: 2` + `workflows: []`）；residual canonical 见 **`mstar-artifacts` SKILL.md**；字段与生命周期见 **`mstar-artifacts/references/status-and-residuals.md`**。`projects/_default/`（`roadmap.md` + 空 `residuals.json`）由 **`scaffoldHarness` / `mstar scaffold` 预建**；其余 project id 与 `workflows/` 子目录由 engine writers 按需创建（**不**在 bootstrap 预建）。
 3. `sdd/` 空目录占位（per-plan 子目录由 **`mstar-sdd`** → `mstar sdd workspace <plan-id>` 创建）。
 4. 项目根 `.gitignore` 追加 Morning Star **进程产物**忽略集（canonical snippet → `mstar-conventions` SKILL.md「Git 跟踪策略」；legacy `.agents/` 有等价表）。
 5. 可选：创建 `{ITERATION_DIR}`（`iterations/` + `README.md`）与 `{KNOWLEDGE_DIR}`（`knowledge/` + `README.md`）；`{HARNESS_DIR}/specs/`（解析后的 `{SPECS_DIR}` 默认落点）；内容边界见 `mstar-conventions` SKILL.md 与 `references/knowledge-and-designs.md`。
 6. 创建 `{HARNESS_DIR}/AGENTS.md`（harness 子树规则；**tracked**）：符号表可复述 `{HARNESS_DIR}`、`{PLAN_DIR}`、`{ITERATION_DIR}`、`{KNOWLEDGE_DIR}`、`{SPECS_DIR}` 与 `docs/` 分工；新项目推荐 `.mstar/AGENTS.md`，已有项目可继续使用 `.agents/AGENTS.md`。
 7. 校准根 `AGENTS.md`：只保留仓库级长期约束，显式引用 `{HARNESS_DIR}/AGENTS.md` 作为 harness SSOT。
 8. 仅在确有稳定边界时新增目录级 `AGENTS.md`（如 `contracts/`、`gateway/`、`sdk/`）。
+
+**程序化路径**：`mstar scaffold [path]`（CLI，默认 cwd）一次性完成步骤 1–2（含 `projects/_default/`）、4 与 6 —— 调用 engine `scaffoldHarness`、追加 canonical gitignore snippet（已存在则跳过）、写最小 `{HARNESS_DIR}/AGENTS.md`（已存在则跳过）；幂等，重跑只补缺失件。步骤 3、5、7、8 仍按需手工。
 
 ## Git 跟踪策略（进程 vs 结果）
 

--- a/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
+++ b/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
@@ -23,6 +23,8 @@
 
 **程序化路径**：`mstar harness scaffold [path]`（CLI，默认 cwd）一次性完成步骤 1–2（含 `projects/_default/`）、4 与 6 —— 调用 engine `scaffoldHarness`、追加 canonical gitignore snippet（已存在则跳过）、写最小 `{HARNESS_DIR}/AGENTS.md`（已存在则跳过）；幂等，重跑只补缺失件。步骤 3、5、7、8 仍按需手工。 scaffold 遵循 `.mstarc` 的 `harness_dir` / `project_dir` 覆盖（写入解析后的目录）；解析出的 harness 目录名非 `.mstar` 时跳过 canonical gitignore snippet（自定义 harness 布局自行管理 ignore 规则）。
 
+**gitignore 归一化契约与权衡（round-10 定稿）**：scaffold 对默认布局的根 `.gitignore` 只做四类收敛——分区（用户针对性 `.mstar/…` 规则整体移到 fence 之后、相对顺序不变）、去重冗余宽规则、把错位的主宽规则移到首个 canonical negation 之前（仅当跨越行全部为 scaffold 自有语义）、补齐 canonical negation 使其出现在最后一条宽规则之后。契约保证：① scaffold 的 tracked 结果（AGENTS/knowledge/specs）永不因错序 fence 被忽略；② 用户针对性规则的**字面意图最后生效**（写了 `!x` 即 track `x`）。已知权衡：病态的自我否定序列（先 `!x` 再用后续宽规则压回）会被归一化翻转为字面意图；gitignore 仅有的 last-match-wins 语义下，该冲突不可两全，scaffold 选择字面意图优先并在输出中如实报告每次变更。
+
 ## Git 跟踪策略（进程 vs 结果）
 
 **原则**：进程留在本地；结果与团队共享。完整规则与 canonical `.gitignore` snippet → **`mstar-conventions` SKILL.md「Git 跟踪策略」**。

--- a/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
+++ b/skills/mstar-conventions/references/harness-bootstrap-and-agents-layering.md
@@ -13,7 +13,7 @@
 ## Bootstrap 最小步骤
 
 1. 创建 `{HARNESS_DIR}`（推荐 `.mstar/`）与 `{PLAN_DIR}`（推荐 `.mstar/plans/`）。
-2. 初始化 `status.json`：从 **`mstar-artifacts/templates/status.empty.json`** 复制（**v2 形状**：`version: 2` + `workflows: []`）；residual canonical 见 **`mstar-artifacts` SKILL.md**；字段与生命周期见 **`mstar-artifacts/references/status-and-residuals.md`**。`projects/_default/`（`roadmap.md` + 空 `residuals.json`）由 **`scaffoldHarness` / `mstar scaffold` 预建**；其余 project id 与 `workflows/` 子目录由 engine writers 按需创建（**不**在 bootstrap 预建）。
+2. 初始化 `status.json`：从 **`mstar-artifacts/templates/status.empty.json`** 复制（**v2 形状**：`version: 2` + `workflows: []`）；residual canonical 见 **`mstar-artifacts` SKILL.md**；字段与生命周期见 **`mstar-artifacts/references/status-and-residuals.md`**。`projects/_default/`（`roadmap.md` + 空 `residuals.json`）由 **`scaffoldHarness` / `mstar harness scaffold` 预建**；其余 project id 与 `workflows/` 子目录由 engine writers 按需创建（**不**在 bootstrap 预建）。
 3. `sdd/` 空目录占位（per-plan 子目录由 **`mstar-sdd`** → `mstar sdd workspace <plan-id>` 创建）。
 4. 项目根 `.gitignore` 追加 Morning Star **进程产物**忽略集（canonical snippet → `mstar-conventions` SKILL.md「Git 跟踪策略」；legacy `.agents/` 有等价表）。
 5. 可选：创建 `{ITERATION_DIR}`（`iterations/` + `README.md`）与 `{KNOWLEDGE_DIR}`（`knowledge/` + `README.md`）；`{HARNESS_DIR}/specs/`（解析后的 `{SPECS_DIR}` 默认落点）；内容边界见 `mstar-conventions` SKILL.md 与 `references/knowledge-and-designs.md`。
@@ -21,7 +21,7 @@
 7. 校准根 `AGENTS.md`：只保留仓库级长期约束，显式引用 `{HARNESS_DIR}/AGENTS.md` 作为 harness SSOT。
 8. 仅在确有稳定边界时新增目录级 `AGENTS.md`（如 `contracts/`、`gateway/`、`sdk/`）。
 
-**程序化路径**：`mstar scaffold [path]`（CLI，默认 cwd）一次性完成步骤 1–2（含 `projects/_default/`）、4 与 6 —— 调用 engine `scaffoldHarness`、追加 canonical gitignore snippet（已存在则跳过）、写最小 `{HARNESS_DIR}/AGENTS.md`（已存在则跳过）；幂等，重跑只补缺失件。步骤 3、5、7、8 仍按需手工。
+**程序化路径**：`mstar harness scaffold [path]`（CLI，默认 cwd）一次性完成步骤 1–2（含 `projects/_default/`）、4 与 6 —— 调用 engine `scaffoldHarness`、追加 canonical gitignore snippet（已存在则跳过）、写最小 `{HARNESS_DIR}/AGENTS.md`（已存在则跳过）；幂等，重跑只补缺失件。步骤 3、5、7、8 仍按需手工。
 
 ## Git 跟踪策略（进程 vs 结果）
 


### PR DESCRIPTION
## Summary

- **Engine** (`packages/engine`): `scaffoldHarness` now also prebuilds `projects/_default/` — a `roadmap.md` with valid `validateRoadmap` frontmatter (`project_id: _default`, `status: active`, UTC `created_at`, `## Direction` placeholder) and an empty `residuals.json` passing `validateProjectRegister`. Idempotent: existing files are never clobbered.
- **CLI** (`packages/cli`): new namespaced command **`mstar harness scaffold [path]`** (group pattern matches `path`/`status`/`sdd`/`audit`; avoids ambiguity with `mstar audit scaffold`). One-shot bootstrap: engine scaffold + idempotent canonical `.gitignore` snippet append (partial fences get only missing entries) + minimal `.mstar/AGENTS.md` when absent + created/skipped summary.
- **Bug fix**: `mstar path resolve` failure guidance (CLI and engine internal error path) previously pointed users at `mstar init`, which is host agent bootstrap and does not scaffold the harness. Now points to `mstar harness scaffold`.
- **Docs**: `skills/mstar-conventions/SKILL.md`（初始化 Plan 目录 / Git 跟踪策略 v3 note）and `references/harness-bootstrap-and-agents-layering.md` updated to name `mstar harness scaffold` as the programmatic init path; `projects/_default/` is now scaffolded while other project ids and `workflows/` remain on-demand.
- Changelog fragment `.changes/unreleased/harness-scaffold-command.md` (`packages: root, engine, cli`). No hand-edited `CHANGELOG*`.

## Verification

- Engine `path.test.ts`: 84 pass (incl. new `_default` prebuild + idempotency tests; roadmap → `validateRoadmap` 0 violations, register → `validateProjectRegister` ok).
- CLI tests: 16 pass (fresh init, idempotent re-run, partial-fence gitignore, cwd default, guidance strings).
- `bunx tsc` exit 0 on root + packages/engine.
- QC: single-seat review, two rounds (round-1 Approve-with-residuals → fixes → round-2 **Approve**).
- Smoke (rebuilt dist, fresh temp dir): first run creates everything incl. `_default`; second run is a no-op (`ensured`); `path resolve --json` ok:true; flat `mstar scaffold` correctly rejected as unknown command.

## Notes

- Top-level `init` (host adapter install) intentionally untouched.
- ESM import addition in `path.ts` follows the existing call-time-only cycle precedent (`status.ts` ↔ `workflow.ts`).

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI/engine bootstrap and documentation; `mstar init` is unchanged, and scaffold/gitignore logic is idempotent with broad test coverage.
> 
> **Overview**
> Adds **`mstar harness scaffold [path]`** as the programmatic way to bootstrap a Morning Star harness (distinct from **`mstar init`**, which remains host/agent config only).
> 
> **Engine:** `scaffoldHarness` now also creates **`projects/_default/`** with validator-ready `roadmap.md` (frontmatter + `## Direction`) and empty `residuals.json`; behavior stays idempotent (no clobbering existing files).
> 
> **CLI:** New `harness scaffold` subcommand calls the engine, appends only **missing** canonical `.gitignore` fence lines (partial fences get re-includes without duplicating `.mstar/**`), writes a minimal **`.mstar/AGENTS.md`** when absent, and prints a created/skipped summary.
> 
> **Guidance fix:** When no harness resolves, **`mstar path resolve`** and engine subdir resolution errors now point users at **`mstar harness scaffold`** instead of **`mstar init`**.
> 
> **Docs & tests:** `mstar-conventions` and bootstrap reference docs describe the scaffold path and `_default` prebuild; new CLI integration tests plus engine tests for `_default` and idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2257068c962f8a8695c0bb86626207035b10bad1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->