### PR TITLE
feat(store): ArtifactStore honesty — schema fail-loud, list?, persist delete/get --validate, TZ flake

### DIFF
--- a/.changes/unreleased/store-contract-completion.md
+++ b/.changes/unreleased/store-contract-completion.md
@@ -1,0 +1,10 @@
+---
+packages: engine
+---
+
+- Made `FsStore.put` **fail loud on unpersistable envelope schemas**: a doc carrying an envelope `schema` id is now rejected with a canonical error instead of being silently dropped (FsStore persists `doc.payload` only); payload-internal `schema` fields are unaffected.
+- Added optional **`ArtifactStore.list?(kind)`** enumeration: stores that cannot enumerate decline by omitting the member (callers probe `typeof store.list === "function"`, same pattern as `delete?`); `FsStore` implements it via the single kind→path table (missing backing file → `[]`, keys sorted ascending, every listed key round-trips through `get`, `json` kind throws the canonical usage error).
+
+<!-- CN -->
+- `FsStore.put` 现对**无法持久化的 envelope schema 快速失败**：携带 envelope `schema` id 的文档会以规范化错误拒绝写入，而非静默丢弃（FsStore 仅落盘 `doc.payload`）；payload 内部的 `schema` 字段不受影响。
+- 新增可选 **`ArtifactStore.list?(kind)`** 枚举能力：无法枚举的存储可不实现该成员（调用方以 `typeof store.list === "function"` 探测，与 `delete?` 同一模式）；`FsStore` 基于唯一的 kind→path 表实现（缺失落盘文件 → `[]`，key 升序排列，每个列出的 key 均可经 `get` 往返，`json` kind 抛出规范化用法错误）。

--- a/.changes/unreleased/store-contract-completion.md
+++ b/.changes/unreleased/store-contract-completion.md
@@ -1,10 +1,16 @@
 ---
-packages: engine
+packages: engine, cli
 ---
 
 - Made `FsStore.put` **fail loud on unpersistable envelope schemas**: a doc carrying an envelope `schema` id is now rejected with a canonical error instead of being silently dropped (FsStore persists `doc.payload` only); payload-internal `schema` fields are unaffected.
 - Added optional **`ArtifactStore.list?(kind)`** enumeration: stores that cannot enumerate decline by omitting the member (callers probe `typeof store.list === "function"`, same pattern as `delete?`); `FsStore` implements it via the single kind→path table (missing backing file → `[]`, keys sorted ascending, every listed key round-trips through `get`, `json` kind throws the canonical usage error).
+- Added the **`persist list <kind>`** CLI face: prints stored keys only (one per line, ascending, no header); `json` is rejected as a usage error before enumeration, and an injected store without `list` exits 2 (probed, never a TypeError).
+- Added **`persist get --validate`**: reuses the put-gate validators on the fetched payload — stdout stays payload JSON only; notes (`validation: ok` / `json: parse-only`) and violations go to stderr; a miss or an invalid document exits 1.
+- Added the **`persist delete <kind> --key <key>`** CLI face: idempotent (absent key is a no-op, exit 0, prints `deleted <kind>/<key>`), no confirmation prompt; an injected store without `delete` exits 2.
 
 <!-- CN -->
 - `FsStore.put` 现对**无法持久化的 envelope schema 快速失败**：携带 envelope `schema` id 的文档会以规范化错误拒绝写入，而非静默丢弃（FsStore 仅落盘 `doc.payload`）；payload 内部的 `schema` 字段不受影响。
 - 新增可选 **`ArtifactStore.list?(kind)`** 枚举能力：无法枚举的存储可不实现该成员（调用方以 `typeof store.list === "function"` 探测，与 `delete?` 同一模式）；`FsStore` 基于唯一的 kind→path 表实现（缺失落盘文件 → `[]`，key 升序排列，每个列出的 key 均可经 `get` 往返，`json` kind 抛出规范化用法错误）。
+- 新增 **`persist list <kind>`** CLI 面：仅打印存储的 key（每行一个，升序，无表头）；`json` 在枚举前即以用法错误拒绝；注入的存储缺少 `list` 时退出码 2（探测，绝不抛 TypeError）。
+- 新增 **`persist get --validate`**：复用写入门禁的校验器校验读出的 payload——stdout 保持纯 payload JSON；备注（`validation: ok` / `json: parse-only`）与违规列表走 stderr；miss 或无效文档退出码 1。
+- 新增 **`persist delete <kind> --key <key>`** CLI 面：幂等（key 不存在为空操作，退出码 0，打印 `deleted <kind>/<key>`），无确认提示；注入的存储缺少 `delete` 时退出码 2。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -213,7 +213,7 @@ Persist one JSON coordination doc through the pluggable **ArtifactStore** (engin
 
 `<kind>` is one of `status` | `snapshot` | `residuals` | `review` | `json` (an unknown kind is a usage error, exit 2).
 
-Payload source: `--file <path>` reads a JSON file; `--stdin` (or no flag) reads stdin; the two flags are mutually exclusive. `--key` is required: `status` always uses the key `root`; `json` takes an absolute file path (relative or `..`-containing keys are rejected); the other kinds take a stable id (workflow id, project id, or review id). `--schema <id>` optionally records a schema id (e.g. `mstar.review/v1`) on the stored doc.
+Payload source: `--file <path>` reads a JSON file; `--stdin` (or no flag) reads stdin; the two flags are mutually exclusive. `--key` is required: `status` always uses the key `root`; `json` takes an absolute file path (relative or `..`-containing keys are rejected); the other kinds take a stable id (workflow id, project id, or review id). `--schema <id>` optionally records a schema id (e.g. `mstar.review/v1`) on the artifact doc — stored only by store modules that persist it; the default `FsStore` rejects it (exit 1, nothing written).
 
 Validators run before put: `status` / `snapshot` / `residuals` payloads are checked with the existing `validateStatusV2` / `validateWorkflowSnapshot` / `validateProjectRegister` and an invalid document is refused (exit 1, nothing written). `review` payloads must be a valid `mstar.review/v1` envelope (`validateMstarReviewV1` — harness verdicts `ship it` / `needs fixes` / `blocked` and merge classes `must-fix` / `should-fix` / `nit`; inspector M1 vocab such as `approve` / `critical` is rejected with `review.inspector-vocab`); `json` is an escape hatch.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -209,7 +209,9 @@ Exit codes:
 Persist one JSON coordination doc through the pluggable **ArtifactStore** (engine `@mstar-harness/engine` — `ArtifactStore` / `ArtifactKind` / `createFsStore` / `setArtifactStore` / `getArtifactStore` / `loadStoreModule`). The default `FsStore` maps kinds to the existing `{HARNESS_DIR}` paths and keeps the atomic temp+rename write semantics; integrations can mount their own store in-process (`setArtifactStore`) or per-command via `--store` / `MSTAR_STORE_MODULE`.
 
 - `mstar-harness persist <kind> --key <key> [--file <path>|--stdin] [--store <module>] [--schema <id>]`
-- `mstar-harness persist get <kind> --key <key> [--store <module>]`
+- `mstar-harness persist get <kind> --key <key> [--validate] [--store <module>]`
+- `mstar-harness persist list <kind> [--store <module>]`
+- `mstar-harness persist delete <kind> --key <key> [--store <module>]`
 
 `<kind>` is one of `status` | `snapshot` | `residuals` | `review` | `json` (an unknown kind is a usage error, exit 2).
 
@@ -229,13 +231,21 @@ Default `FsStore` path table:
 | `review` | plan-shaped key (`^[0-9]{8}-[a-z0-9-]+$`) → `{HARNESS_DIR}/sdd/<key>/review/report.json`; other keys → `{HARNESS_DIR}/sdd/_reviews/<key>.json` |
 | `json` | the absolute `key` path itself |
 
-`persist get` prints the stored payload JSON (pretty-printed) and exits 0; a missing document exits 1.
+`persist get` prints the stored payload JSON (pretty-printed) on stdout and exits 0; a missing document exits 1 (`persist get <kind>/<key>: no stored document` on stderr). Stdout is payload JSON only — notes and violations never mix into it, so agents can pipe the output. With `--validate`, the same per-kind validator as the put gate runs on the fetched payload (no second validator): a valid document exits 0 with the payload on stdout and `validation: ok` on stderr; `json` accepts `--validate` as a parse-only no-op (`json: parse-only` on stderr); an invalid document exits 1 with stdout empty and the same violations list as put on stderr. FsStore persists payloads verbatim; integrity checks live at the write gate and at `persist get --validate`.
 
-Exit codes:
+`persist list` prints the stored keys only — one per line, ascending, with **no header** (the kind is already the argv; pipe-friendly). An empty kind prints nothing and exits 0. Enumeration reports what exists: a missing backing file or directory yields an empty list, and every listed key round-trips through `persist get` — `status` lists `root` iff `{HARNESS_DIR}/status.json` exists; `review` is the union of `{HARNESS_DIR}/sdd/_reviews/*.json` keys and plan-shaped `{HARNESS_DIR}/sdd/<key>/review/report.json` directories. `json` keys are absolute paths and cannot be listed — a usage error (exit 2) raised before enumeration.
 
-- `0` — put OK (`persist <kind>/<key>: OK`) or get printed the stored payload
-- `1` — invalid payload refused, missing payload file, missing stored document, store-module load/verification failure, harness dir not found
-- `2` — usage: unknown kind, missing `--key`, `--file` + `--stdin` together
+`persist delete` removes the stored document and prints `deleted <kind>/<key>`. Deleting an absent document is an idempotent no-op (same output, exit 0) and there is no confirmation prompt. `status` deletes `{HARNESS_DIR}/status.json` — allowed; it is a normal store doc, not privileged.
+
+All three faces go through the same `--store` / `MSTAR_STORE_MODULE` injection path as put/get. An injected store without the optional `list` or `delete` member is a usage error (exit 2, probed before the call) — never a TypeError.
+
+Exit codes (binding):
+
+| Code | When |
+|------|------|
+| `0` | put OK (`persist <kind>/<key>: OK`); get printed the payload (with or without `--validate`); delete succeeded or no-op; list printed keys (including none) |
+| `1` | get miss; get `--validate` invalid; put invalid payload; put payload file missing / not valid JSON; stored file unparseable JSON on get; FsStore `doc.schema` rejection; store-module load failure; harness dir not found |
+| `2` | usage: unknown kind; missing `--key`; `--file` + `--stdin` together; `persist list json`; injected store missing `list` / `delete` |
 
 #### Persist a review envelope
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1127,6 +1127,7 @@ function parsePersistKind(kind: string): ArtifactKind {
   throw new SddScriptError(
     "usage: persist <kind> --key <key> [--file <path>|--stdin] [--store <module>] [--schema <id>]\n" +
       "       persist get <kind> --key <key> [--store <module>]\n" +
+      "       persist list <kind> [--store <module>]\n" +
       `  unknown kind ${JSON.stringify(kind)} \u2014 expected status | snapshot | residuals | review | json`,
     2,
   );
@@ -1240,6 +1241,41 @@ persistCommand
       console.log(JSON.stringify(payload, null, 2));
     } catch (error) {
       failScript(error, "persist get");
+    }
+  });
+
+persistCommand
+  .command("list")
+  .description("Print the stored keys for <kind>, one per line, ascending, no header (json is not listable)")
+  .argument("<kind>", "status | snapshot | residuals | review | json")
+  // --store is parsed by the parent `persist` command (same commander
+  // dispatch constraint as `get` — see the note there).
+  .action(async (kind: string, _options: object, command: Command) => {
+    try {
+      const parsedKind = parsePersistKind(kind);
+      // D5: json keys are absolute paths — usage error exit 2 BEFORE
+      // calling list (engine list("json") still throws for in-process
+      // callers).
+      if (parsedKind === "json") {
+        throw new SddScriptError("ArtifactStore json keys are absolute paths and cannot be listed", 2);
+      }
+      const parentOpts = command.parent?.opts() ?? {};
+      const store = typeof parentOpts.store === "string" ? parentOpts.store : undefined;
+      await resolvePersistStore(store);
+      const artifactStore = getArtifactStore();
+      // D4: probe the optional method — an injected store without list is a
+      // usage error exit 2, never a TypeError mapped to exit 1.
+      if (typeof artifactStore.list !== "function") {
+        throw new SddScriptError("store does not support list", 2);
+      }
+      const refs = await artifactStore.list(parsedKind);
+      // Keys only, ascending, no header — pipe-friendly (D5). Sort here so
+      // the contract holds for injected stores too, not just FsStore.
+      for (const key of refs.map((ref) => ref.key).sort()) {
+        console.log(key);
+      }
+    } catch (error) {
+      failScript(error, "persist list");
     }
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1115,6 +1115,7 @@ const persistCommand = program
   .command("persist")
   .description(
     "Persist one JSON coordination doc through the ArtifactStore (status / snapshot / residuals / review / json). " +
+      "Faces: put (default), get [--validate], list (keys only, no header), delete (idempotent). " +
       "The default FsStore resolves the harness dir from the cwd / MSTAR_HARNESS_DIR; --store <module> or " +
       "MSTAR_STORE_MODULE injects a module-backed store (filesystem paths only) for the process.",
   );
@@ -1184,7 +1185,7 @@ persistCommand
   .option("--file <path>", "Payload JSON file (default: read stdin)")
   .option("--stdin", "Read the payload JSON from stdin")
   .option("--store <module>", "Store module path (filesystem only; overrides MSTAR_STORE_MODULE)")
-  .option("--schema <id>", "Optional schema id stored on the artifact doc (e.g. mstar.review/v1)")
+  .option("--schema <id>", "Optional schema id stored on the artifact doc (e.g. mstar.review/v1); stored only by store modules that persist it \u2014 the default FsStore rejects it (exit 1)")
   .action(
     async (kind: string, options: { key?: string; file?: string; stdin?: boolean; store?: string; schema?: string }) => {
       try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1126,8 +1126,9 @@ function parsePersistKind(kind: string): ArtifactKind {
   if (PERSIST_KINDS.includes(kind)) return kind as ArtifactKind;
   throw new SddScriptError(
     "usage: persist <kind> --key <key> [--file <path>|--stdin] [--store <module>] [--schema <id>]\n" +
-      "       persist get <kind> --key <key> [--store <module>]\n" +
+      "       persist get <kind> --key <key> [--validate] [--store <module>]\n" +
       "       persist list <kind> [--store <module>]\n" +
+      "       persist delete <kind> --key <key> [--store <module>]\n" +
       `  unknown kind ${JSON.stringify(kind)} \u2014 expected status | snapshot | residuals | review | json`,
     2,
   );
@@ -1224,19 +1225,30 @@ persistCommand
   // commander parses a parent's options from the whole arg list, so a
   // subcommand's same-named declaration would never see the value. The get
   // action reads the values the parent parsed (probe-verified).
-  .action(async (kind: string, _options: object, command: Command) => {
+  // --validate has no parent twin, so it is declared here and read from the
+  // action's own options.
+  .option("--validate", "Run the kind's validator on the fetched payload (notes on stderr; invalid \u2192 exit 1)")
+  .action(async (kind: string, options: { validate?: boolean }, command: Command) => {
     try {
       const parsedKind = parsePersistKind(kind);
       const parentOpts = command.parent?.opts() ?? {};
       const key = typeof parentOpts.key === "string" ? parentOpts.key : undefined;
       const store = typeof parentOpts.store === "string" ? parentOpts.store : undefined;
       if (key === undefined) {
-        throw new SddScriptError("usage: persist get <kind> --key <key> [--store <module>]", 2);
+        throw new SddScriptError("usage: persist get <kind> --key <key> [--validate] [--store <module>]", 2);
       }
       await resolvePersistStore(store);
       const payload = await getArtifactStore().get({ kind: parsedKind, key });
       if (payload === undefined) {
         throw new Error(`persist get ${parsedKind}/${key}: no stored document`);
+      }
+      if (options.validate === true) {
+        // D1: reuse the put-gate validator (no second validator home). An
+        // invalid doc throws BEFORE stdout is written, so stdout stays
+        // payload-JSON-only and stderr carries the same violations list as
+        // put. json is parse-only — the helper returns without validating.
+        validatePersistPayload(parsedKind, payload);
+        console.error(parsedKind === "json" ? "json: parse-only" : "validation: ok");
       }
       console.log(JSON.stringify(payload, null, 2));
     } catch (error) {
@@ -1276,6 +1288,34 @@ persistCommand
       }
     } catch (error) {
       failScript(error, "persist list");
+    }
+  });
+persistCommand
+  .command("delete")
+  .description("Delete the stored document for <kind>/<key> (idempotent: absent is a no-op; no prompt)")
+  .argument("<kind>", "status | snapshot | residuals | review | json")
+  // --key / --store are parsed by the parent `persist` command (same
+  // commander dispatch constraint as `get` — see the note there).
+  .action(async (kind: string, _options: object, command: Command) => {
+    try {
+      const parsedKind = parsePersistKind(kind);
+      const parentOpts = command.parent?.opts() ?? {};
+      const key = typeof parentOpts.key === "string" ? parentOpts.key : undefined;
+      const store = typeof parentOpts.store === "string" ? parentOpts.store : undefined;
+      if (key === undefined) {
+        throw new SddScriptError("usage: persist delete <kind> --key <key> [--store <module>]", 2);
+      }
+      await resolvePersistStore(store);
+      const artifactStore = getArtifactStore();
+      // D2: probe the optional method — an injected store without delete is
+      // a usage error exit 2, never a TypeError mapped to exit 1.
+      if (typeof artifactStore.delete !== "function") {
+        throw new SddScriptError("store does not support delete", 2);
+      }
+      await artifactStore.delete({ kind: parsedKind, key });
+      console.log(`deleted ${parsedKind}/${key}`);
+    } catch (error) {
+      failScript(error, "persist delete");
     }
   });
 

--- a/packages/cli/test/persist.test.ts
+++ b/packages/cli/test/persist.test.ts
@@ -549,16 +549,63 @@ describe("mstar persist — --store / MSTAR_STORE_MODULE module injection (SP2-A
   });
 });
 
-describe("mstar persist — --schema is accepted as doc metadata", () => {
-  test("--schema id is accepted and the put still lands", () => {
+describe("mstar persist — --schema under the D3 fail-loud store contract", () => {
+  test("--schema + default FsStore is a store refusal: exit 1 with the canonical message", () => {
     withTempDir((dir) => {
       const payloadFile = writePayload(dir, "review.json", REVIEW_PAYLOAD);
       const r = runCli(
         ["persist", "review", "--key", "20260827-artifact-store", "--file", payloadFile, "--schema", "mstar.review/v1"],
         { env: harnessEnv(dir) },
       );
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toContain("FsStore does not persist schema ids");
+      expect(existsSync(join(dir, "sdd", "20260827-artifact-store", "review", "report.json"))).toBe(false);
+    });
+  });
+
+  test("--schema lands through an injected store module that persists it", () => {
+    withTempDir((dir) => {
+      const module = join(dir, "schema-store.ts");
+      writeFileSync(
+        module,
+        [
+          'import { writeFileSync, readFileSync, existsSync } from "node:fs";',
+          "const file = process.env.PERSIST_SCHEMA_FILE;",
+          'if (!file) throw new Error("PERSIST_SCHEMA_FILE is required");',
+          "export function createArtifactStore() {",
+          "  return {",
+          "    async put(doc) {",
+          "      writeFileSync(file, JSON.stringify({ key: doc.key, schema: doc.schema, payload: doc.payload }));",
+          "    },",
+          "    async get(ref) {",
+          "      if (!existsSync(file)) return undefined;",
+          '      const stored = JSON.parse(readFileSync(file, "utf8"));',
+          "      return stored.key === ref.key ? stored.payload : undefined;",
+          "    },",
+          "  };",
+          "}",
+        ].join("\n"),
+        "utf8",
+      );
+      const payloadFile = writePayload(dir, "review.json", REVIEW_PAYLOAD);
+      const out = join(dir, "schema-store.json");
+      const r = runCli(
+        [
+          "persist",
+          "review",
+          "--key",
+          "20260827-artifact-store",
+          "--file",
+          payloadFile,
+          "--schema",
+          "mstar.review/v1",
+          "--store",
+          module,
+        ],
+        { env: { ...harnessEnv(dir), PERSIST_SCHEMA_FILE: out } },
+      );
       expect(r.exitCode).toBe(0);
-      expect(existsSync(join(dir, "sdd", "20260827-artifact-store", "review", "report.json"))).toBe(true);
+      expect(JSON.parse(readFileSync(out, "utf8")).schema).toBe("mstar.review/v1");
     });
   });
 });

--- a/packages/cli/test/persist.test.ts
+++ b/packages/cli/test/persist.test.ts
@@ -609,3 +609,92 @@ describe("mstar persist — --schema under the D3 fail-loud store contract", () 
     });
   });
 });
+
+describe("mstar persist list — D4/D5 enumeration face (plan 20260828-store-cli-faces T1)", () => {
+  test("snapshot keys print one per line ascending, no header (D5)", () => {
+    withTempDir((dir) => {
+      const payloadFile = writePayload(dir, "snapshot.json", SNAPSHOT_PAYLOAD);
+      for (const key of ["wf-2", "wf-10", "wf-1"]) {
+        const put = runCli(["persist", "snapshot", "--key", key, "--file", payloadFile], {
+          env: harnessEnv(dir),
+        });
+        expect(put.exitCode).toBe(0);
+      }
+      const list = runCli(["persist", "list", "snapshot"], { env: harnessEnv(dir) });
+      expect(list.exitCode).toBe(0);
+      expect(list.stdout).toBe("wf-1\nwf-10\nwf-2\n");
+    });
+  });
+
+  test("review union: plan-shaped dir keys + _reviews flat keys (D4)", () => {
+    withTempDir((dir) => {
+      const payloadFile = writePayload(dir, "review.json", REVIEW_PAYLOAD);
+      const planShaped = runCli(
+        ["persist", "review", "--key", "20260828-store-cli-faces", "--file", payloadFile],
+        { env: harnessEnv(dir) },
+      );
+      expect(planShaped.exitCode).toBe(0);
+      const flat = runCli(["persist", "review", "--key", "review-abc", "--file", payloadFile], {
+        env: harnessEnv(dir),
+      });
+      expect(flat.exitCode).toBe(0);
+      const list = runCli(["persist", "list", "review"], { env: harnessEnv(dir) });
+      expect(list.exitCode).toBe(0);
+      expect(list.stdout).toBe("20260828-store-cli-faces\nreview-abc\n");
+    });
+  });
+
+  test("status lists root only when status.json exists; empty stdout + exit 0 when absent (D4 exists-conditional)", () => {
+    withTempDir((dir) => {
+      const missing = runCli(["persist", "list", "status"], { env: harnessEnv(dir) });
+      expect(missing.exitCode).toBe(0);
+      expect(missing.stdout).toBe("");
+
+      const payloadFile = writePayload(dir, "status.json", STATUS_PAYLOAD);
+      const put = runCli(["persist", "status", "--key", "root", "--file", payloadFile], {
+        env: harnessEnv(dir),
+      });
+      expect(put.exitCode).toBe(0);
+      const list = runCli(["persist", "list", "status"], { env: harnessEnv(dir) });
+      expect(list.exitCode).toBe(0);
+      expect(list.stdout).toBe("root\n");
+    });
+  });
+
+  test("empty kind → empty stdout, exit 0 (D5)", () => {
+    withTempDir((dir) => {
+      const list = runCli(["persist", "list", "snapshot"], { env: harnessEnv(dir) });
+      expect(list.exitCode).toBe(0);
+      expect(list.stdout).toBe("");
+    });
+  });
+
+  test("json kind → usage error exit 2 before calling list (D5)", () => {
+    withTempDir((dir) => {
+      const list = runCli(["persist", "list", "json"], { env: harnessEnv(dir) });
+      expect(list.exitCode).toBe(2);
+      expect(list.stderr).toContain("json keys are absolute paths and cannot be listed");
+      expect(list.stdout).toBe("");
+    });
+  });
+
+  test("unknown kind → usage, exit 2", () => {
+    withTempDir((dir) => {
+      const list = runCli(["persist", "list", "bogus"], { env: harnessEnv(dir) });
+      expect(list.exitCode).toBe(2);
+      expect(list.stderr).toContain("unknown kind");
+    });
+  });
+
+  test("injected store without list → usage error exit 2, not TypeError exit 1 (D4 probe)", () => {
+    withTempDir((dir) => {
+      const moduleFile = join(dir, "store-mod.ts");
+      writeFileSync(moduleFile, storeModuleSource("PERSIST_MODULE_FILE"), "utf8");
+      const list = runCli(["persist", "list", "snapshot", "--store", moduleFile], {
+        env: { ...harnessEnv(dir), PERSIST_MODULE_FILE: join(dir, "recording.json") },
+      });
+      expect(list.exitCode).toBe(2);
+      expect(list.stderr).toContain("store does not support list");
+    });
+  });
+});

--- a/packages/cli/test/persist.test.ts
+++ b/packages/cli/test/persist.test.ts
@@ -698,3 +698,170 @@ describe("mstar persist list — D4/D5 enumeration face (plan 20260828-store-cli
     });
   });
 });
+
+/** Self-contained store module WITH delete: records the deleted ref so a
+ * test can assert the ref that reached the store's delete (D2 routing). */
+function deletingStoreModuleSource(envVar: string): string {
+  return [
+    'import { writeFileSync } from "node:fs";',
+    `const file = process.env.${envVar};`,
+    `if (!file) throw new Error("${envVar} is required");`,
+    "export function createArtifactStore() {",
+    "  return {",
+    "    async put() {},",
+    "    async get() { return undefined; },",
+    "    async delete(ref) { writeFileSync(file, JSON.stringify({ kind: ref.kind, key: ref.key })); },",
+    "  };",
+    "}",
+  ].join("\n");
+}
+
+describe("mstar persist get --validate + persist delete — D1/D2 faces (plan 20260828-store-cli-faces T2)", () => {
+  test("valid status doc + --validate → exit 0; stdout is payload JSON only; stderr note validation: ok (D1)", () => {
+    withTempDir((dir) => {
+      const payloadFile = writePayload(dir, "status.json", STATUS_PAYLOAD);
+      const put = runCli(["persist", "status", "--key", "root", "--file", payloadFile], {
+        env: harnessEnv(dir),
+      });
+      expect(put.exitCode).toBe(0);
+      const get = runCli(["persist", "get", "status", "--key", "root", "--validate"], {
+        env: harnessEnv(dir),
+      });
+      expect(get.exitCode).toBe(0);
+      expect(JSON.parse(get.stdout)).toEqual(STATUS_PAYLOAD);
+      expect(get.stderr).toContain("validation: ok");
+    });
+  });
+
+  test("invalid stored status doc + --validate → exit 1; stdout empty; stderr carries the put-gate violations (D1)", () => {
+    withTempDir((dir) => {
+      // Bypass the put gate by writing the backing file directly.
+      writePayload(dir, "status.json", { version: 1, plans: [] });
+      const get = runCli(["persist", "get", "status", "--key", "root", "--validate"], {
+        env: harnessEnv(dir),
+      });
+      expect(get.exitCode).toBe(1);
+      expect(get.stdout).toBe("");
+      expect(get.stderr).toContain("refusing to persist invalid status document");
+    });
+  });
+
+  test("without --validate an invalid stored doc still prints raw, exit 0 (D1 read-stays-raw)", () => {
+    withTempDir((dir) => {
+      const invalid = { version: 1, plans: [] };
+      writePayload(dir, "status.json", invalid);
+      const get = runCli(["persist", "get", "status", "--key", "root"], { env: harnessEnv(dir) });
+      expect(get.exitCode).toBe(0);
+      expect(JSON.parse(get.stdout)).toEqual(invalid);
+      expect(get.stderr).not.toContain("validation");
+    });
+  });
+
+  test("json kind + --validate is a parse-only no-op → exit 0, stderr note json: parse-only (D1)", () => {
+    withTempDir((dir) => {
+      const loose = { anything: ["goes", 1] };
+      const looseFile = writePayload(dir, "loose.json", loose);
+      const get = runCli(["persist", "get", "json", "--key", looseFile, "--validate"], {
+        env: harnessEnv(dir),
+      });
+      expect(get.exitCode).toBe(0);
+      expect(JSON.parse(get.stdout)).toEqual(loose);
+      expect(get.stderr).toContain("json: parse-only");
+    });
+  });
+
+  test("miss + --validate → exit 1 with the existing miss string; validation never runs (D1)", () => {
+    withTempDir((dir) => {
+      const get = runCli(["persist", "get", "snapshot", "--key", "no-such-wf", "--validate"], {
+        env: harnessEnv(dir),
+      });
+      expect(get.exitCode).toBe(1);
+      expect(get.stdout).toBe("");
+      expect(get.stderr).toContain("persist get snapshot/no-such-wf: no stored document");
+      expect(get.stderr).not.toContain("validation: ok");
+    });
+  });
+
+  test("delete after put → exit 0, stdout deleted <kind>/<key>; a later get misses (D2)", () => {
+    withTempDir((dir) => {
+      const payloadFile = writePayload(dir, "snapshot.json", SNAPSHOT_PAYLOAD);
+      const put = runCli(["persist", "snapshot", "--key", "wf-1", "--file", payloadFile], {
+        env: harnessEnv(dir),
+      });
+      expect(put.exitCode).toBe(0);
+      const del = runCli(["persist", "delete", "snapshot", "--key", "wf-1"], { env: harnessEnv(dir) });
+      expect(del.exitCode).toBe(0);
+      expect(del.stdout).toBe("deleted snapshot/wf-1\n");
+      const get = runCli(["persist", "get", "snapshot", "--key", "wf-1"], { env: harnessEnv(dir) });
+      expect(get.exitCode).toBe(1);
+      expect(get.stderr).toContain("no stored document");
+    });
+  });
+
+  test("delete of an absent key → success exit 0 with the same stdout (idempotent, no prompt) (D2)", () => {
+    withTempDir((dir) => {
+      const del = runCli(["persist", "delete", "snapshot", "--key", "never-existed"], {
+        env: harnessEnv(dir),
+      });
+      expect(del.exitCode).toBe(0);
+      expect(del.stdout).toBe("deleted snapshot/never-existed\n");
+    });
+  });
+
+  test("status kind delete removes {HARNESS_DIR}/status.json (allowed) (D2)", () => {
+    withTempDir((dir) => {
+      const payloadFile = writePayload(dir, "payload.json", STATUS_PAYLOAD);
+      const put = runCli(["persist", "status", "--key", "root", "--file", payloadFile], {
+        env: harnessEnv(dir),
+      });
+      expect(put.exitCode).toBe(0);
+      const del = runCli(["persist", "delete", "status", "--key", "root"], { env: harnessEnv(dir) });
+      expect(del.exitCode).toBe(0);
+      expect(del.stdout).toBe("deleted status/root\n");
+      const get = runCli(["persist", "get", "status", "--key", "root"], { env: harnessEnv(dir) });
+      expect(get.exitCode).toBe(1);
+    });
+  });
+
+  test("delete without --key → usage error exit 2 (D5)", () => {
+    withTempDir((dir) => {
+      const del = runCli(["persist", "delete", "snapshot"], { env: harnessEnv(dir) });
+      expect(del.exitCode).toBe(2);
+      expect(del.stderr).toContain("usage: persist delete");
+    });
+  });
+
+  test("delete with an unknown kind → usage error exit 2 (D5)", () => {
+    withTempDir((dir) => {
+      const del = runCli(["persist", "delete", "bogus", "--key", "x"], { env: harnessEnv(dir) });
+      expect(del.exitCode).toBe(2);
+      expect(del.stderr).toContain("unknown kind");
+    });
+  });
+
+  test("injected store without delete → usage error exit 2, not TypeError exit 1 (D2 probe)", () => {
+    withTempDir((dir) => {
+      const moduleFile = join(dir, "store-mod.ts");
+      writeFileSync(moduleFile, storeModuleSource("PERSIST_MODULE_FILE"), "utf8");
+      const del = runCli(["persist", "delete", "snapshot", "--key", "wf-1", "--store", moduleFile], {
+        env: { ...harnessEnv(dir), PERSIST_MODULE_FILE: join(dir, "recording.json") },
+      });
+      expect(del.exitCode).toBe(2);
+      expect(del.stderr).toContain("store does not support delete");
+    });
+  });
+
+  test("injected store with delete → delete routes through the module with the resolved ref (D2)", () => {
+    withTempDir((dir) => {
+      const moduleFile = join(dir, "store-mod.ts");
+      const recording = join(dir, "recording.json");
+      writeFileSync(moduleFile, deletingStoreModuleSource("PERSIST_MODULE_FILE"), "utf8");
+      const del = runCli(["persist", "delete", "status", "--key", "root", "--store", moduleFile], {
+        env: { ...harnessEnv(dir), PERSIST_MODULE_FILE: recording },
+      });
+      expect(del.exitCode).toBe(0);
+      expect(del.stdout).toBe("deleted status/root\n");
+      expect(JSON.parse(readFileSync(recording, "utf8"))).toEqual({ kind: "status", key: "root" });
+    });
+  });
+});

--- a/packages/cli/test/slice4-cli.test.ts
+++ b/packages/cli/test/slice4-cli.test.ts
@@ -25,7 +25,13 @@ const SRC_ENTRY = join(CLI_ROOT, "src/index.ts");
  * CLI suites — engine dir resolution must not leak into fixtures).
  * MSTAR_CLI_PROJECT_ROOT / INIT_CWD are pinned too: `resolveCliPath`
  * (audit-002) reads them ahead of PWD, so an ambient value would redirect
- * every relative-path fixture spuriously. */
+ * every relative-path fixture spuriously. TZ is pinned to the test process's
+ * own frame (residual 20260827-qa-tzflake-cli-slice4): `bun test` runs this
+ * process in UTC when TZ is unset, while a bare subprocess would fall back to
+ * the system zone — the two frames diverge across the local calendar-day
+ * boundary (00:00–08:00 in positive-offset zones), breaking the backlog
+ * `registered_at`/`closed_at` date assertions. An explicit ambient TZ is
+ * propagated so both sides always share one frame. */
 function cliEnv(): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
@@ -41,6 +47,7 @@ function cliEnv(): Record<string, string> {
     }
     if (value !== undefined) env[key] = value;
   }
+  env.TZ = process.env.TZ ?? "UTC";
   return env;
 }
 

--- a/packages/engine/src/store.test.ts
+++ b/packages/engine/src/store.test.ts
@@ -474,6 +474,32 @@ describe("FsStore list (D4)", () => {
     }
   });
 
+  test("a readdir ENOENT/ENOTDIR 'path gone' race maps to [], never throws out of list (greptile P1)", async () => {
+    const root = tmpRoot("store-list-race-");
+    try {
+      const store = createFsStore(root);
+      // Deterministic stand-in for the existsSync→readdirSync race: a
+      // regular file where the backing dir is expected makes readdirSync
+      // throw ENOTDIR — the same "path gone" class as ENOENT when the dir
+      // vanishes between check and read. Pre-fix list threw; post-fix [].
+      writeFileSync(join(root, "workflows"), "not a dir", "utf8");
+      expect(await store.list!("snapshot")).toEqual([]);
+      writeFileSync(join(root, "projects"), "not a dir", "utf8");
+      expect(await store.list!("residuals")).toEqual([]);
+      // Same for the review union: sdd/_reviews as a file.
+      mkdirSync(join(root, "sdd"), { recursive: true });
+      writeFileSync(join(root, "sdd", "_reviews"), "not a dir", "utf8");
+      expect(await store.list!("review")).toEqual([]);
+      // ENOENT proper: the whole backing tree removed after store
+      // creation — readdirSync throws ENOENT with no existsSync pre-check.
+      rmSync(root, { recursive: true, force: true });
+      expect(await store.list!("snapshot")).toEqual([]);
+      expect(await store.list!("review")).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("optional-member absence: a store with only put/get stays a valid ArtifactStore (D1-adapter class declines)", () => {
     const store = recordingStore();
     setArtifactStore(store);

--- a/packages/engine/src/store.test.ts
+++ b/packages/engine/src/store.test.ts
@@ -321,7 +321,7 @@ describe("FsStore schema guard (D3)", () => {
 const LIST_JSON_MESSAGE = "ArtifactStore json keys are absolute paths and cannot be listed";
 
 describe("FsStore list (D4)", () => {
-  test("status lists [root] iff status.json exists; absent file → []", async () => {
+  test("status lists [root] iff status.json exists; absent file \u2192 []", async () => {
     const root = tmpRoot("store-list-status-");
     try {
       const store = createFsStore(root);
@@ -334,7 +334,7 @@ describe("FsStore list (D4)", () => {
     }
   });
 
-  test("snapshot lists workflow dirs with snapshot.json, ascending; stray dirs/files excluded; missing backing → []", async () => {
+  test("snapshot lists workflow dirs with snapshot.json, ascending; stray dirs/files excluded; missing backing \u2192 []", async () => {
     const root = tmpRoot("store-list-snapshot-");
     try {
       const store = createFsStore(root);
@@ -354,7 +354,7 @@ describe("FsStore list (D4)", () => {
     }
   });
 
-  test("residuals lists project dirs with residuals.json, ascending; stray dirs excluded; missing backing → []", async () => {
+  test("residuals lists project dirs with residuals.json, ascending; stray dirs excluded; missing backing \u2192 []", async () => {
     const root = tmpRoot("store-list-residuals-");
     try {
       const store = createFsStore(root);
@@ -391,7 +391,7 @@ describe("FsStore list (D4)", () => {
     }
   });
 
-  test("review: a plan-shaped _reviews file is not listed (get would route elsewhere) until the plan dir exists — then exactly once", async () => {
+  test("review: a plan-shaped _reviews file is not listed (get would route elsewhere) until the plan dir exists \u2014 then exactly once", async () => {
     const root = tmpRoot("store-list-review-guard-");
     try {
       const store = createFsStore(root);
@@ -423,7 +423,11 @@ describe("FsStore list (D4)", () => {
       await store.put({ kind: "review", key: "review-inline", payload: payloads.review });
       for (const kind of ["status", "snapshot", "residuals", "review"] as const) {
         for (const ref of await store.list!(kind)) {
-          expect(await store.get(ref)).toEqual(payloads[kind]);
+          // Intermediate variable: a nested `expect(await store.get(...))` lets
+          // TS infer the get<T> type parameter from the expect overload (never)
+          // — assign first, then assert.
+          const got = await store.get(ref);
+          expect(got).toEqual(payloads[kind]);
         }
       }
     } finally {

--- a/packages/engine/src/store.test.ts
+++ b/packages/engine/src/store.test.ts
@@ -406,6 +406,35 @@ describe("FsStore list (D4)", () => {
     }
   });
 
+  test("snapshot: a stray unsafe dir name is skipped without throwing, never advertised (qc1-S/qc3-S)", async () => {
+    const root = tmpRoot("store-list-unsafe-dir-");
+    try {
+      const store = createFsStore(root);
+      await store.put({ kind: "snapshot", key: "wf-1", payload: { id: "wf-1" } });
+      // Unsafe name (space) WITH a backing snapshot.json: skipped for the
+      // name itself — a get on such a key would throw, so list must not
+      // advertise it (and must not throw either).
+      mkdirSync(join(root, "workflows", "bad name"), { recursive: true });
+      writeFileSync(join(root, "workflows", "bad name", "snapshot.json"), "{}", "utf8");
+      expect(await store.list!("snapshot")).toEqual([{ kind: "snapshot", key: "wf-1" }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("review: an unsafe _reviews filename is skipped without throwing, never advertised (qc1-S/qc3-S)", async () => {
+    const root = tmpRoot("store-list-unsafe-review-");
+    try {
+      const store = createFsStore(root);
+      await store.put({ kind: "review", key: "review-inline", payload: { verdict: "approve" } });
+      // Garbage flat filename: advertised pre-fix, then get threw.
+      writeFileSync(join(root, "sdd", "_reviews", "bad name.json"), "{}", "utf8");
+      expect(await store.list!("review")).toEqual([{ kind: "review", key: "review-inline" }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("every listed key across kinds round-trips through get (D4 uniform rule)", async () => {
     const root = tmpRoot("store-list-roundtrip-");
     try {

--- a/packages/engine/src/store.test.ts
+++ b/packages/engine/src/store.test.ts
@@ -19,6 +19,9 @@
  * - Module loader (`loadStoreModule` — named export / default factory /
  *   default object; URI-scheme rejection before import; missing file and
  *   non-store shape throw): SP2 § Injection 2–3 + SP2-AC6 / SP2-AC7.
+ * - `put` schema guard (throw on `doc.schema !== undefined`, canonical
+ *   message; `payload.schema` unaffected): `iter-20260828-store-completeness`
+ *   spec `store-contract-completion` § D3.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -29,6 +32,7 @@ import {
   createFsStore,
   getArtifactStore,
   loadStoreModule,
+  resolveArtifactPath,
   setArtifactStore,
   type ArtifactDoc,
   type ArtifactStore,
@@ -239,6 +243,63 @@ describe("FsStore round-trip", () => {
       expect(await store.get({ kind: "status", key: "root" })).toBeUndefined();
       // deleting a missing artifact is a no-op
       await store.delete?.({ kind: "status", key: "root" });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema guard — store-contract-completion D3 (fail-loud on doc.schema)
+// ---------------------------------------------------------------------------
+
+/** Canonical rejection message (single home: spec store-contract-completion
+ * § D3 — do not reword). Source escapes the em-dash per lint:ascii-literals. */
+const SCHEMA_GUARD_MESSAGE =
+  "FsStore does not persist schema ids \u2014 omit --schema or inject a store module that persists it";
+
+describe("FsStore schema guard (D3)", () => {
+  test("doc carrying an envelope schema is rejected with the canonical message and no file is written", async () => {
+    const root = tmpRoot("store-schema-guard-");
+    try {
+      const store = createFsStore(root);
+      const doc: ArtifactDoc = {
+        kind: "review",
+        key: "r-1",
+        payload: { verdict: "approve" },
+        schema: "mstar.review/v1",
+      };
+      await expect(store.put(doc)).rejects.toThrow(SCHEMA_GUARD_MESSAGE);
+      // Fail-loud means refuse-before-write: nothing may land on disk.
+      expect(existsSync(resolveArtifactPath(root, doc))).toBe(false);
+      expect(await store.get({ kind: "review", key: "r-1" })).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("doc without schema puts unchanged (payload written verbatim)", async () => {
+    const root = tmpRoot("store-schema-absent-");
+    try {
+      const store = createFsStore(root);
+      const payload = { version: 2, updated_at: "2026-08-28", workflows: [] };
+      await store.put({ kind: "status", key: "root", payload });
+      const got = await store.get({ kind: "status", key: "root" });
+      expect(got).toEqual(payload);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("review payload with inner schema field still writes (payload.schema is data, not doc.schema)", async () => {
+    const root = tmpRoot("store-payload-schema-");
+    try {
+      const store = createFsStore(root);
+      const ref = { kind: "review", key: "20260828-store-engine-contract" } as const;
+      const payload = { schema: "mstar.review/v1", verdict: "approve", findings: [] };
+      await store.put({ ...ref, payload });
+      const got = await store.get(ref);
+      expect(got).toEqual(payload);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/engine/src/store.test.ts
+++ b/packages/engine/src/store.test.ts
@@ -22,6 +22,12 @@
  * - `put` schema guard (throw on `doc.schema !== undefined`, canonical
  *   message; `payload.schema` unaffected): `iter-20260828-store-completeness`
  *   spec `store-contract-completion` § D3.
+ * - `list?` interface + FsStore enumeration (exists-conditional status,
+ *   snapshot/residuals dir scans through the single path table, review
+ *   union with the one PLAN_SHAPED_KEY_RE detector, json non-enumerable,
+ *   `[]` on missing backing, sorted ascending, listed keys round-trip
+ *   through `get`): `iter-20260828-store-completeness` spec
+ *   `store-contract-completion` § D4 + § Architecture lock 4.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -303,6 +309,145 @@ describe("FsStore schema guard (D3)", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list? enumeration — store-contract-completion D4 (FsStore per-kind table)
+// ---------------------------------------------------------------------------
+
+/** Canonical json non-enumerable message (single home: spec
+ * store-contract-completion § D4 — do not reword). */
+const LIST_JSON_MESSAGE = "ArtifactStore json keys are absolute paths and cannot be listed";
+
+describe("FsStore list (D4)", () => {
+  test("status lists [root] iff status.json exists; absent file → []", async () => {
+    const root = tmpRoot("store-list-status-");
+    try {
+      const store = createFsStore(root);
+      expect(await store.list!("status")).toEqual([]);
+      const payload = { version: 2, updated_at: "2026-08-28", workflows: [] };
+      await store.put({ kind: "status", key: "root", payload });
+      expect(await store.list!("status")).toEqual([{ kind: "status", key: "root" }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("snapshot lists workflow dirs with snapshot.json, ascending; stray dirs/files excluded; missing backing → []", async () => {
+    const root = tmpRoot("store-list-snapshot-");
+    try {
+      const store = createFsStore(root);
+      expect(await store.list!("snapshot")).toEqual([]);
+      await store.put({ kind: "snapshot", key: "wf-2", payload: { id: "wf-2" } });
+      await store.put({ kind: "snapshot", key: "wf-10", payload: { id: "wf-10" } });
+      // Stray subdir without snapshot.json and a loose file: never listed.
+      mkdirSync(join(root, "workflows", "wf-empty"));
+      writeFileSync(join(root, "workflows", "stray.json"), "{}", "utf8");
+      // Ascending means lexicographic by key (wf-10 < wf-2), never numeric.
+      expect(await store.list!("snapshot")).toEqual([
+        { kind: "snapshot", key: "wf-10" },
+        { kind: "snapshot", key: "wf-2" },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("residuals lists project dirs with residuals.json, ascending; stray dirs excluded; missing backing → []", async () => {
+    const root = tmpRoot("store-list-residuals-");
+    try {
+      const store = createFsStore(root);
+      expect(await store.list!("residuals")).toEqual([]);
+      await store.put({ kind: "residuals", key: "proj-1", payload: { entries: [] } });
+      await store.put({ kind: "residuals", key: "_default", payload: { entries: [] } });
+      mkdirSync(join(root, "projects", "no-register"));
+      expect(await store.list!("residuals")).toEqual([
+        { kind: "residuals", key: "_default" },
+        { kind: "residuals", key: "proj-1" },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("review union lists _reviews flat keys + plan-shaped dirs with report.json, ascending; non-qualifying entries excluded", async () => {
+    const root = tmpRoot("store-list-review-");
+    try {
+      const store = createFsStore(root);
+      expect(await store.list!("review")).toEqual([]); // missing sdd backing
+      await store.put({ kind: "review", key: "review-inline", payload: { verdict: "approve" } });
+      await store.put({ kind: "review", key: "20260828-store-engine", payload: { verdict: "approve" } });
+      // Plan-shaped dir without report.json: not listed (no backing).
+      mkdirSync(join(root, "sdd", "20260828-empty-plan"), { recursive: true });
+      // Non-plan-shaped dir directly under sdd: not part of the union.
+      mkdirSync(join(root, "sdd", "scratch"));
+      expect(await store.list!("review")).toEqual([
+        { kind: "review", key: "20260828-store-engine" },
+        { kind: "review", key: "review-inline" },
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("review: a plan-shaped _reviews file is not listed (get would route elsewhere) until the plan dir exists — then exactly once", async () => {
+    const root = tmpRoot("store-list-review-guard-");
+    try {
+      const store = createFsStore(root);
+      mkdirSync(join(root, "sdd", "_reviews"), { recursive: true });
+      writeFileSync(join(root, "sdd", "_reviews", "20260828-orphan.json"), "{}", "utf8");
+      // Empty case: existing but non-qualifying backing → [].
+      expect(await store.list!("review")).toEqual([]);
+      await store.put({ kind: "review", key: "20260828-orphan", payload: { verdict: "approve" } });
+      expect(await store.list!("review")).toEqual([{ kind: "review", key: "20260828-orphan" }]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("every listed key across kinds round-trips through get (D4 uniform rule)", async () => {
+    const root = tmpRoot("store-list-roundtrip-");
+    try {
+      const store = createFsStore(root);
+      const payloads: Record<string, unknown> = {
+        status: { version: 2, updated_at: "2026-08-28", workflows: [] },
+        snapshot: { id: "wf-1" },
+        residuals: { entries: [] },
+        review: { verdict: "approve" },
+      };
+      await store.put({ kind: "status", key: "root", payload: payloads.status });
+      await store.put({ kind: "snapshot", key: "wf-1", payload: payloads.snapshot });
+      await store.put({ kind: "residuals", key: "proj-1", payload: payloads.residuals });
+      await store.put({ kind: "review", key: "20260828-store-engine", payload: payloads.review });
+      await store.put({ kind: "review", key: "review-inline", payload: payloads.review });
+      for (const kind of ["status", "snapshot", "residuals", "review"] as const) {
+        for (const ref of await store.list!(kind)) {
+          expect(await store.get(ref)).toEqual(payloads[kind]);
+        }
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("json kind throws the canonical usage error", async () => {
+    const root = tmpRoot("store-list-json-");
+    try {
+      const store = createFsStore(root);
+      await expect(store.list!("json")).rejects.toThrow(LIST_JSON_MESSAGE);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("optional-member absence: a store with only put/get stays a valid ArtifactStore (D1-adapter class declines)", () => {
+    const store = recordingStore();
+    setArtifactStore(store);
+    const active = getArtifactStore();
+    expect(active).toBe(store);
+    expect(active.delete).toBeUndefined();
+    expect(active.list).toBeUndefined();
   });
 });
 

--- a/packages/engine/src/store.ts
+++ b/packages/engine/src/store.ts
@@ -7,6 +7,7 @@
  * package (roadmap §8.4 discipline).
  */
 import { existsSync, readdirSync, unlinkSync } from "node:fs";
+import type { Dirent } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { readJson, writeJson } from "./core.js";
 import {
@@ -96,8 +97,7 @@ export function resolveArtifactPath(harnessRoot: string, ref: ArtifactRef): stri
 /** Directory names directly under `dir` — `[]` when the backing dir is
  * missing (D4 uniform rule: enumerate what exists, never throw). */
 function listDirNames(dir: string): string[] {
-  if (!existsSync(dir)) return [];
-  return readdirSync(dir, { withFileTypes: true })
+  return readDirEntries(dir)
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name);
 }
@@ -105,10 +105,24 @@ function listDirNames(dir: string): string[] {
 /** Keys for the `*.json` files directly under `dir` (extension stripped) —
  * `[]` when the backing dir is missing. */
 function listJsonKeys(dir: string): string[] {
-  if (!existsSync(dir)) return [];
-  return readdirSync(dir, { withFileTypes: true })
+  return readDirEntries(dir)
     .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
     .map((entry) => entry.name.slice(0, -".json".length));
+}
+
+/** Read dir entries, or `[]` when the path is gone (ENOENT) or not a
+ * directory (ENOTDIR). No `existsSync` pre-check: a dir removed between
+ * check and readdir would throw ENOENT out of `list`, breaking the D4
+ * "missing backing → `[]`" rule (greptile P1) — catch it instead. Other
+ * errors (EACCES, …) still throw. */
+function readDirEntries(dir: string): Dirent[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return [];
+    throw error;
+  }
 }
 
 /** Resolve the get-path for `key` through the single path table, or

--- a/packages/engine/src/store.ts
+++ b/packages/engine/src/store.ts
@@ -111,6 +111,19 @@ function listJsonKeys(dir: string): string[] {
     .map((entry) => entry.name.slice(0, -".json".length));
 }
 
+/** Resolve the get-path for `key` through the single path table, or
+ * `undefined` when the name is outside the safe path-component charset.
+ * Enumeration probes every discovered name through this guard (qc1-S /
+ * qc3-S): a stray unsafe name is skipped — never thrown, never advertised —
+ * so every listed key round-trips through `get`. */
+function tryResolveGetPath(root: string, kind: ArtifactKind, key: string): string | undefined {
+  try {
+    return resolveArtifactPath(root, { kind, key });
+  } catch {
+    return undefined;
+  }
+}
+
 /** Default local adapter: maps kinds to the existing `.mstar/` paths.
  * `put` uses the sync `writeJson` (atomic temp+rename unchanged) and
  * returns a resolved Promise; locks stay with callers (architect-locked
@@ -167,7 +180,8 @@ export function createFsStore(harnessRoot: string): ArtifactStore & { root: stri
         for (const name of listDirNames(baseDir)) {
           // Round-trip guard through the single path table: list the dir
           // only when its exact get-path (<dir>/<name>/<file>) exists.
-          if (existsSync(resolveArtifactPath(root, { kind, key: name }))) keys.push(name);
+          const getPath = tryResolveGetPath(root, kind, name);
+          if (getPath !== undefined && existsSync(getPath)) keys.push(name);
         }
       } else {
         // kind === "review" — union enumeration (D4), single detector
@@ -177,15 +191,17 @@ export function createFsStore(harnessRoot: string): ArtifactStore & { root: stri
         // excluded: get routes such a key to <key>/review/report.json, so
         // listing the _reviews file would advertise an unreachable key.
         for (const key of listJsonKeys(join(sddDir, "_reviews"))) {
-          if (!PLAN_SHAPED_KEY_RE.test(key)) keys.push(key);
+          if (!PLAN_SHAPED_KEY_RE.test(key) && tryResolveGetPath(root, kind, key) !== undefined) {
+            keys.push(key);
+          }
         }
         // (b) plan-shaped dirs carrying <dir>/review/report.json.
         for (const name of listDirNames(sddDir)) {
-          if (
-            PLAN_SHAPED_KEY_RE.test(name) &&
-            existsSync(resolveArtifactPath(root, { kind, key: name }))
-          ) {
-            keys.push(name);
+          if (PLAN_SHAPED_KEY_RE.test(name)) {
+            // PLAN_SHAPED_KEY_RE is a subset of the safe charset, so this
+            // probe never throws — same uniform guard as the other arms.
+            const getPath = tryResolveGetPath(root, kind, name);
+            if (getPath !== undefined && existsSync(getPath)) keys.push(name);
           }
         }
       }

--- a/packages/engine/src/store.ts
+++ b/packages/engine/src/store.ts
@@ -6,7 +6,7 @@
  * and atomic write semantics. No concrete non-FS adapter lives in this
  * package (roadmap §8.4 discipline).
  */
-import { existsSync, unlinkSync } from "node:fs";
+import { existsSync, readdirSync, unlinkSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { readJson, writeJson } from "./core.js";
 import {
@@ -35,11 +35,18 @@ export type ArtifactDoc<T = unknown> = ArtifactRef & {
 
 /** Type-only persist contract (HostAdapter pattern). `put` / `get` /
  * `delete` are async-only — a network-backed store never needs a sync
- * facade (architect-locked 2026-08-27: no `putSync` anywhere). */
+ * facade (architect-locked 2026-08-27: no `putSync` anywhere). `list?`
+ * is optional enumeration (D4): stores that cannot enumerate decline by
+ * omitting the member — callers probe `typeof store.list === "function"`
+ * (same pattern as `delete?`). */
 export interface ArtifactStore {
   put(doc: ArtifactDoc): Promise<void>;
   get<T = unknown>(ref: ArtifactRef): Promise<T | undefined>;
   delete?(ref: ArtifactRef): Promise<void>;
+  /** Enumerate refs of `kind`, sorted by key ascending (spec D4). Uniform
+   * rule: report what exists — missing backing dir/file → `[]`; every
+   * listed key round-trips through `get`. `json` is not enumerable. */
+  list?(kind: ArtifactKind): Promise<ArtifactRef[]>;
 }
 
 /** Plan-shaped review key detector (architect-locked 2026-08-27): full
@@ -86,6 +93,24 @@ export function resolveArtifactPath(harnessRoot: string, ref: ArtifactRef): stri
   return join(harnessRoot, "sdd", "_reviews", `${key}.json`);
 }
 
+/** Directory names directly under `dir` — `[]` when the backing dir is
+ * missing (D4 uniform rule: enumerate what exists, never throw). */
+function listDirNames(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+/** Keys for the `*.json` files directly under `dir` (extension stripped) —
+ * `[]` when the backing dir is missing. */
+function listJsonKeys(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name.slice(0, -".json".length));
+}
+
 /** Default local adapter: maps kinds to the existing `.mstar/` paths.
  * `put` uses the sync `writeJson` (atomic temp+rename unchanged) and
  * returns a resolved Promise; locks stay with callers (architect-locked
@@ -93,7 +118,9 @@ export function resolveArtifactPath(harnessRoot: string, ref: ArtifactRef): stri
  * malformed JSON → throw with the path in the message. The returned store
  * also exposes its resolved `root` so the routed writers can fail loud
  * when a caller's explicit target path diverges from the store-resolved
- * path (qc3 F-201); `root` is not part of the `ArtifactStore` contract. */
+ * path (qc3 F-201); `root` is not part of the `ArtifactStore` contract.
+ * `list` enumerates per the D4 table: report what exists — missing
+ * backing dir/file → `[]`, `json` throws, keys sorted ascending. */
 export function createFsStore(harnessRoot: string): ArtifactStore & { root: string } {
   const root = resolve(harnessRoot);
   return {
@@ -119,6 +146,50 @@ export function createFsStore(harnessRoot: string): ArtifactStore & { root: stri
     async delete(ref: ArtifactRef): Promise<void> {
       const filePath = resolveArtifactPath(root, ref);
       if (existsSync(filePath)) unlinkSync(filePath);
+    },
+    async list(kind: ArtifactKind): Promise<ArtifactRef[]> {
+      // json keys are caller-supplied absolute paths — nothing to
+      // enumerate (canonical message, single home: spec D4).
+      if (kind === "json") {
+        throw new Error("ArtifactStore json keys are absolute paths and cannot be listed");
+      }
+      const keys: string[] = [];
+      if (kind === "status") {
+        // Exists-conditional (architect-amended D4): [root] iff the file
+        // exists — never a key whose get would miss.
+        if (existsSync(resolveArtifactPath(root, { kind, key: "root" }))) keys.push("root");
+      } else if (kind === "snapshot" || kind === "residuals") {
+        // Same root resolution as the path table (.mstarc overrides apply).
+        const baseDir =
+          kind === "snapshot"
+            ? resolveWorkflowDir(root, { harnessDir: root })
+            : resolveProjectDir(root, { harnessDir: root });
+        for (const name of listDirNames(baseDir)) {
+          // Round-trip guard through the single path table: list the dir
+          // only when its exact get-path (<dir>/<name>/<file>) exists.
+          if (existsSync(resolveArtifactPath(root, { kind, key: name }))) keys.push(name);
+        }
+      } else {
+        // kind === "review" — union enumeration (D4), single detector
+        // (PLAN_SHAPED_KEY_RE), same sdd root as the path table.
+        const sddDir = join(root, "sdd");
+        // (a) flat keys from _reviews/<key>.json. Plan-shaped names are
+        // excluded: get routes such a key to <key>/review/report.json, so
+        // listing the _reviews file would advertise an unreachable key.
+        for (const key of listJsonKeys(join(sddDir, "_reviews"))) {
+          if (!PLAN_SHAPED_KEY_RE.test(key)) keys.push(key);
+        }
+        // (b) plan-shaped dirs carrying <dir>/review/report.json.
+        for (const name of listDirNames(sddDir)) {
+          if (
+            PLAN_SHAPED_KEY_RE.test(name) &&
+            existsSync(resolveArtifactPath(root, { kind, key: name }))
+          ) {
+            keys.push(name);
+          }
+        }
+      }
+      return keys.sort().map((key) => ({ kind, key }));
     },
   };
 }

--- a/packages/engine/src/store.ts
+++ b/packages/engine/src/store.ts
@@ -99,6 +99,16 @@ export function createFsStore(harnessRoot: string): ArtifactStore & { root: stri
   return {
     root,
     async put(doc: ArtifactDoc): Promise<void> {
+      // D3 schema fail-loud: FsStore writes only `doc.payload`, so it
+      // cannot persist the envelope schema id honestly — refuse instead of
+      // silently dropping it. `doc.schema` ≠ `payload.schema`: a review
+      // envelope's inner "schema" is payload data and stays unaffected.
+      // Canonical message (single home: spec store-contract-completion D3).
+      if (doc.schema !== undefined) {
+        throw new Error(
+          "FsStore does not persist schema ids \u2014 omit --schema or inject a store module that persists it",
+        );
+      }
       writeJson(resolveArtifactPath(root, doc), doc.payload);
     },
     async get<T = unknown>(ref: ArtifactRef): Promise<T | undefined> {


### PR DESCRIPTION
## Summary

Closes the four honesty gaps in the ArtifactStore port shipped by #159, so Inspector (and any injected-store consumer) can use engine/cli without reading `.mstar/` or `store.ts`.

- **D3 fail-loud**: `FsStore.put` rejects `doc.schema` (canonical message); payload inner `schema` (review envelopes) still writes. `--schema` + default store → exit 1.
- **D4 `list?`**: optional `ArtifactStore.list?(kind)` + FsStore implementation (exists-conditional `status`; snapshot/residuals dir scans; review union via single `PLAN_SHAPED_KEY_RE`; `json` throws; listed keys round-trip through `get`; unsafe names skipped uniformly).
- **D1 `persist get --validate`**: engine `get` stays raw (port is storage); CLI opt-in reuses `validatePersistPayload`; stdout = payload JSON; notes/violations on stderr.
- **D2 `persist delete`**: CLI face for the existing optional `delete?`; probed (missing method → exit 2); idempotent, no prompt.
- **TZ flake residual closed**: `slice4-cli` subprocess TZ now matches the test-process frame (`TZ = process.env.TZ ?? "UTC"`). Residual `20260827-qa-tzflake-cli-slice4` closed.

A5 (cross-doc transactions) is an explicit Non-Goal: transactions belong to a coordination layer *above* the port (`locks stay with callers`). Trigger recorded in the iteration compass.

## Plans

| Plan | Merge | QC | QA |
|------|-------|-----|-----|
| SP1 `20260828-store-engine-contract` | `7920d72c` | tri 3/3 Approve (fix wave `f42ed7af`) | mandatory Pass |
| SP2 `20260828-store-cli-faces` | `48d1fc6d` | tri 3/3 Approve | mandatory Pass |
| SP3 `20260828-tz-flake-slice4` | `68295e3d` | tri 3/3 Approve | pm-acceptance |

Seat 3 of each tri ran via C5 fallback (`qc-specialist-3` backing model quota-exceeded); degraded recorded in each `qc-consolidated.md`.

## Test plan

- [x] `bun run --cwd packages/engine test` — 1119 pass
- [x] `bun run --cwd packages/cli test` — 495 pass
- [x] `bun run typecheck && bun run validation:drift && bun run validation:standalone && bun run lint:ascii-literals`
- [x] Persist spot-checks: `list` / `get --validate` / `delete` against a temp harness (QA L4)
- [x] `TZ=America/New_York` and `TZ=Asia/Shanghai` `bun test packages/cli/test/slice4-cli.test.ts` — 137 pass each

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default persist behavior for `--schema` on FsStore and adds enumeration/delete paths that touch harness coordination files under `.mstar/`, though behavior is spec-locked and heavily tested.
> 
> **Overview**
> Completes the **ArtifactStore** honesty contract in engine and exposes it through **`mstar-harness persist`**.
> 
> **Engine:** `FsStore.put` now **rejects** writes when `doc.schema` is set (canonical error; inner `payload.schema` unchanged). **`ArtifactStore.list?(kind)`** is optional; **`FsStore.list`** enumerates keys per the existing path table (empty when missing, sorted keys, review union, `json` throws, unsafe names skipped).
> 
> **CLI:** New **`persist list`**, **`persist get --validate`** (put-gate validators; stdout JSON only), and **`persist delete`** (idempotent). Injected stores without `list`/`delete` exit **2** after probing. **`--schema`** with default FsStore now fails at put (exit **1**).
> 
> **Tests/docs:** Broad engine/CLI coverage; **`slice4-cli`** pins **`TZ`** to avoid calendar-day flakes across subprocess vs test process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48d1fc6de8f9c53c18a1a0ca7bfb0734a64109eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->