### PR TITLE
feat(roles): YAGNI/PDCA coding philosophy for dev roles + unify executor mission phrasing

### DIFF
--- a/.changes/unreleased/dev-role-yagni-pdca.md
+++ b/.changes/unreleased/dev-role-yagni-pdca.md
@@ -1,0 +1,10 @@
+---
+packages: root, opencode
+---
+
+- **Role references:** Add a shared coding-philosophy line to dev-role Role Missions (`fullstack-dev`, `fullstack-dev-2`, `frontend-dev`): "YAGNI is your coding philosophy; PDCA is your behavioral discipline."
+- **Role references:** Unify executor Role Mission phrasing to the second-person "You are …" convention (`qa-engineer`, `prompt-engineer`, `ops-engineer`, `fullstack-dev-shared`); `project-manager` keeps its Identity section as orchestrator exception.
+
+<!-- CN -->
+- **角色参考：** 为开发角色（`fullstack-dev`、`fullstack-dev-2`、`frontend-dev`）的 Role Mission 增加一句共享编码哲学：“YAGNI 是你的编程哲学，PDCA 是你的行为规范。”
+- **角色参考：** 将执行角色 Role Mission 统一为第二人称 “You are …” 写法（`qa-engineer`、`prompt-engineer`、`ops-engineer`、`fullstack-dev-shared`）；`project-manager` 作为主控保留 Identity 段例外。

--- a/skills/mstar-roles/references/frontend-dev.md
+++ b/skills/mstar-roles/references/frontend-dev.md
@@ -3,6 +3,7 @@
 
 You are the frontend implementation owner for UI/components/interactions/accessibility/performance.
 You are dispatched by `project-manager` and report back with completion evidence.
+YAGNI is your coding philosophy; PDCA is your behavioral discipline.
 
 ## Non-Recursive Dispatch Rule (Hard)
 

--- a/skills/mstar-roles/references/fullstack-dev-shared.md
+++ b/skills/mstar-roles/references/fullstack-dev-shared.md
@@ -11,8 +11,9 @@ Behavior is shared; track identity is parameterized.
 
 ## Role Mission
 
-Backend-led fullstack implementation with contract-aware collaboration.
-Dispatched by `project-manager`; returns completion report and evidence.
+You are `{role_id}`, a backend-led fullstack implementation role with contract-aware collaboration.
+You are dispatched by `project-manager` and return a completion report and evidence.
+YAGNI is your coding philosophy; PDCA is your behavioral discipline.
 
 ## Non-Recursive Dispatch Rule (Hard)
 

--- a/skills/mstar-roles/references/ops-engineer.md
+++ b/skills/mstar-roles/references/ops-engineer.md
@@ -2,7 +2,7 @@
 ## Role Mission
 
 You are the operations/deployment role.
-Dispatched by `project-manager`; responsible for execution safety, observability, and rollback readiness.
+You are dispatched by `project-manager`, owning execution safety, observability, and rollback readiness.
 
 ## Non-Recursive Dispatch Rule (Hard)
 

--- a/skills/mstar-roles/references/prompt-engineer.md
+++ b/skills/mstar-roles/references/prompt-engineer.md
@@ -1,7 +1,7 @@
 
 ## Role Mission
 
-You design and optimize prompts, skills, and rules.
+You are `prompt-engineer`: you design and optimize prompts, skills, and rules.
 You are dispatched by `project-manager` and return structured prompt/rule artifacts with validation notes.
 
 ## Non-Recursive Dispatch Rule (Hard)

--- a/skills/mstar-roles/references/qa-engineer.md
+++ b/skills/mstar-roles/references/qa-engineer.md
@@ -6,7 +6,7 @@ Detailed L4 procedures: `references/qa-engineer/*.md`.
 
 ## Role Mission
 
-L4 **acceptance seat**: map plan DoD to evidence, verify residuals when assigned, return reproducible QA outputs. PM dispatches you only when Assignment says **`QA gate: mandatory`** or **`QA gate: report-only`** (`references/project-manager/qa-trigger-matrix.md`).
+You are `qa-engineer`, the L4 **acceptance seat**: map plan DoD to evidence, verify residuals when assigned, return reproducible QA outputs. You are dispatched by `project-manager` only when Assignment says **`QA gate: mandatory`** or **`QA gate: report-only`** (`references/project-manager/qa-trigger-matrix.md`).
 
 ## Non-Recursive Dispatch Rule (Hard)
 


### PR DESCRIPTION
## Summary

- Add a shared coding-philosophy line to the two implementation roles' Role Missions:
  > YAGNI is your coding philosophy; PDCA is your behavioral discipline.
  Applies to `fullstack-dev` + `fullstack-dev-2` (via shared reference) and `frontend-dev`.
- While reviewing, unify executor Role Mission openers to the second-person identity-first convention already used by all other role references (`qc-specialist-shared.md` proves parameterized templates can do this):
  - `fullstack-dev-shared.md`: third-person description → `You are \`{role_id}\`, a backend-led fullstack implementation role…`
  - `qa-engineer.md`: noun-phrase opener → `You are \`qa-engineer\`, the L4 acceptance seat…`
  - `prompt-engineer.md`: `You design…` → `You are \`prompt-engineer\`: you design and optimize…`
  - `ops-engineer.md`: semicolon fragment → full `You are dispatched by…` sentence
- Bonus: gives the new "your coding philosophy" line a proper antecedent.
- `project-manager` keeps its Identity-section structure as orchestrator exception (per maintainer).

## Scope

Read-only seats (`code-reviewer`, `qc-specialist*`, `qa-engineer`) keep review/QA missions — no philosophy line. Architect and other non-coding roles untouched.

| File | Change |
|---|---|
| `skills/mstar-roles/references/fullstack-dev-shared.md` | mission opener unified + YAGNI/PDCA line |
| `skills/mstar-roles/references/frontend-dev.md` | YAGNI/PDCA line |
| `skills/mstar-roles/references/qa-engineer.md` | mission opener unified |
| `skills/mstar-roles/references/prompt-engineer.md` | mission opener unified |
| `skills/mstar-roles/references/ops-engineer.md` | dispatch line completed |
| `.changes/unreleased/dev-role-yagni-pdca.md` | fragment (EN+CN), `packages: root, opencode` |

Host shells (`agents/*.md`) are thin pointers to these references — no duplicate text to sync.

## Changelog

Fragment added per release process; no hand-edited `CHANGELOG*`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to role reference markdown; no runtime, auth, or deployment behavior changes.
> 
> **Overview**
> Adds a shared **Role Mission** line for implementation dev roles (`frontend-dev`, and `fullstack-dev` / `fullstack-dev-2` via `fullstack-dev-shared.md`): *YAGNI is your coding philosophy; PDCA is your behavioral discipline.* Review/QA seats and non-coding roles are unchanged.
> 
> **Unifies executor Role Mission openers** to second-person, identity-first **You are …** wording in `fullstack-dev-shared.md`, `qa-engineer.md`, `prompt-engineer.md`, and `ops-engineer.md` (including a completed dispatch sentence for ops). `project-manager` stays on its Identity-section orchestrator pattern.
> 
> Documents the change in `.changes/unreleased/dev-role-yagni-pdca.md` (EN + CN), `packages: root, opencode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733a45f30e875c53a37df847afefec9f500d9485. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->