### PR TITLE
fix(omp-install): resolve engine from npm in root manifest (+ release sync, CI guard)

### DIFF
--- a/.changes/unreleased/omp-git-install-workspace-dep.md
+++ b/.changes/unreleased/omp-git-install-workspace-dep.md
@@ -1,0 +1,8 @@
+---
+packages: root
+---
+
+- Fixed git/hosted installs (`omp plugin install github:btspoony/mstar-harness`, `bun add github:…`) failing at dependency resolution: the root manifest's `@mstar-harness/engine` dependency used the pack-time-only `workspace:*` protocol, unresolvable outside the monorepo. It is now `^3.5.0`, fetched from npm on hosted installs, while dev checkouts still link the workspace member.
+
+<!-- CN -->
+- 修复 git/托管安装（`omp plugin install github:btspoony/mstar-harness`、`bun add github:…`）在依赖解析阶段失败的问题：根清单的 `@mstar-harness/engine` 依赖使用了仅在打包期可用的 `workspace:*` 协议，脱离 monorepo 无法解析。现改为 `^3.5.0`，托管安装从 npm 拉取；本地开发检出仍链接 workspace 成员。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         run: bun run --cwd packages/dsh typecheck:tests
 
       - name: Test scripts
-        run: bun test scripts/ascii-literal-utils.test.ts scripts/ci-dep-guard.test.ts scripts/drift-lint.test.ts scripts/escape-dist-literals.test.ts scripts/lint-ascii-literals.test.ts scripts/prepare-release.test.ts
+        run: bun test scripts/ascii-literal-utils.test.ts scripts/ci-dep-guard.test.ts scripts/ci-packed-manifest-guard.test.ts scripts/drift-lint.test.ts scripts/escape-dist-literals.test.ts scripts/lint-ascii-literals.test.ts scripts/prepare-release.test.ts
 
       # spec §7.4: src code literals must stay pure ASCII — bun 1.2.17
       # misdecodes raw multi-byte UTF-8 in literals of the 366KB CLI bundle.
@@ -140,6 +140,12 @@ jobs:
 
       - name: Pack OpenCode tarball
         run: bun run opencode:pack
+      # The root package.json is the manifest git/hosted installs resolve
+      # (`omp plugin install github:…`, `bun add github:…`): a `workspace:`
+      # spec in a shipped dependency section breaks every hosted install at
+      # resolve time (20260829 hotfix). Guard raw + packed root manifests.
+      - name: "Packed manifest guard (no workspace: in shipped deps)"
+        run: bun run ci:packed-manifest-guard
 
   # Roadmap §8.7 item 2 (risk R2): skills must load without the engine.
   # Deliberately NO `bun install` — this job runs in a checkout where

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "morning-star",
       "dependencies": {
-        "@mstar-harness/engine": "workspace:*",
+        "@mstar-harness/engine": "^3.5.0",
       },
       "devDependencies": {
         "@oh-my-pi/pi-coding-agent": "^17.2.11",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "release:prepare": "bun run scripts/prepare-release.ts",
     "release:validate": "bun run scripts/validate-release-version.ts",
     "ci:dep-guard": "bun scripts/ci-dep-guard.ts",
+    "ci:packed-manifest-guard": "bun scripts/ci-packed-manifest-guard.ts",
     "validation:standalone": "bun run scripts/standalone-smoke.ts",
     "validation:drift": "bun run scripts/drift-lint.ts",
     "lint:ascii-literals": "bun scripts/lint-ascii-literals.ts"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "packageManager": "bun@1.2.17",
   "dependencies": {
-    "@mstar-harness/engine": "workspace:*"
+    "@mstar-harness/engine": "^3.5.0"
   },
   "devDependencies": {
     "@oh-my-pi/pi-coding-agent": "^17.2.11",

--- a/scripts/ci-packed-manifest-guard.test.ts
+++ b/scripts/ci-packed-manifest-guard.test.ts
@@ -1,0 +1,42 @@
+/**
+ * scripts/ci-packed-manifest-guard.ts — `workspace:` spec scan semantics.
+ */
+import { describe, expect, test } from "bun:test";
+import { findWorkspaceSpecs } from "./ci-packed-manifest-guard.ts";
+
+describe("findWorkspaceSpecs (packed manifest workspace: guard)", () => {
+  test("flags workspace: specs in dependencies, peerDependencies, optionalDependencies", () => {
+    const hits = findWorkspaceSpecs({
+      dependencies: { "@mstar-harness/engine": "workspace:*" },
+      peerDependencies: { zod: "workspace:^" },
+      optionalDependencies: { fsevents: "workspace:~1.0.0" },
+    });
+    expect(hits).toEqual([
+      'dependencies["@mstar-harness/engine"] = "workspace:*"',
+      'peerDependencies["zod"] = "workspace:^"',
+      'optionalDependencies["fsevents"] = "workspace:~1.0.0"',
+    ]);
+  });
+
+  test("semver ranges and non-workspace protocols pass", () => {
+    expect(
+      findWorkspaceSpecs({
+        dependencies: { "@mstar-harness/engine": "^3.5.0", zod: "^4.0.0" },
+        peerDependencies: { react: ">=18" },
+        optionalDependencies: { fsevents: "^2.3.3" },
+      }),
+    ).toEqual([]);
+  });
+
+  test("devDependencies are exempt (not shipped)", () => {
+    expect(
+      findWorkspaceSpecs({
+        devDependencies: { "@mstar-harness/engine": "workspace:*" },
+      }),
+    ).toEqual([]);
+  });
+
+  test("missing dependency sections pass", () => {
+    expect(findWorkspaceSpecs({})).toEqual([]);
+  });
+});

--- a/scripts/ci-packed-manifest-guard.ts
+++ b/scripts/ci-packed-manifest-guard.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+/**
+ * ci-packed-manifest-guard.ts — the root package.json is the manifest that
+ * git/hosted installs resolve (`omp plugin install github:…`,
+ * `bun add github:…`). The `workspace:` protocol is pack-time-only syntax and
+ * unresolvable outside the declaring workspace, so a `workspace:` spec in a
+ * shipped dependency section breaks every hosted install at resolve time
+ * (20260829-omp-git-install-workspace-dep hotfix).
+ *
+ * Fails when the RAW root package.json — or the PACKED root manifest
+ * (`bun pm pack` into a temp dir, extracted, cleaned up) — carries a
+ * `workspace:` spec in `dependencies` / `peerDependencies` /
+ * `optionalDependencies`. devDependencies are not shipped, so exempt
+ * (internal packages bundle the engine at build time).
+ *
+ * The section scan is a pure exported function; its semantics are guarded by
+ * `scripts/ci-packed-manifest-guard.test.ts`.
+ */
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SHIPPED_SECTIONS = ["dependencies", "peerDependencies", "optionalDependencies"] as const;
+
+type Manifest = Partial<
+  Record<(typeof SHIPPED_SECTIONS)[number] | "devDependencies", Record<string, string>>
+>;
+
+/** `workspace:` specs found in shipped dependency sections (devDependencies exempt). */
+export function findWorkspaceSpecs(manifest: Manifest): string[] {
+  const hits: string[] = [];
+  for (const section of SHIPPED_SECTIONS) {
+    for (const [name, spec] of Object.entries(manifest[section] ?? {})) {
+      if (typeof spec === "string" && spec.startsWith("workspace:")) {
+        hits.push(`${section}["${name}"] = "${spec}"`);
+      }
+    }
+  }
+  return hits;
+}
+
+async function run(cmd: string[]): Promise<void> {
+  const proc = Bun.spawn(cmd, { stdout: "inherit", stderr: "inherit" });
+  if ((await proc.exited) !== 0) throw new Error(`command failed: ${cmd.join(" ")}`);
+}
+
+async function main(): Promise<void> {
+  const failures: string[] = [];
+
+  // 1. Raw root manifest — what `bun add github:…` resolves before any pack
+  //    rewriting (the 20260829 failure happened at this stage).
+  const raw = (await Bun.file("package.json").json()) as Manifest;
+  for (const hit of findWorkspaceSpecs(raw)) failures.push(`package.json ${hit}`);
+
+  // 2. Packed manifest — what a hosted install actually receives.
+  const dir = mkdtempSync(join(tmpdir(), "packed-manifest-guard-"));
+  try {
+    await run(["bun", "pm", "pack", "--destination", dir, "--quiet"]);
+    const tgz = readdirSync(dir).find((f) => f.endsWith(".tgz"));
+    if (!tgz) throw new Error(`bun pm pack produced no tarball in ${dir}`);
+    await run(["tar", "-xzf", join(dir, tgz), "-C", dir]);
+    const packed = (await Bun.file(join(dir, "package", "package.json")).json()) as Manifest;
+    for (const hit of findWorkspaceSpecs(packed)) failures.push(`packed manifest ${hit}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  if (failures.length) {
+    console.error(
+      "workspace: protocol is unresolvable in hosted/git installs — forbidden in shipped dependency sections:",
+    );
+    for (const f of failures) console.error(`  ${f}`);
+    process.exit(1);
+  }
+  console.log("OK — raw + packed root manifests carry no workspace: specs in shipped dependency sections");
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -2,7 +2,7 @@
  * scripts/prepare-release.ts — fragment `packages:` token validation.
  */
 import { describe, expect, test } from "bun:test";
-import { parseFragment, validateFragmentPackages } from "./prepare-release.ts";
+import { parseFragment, syncRootEngineSpec, validateFragmentPackages } from "./prepare-release.ts";
 
 describe("validateFragmentPackages (release packages enum)", () => {
   test("cli, root (comma+space, mixed case 'CLI, Root') is valid and normalized lowercase", () => {
@@ -47,5 +47,36 @@ packages: root, , cli,
 - bullet`);
     expect(ws.packages).toEqual(["root", "cli"]);
     expect(validateFragmentPackages(ws.packages, "ws.md")).toEqual([]);
+  });
+});
+
+describe("syncRootEngineSpec (root manifest engine dependency)", () => {
+  const manifest = (spec: string) => `{
+  "name": "morning-star",
+  "dependencies": {
+    "@mstar-harness/engine": "${spec}"
+  },
+  "devDependencies": {
+    "@mstar-harness/engine": "workspace:*"
+  }
+}
+`;
+
+  test("rewrites workspace:* to the release range, devDependencies untouched", () => {
+    const out = syncRootEngineSpec(manifest("workspace:*"), "3.5.0");
+    expect(out).toContain('"dependencies": {\n    "@mstar-harness/engine": "^3.5.0"\n  }');
+    expect(out).toContain('"devDependencies": {\n    "@mstar-harness/engine": "workspace:*"\n  }');
+  });
+
+  test("rewrites a stale semver range to the new release range", () => {
+    const out = syncRootEngineSpec(manifest("^3.4.0"), "3.5.0");
+    expect(out).toContain('"@mstar-harness/engine": "^3.5.0"');
+    expect(out).not.toContain("^3.4.0");
+  });
+
+  test("throws when the root manifest has no engine runtime dependency", () => {
+    expect(() =>
+      syncRootEngineSpec(`{ "dependencies": { "zod": "^4.0.0" } }`, "3.5.0"),
+    ).toThrow('could not find dependencies["@mstar-harness/engine"]');
   });
 });

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -240,6 +240,25 @@ async function bumpInstall(oldV: string, newV: string): Promise<void> {
   await Bun.write(INSTALL_REF.path, text.replace(re, `$1${newV}$2`));
 }
 
+/**
+ * Rewrite the root manifest's runtime dependency on `@mstar-harness/engine`
+ * to `^<version>`. The root package.json is the manifest git/hosted installs
+ * resolve (`omp plugin install github:…`, `bun add github:…`), where the
+ * `workspace:` protocol is unresolvable — the spec must be a plain semver
+ * range so hosted installs fetch the published engine from npm. Dev checkouts
+ * still link the workspace member (bun links when the range is satisfied).
+ * Scoped to the `dependencies` block: internal packages keep `workspace:*`
+ * devDependencies (bundled at build time). Pure text transform, exported for
+ * tests.
+ */
+export function syncRootEngineSpec(text: string, version: string): string {
+  const re = /("dependencies"\s*:\s*\{[^{}]*?"@mstar-harness\/engine"\s*:\s*")[^"]*(")/;
+  if (!re.test(text)) {
+    throw new Error('package.json: could not find dependencies["@mstar-harness/engine"]');
+  }
+  return text.replace(re, `$1^${version}$2`);
+}
+
 function archiveFragments(version: string, frags: Fragment[]): void {
   if (!frags.length) return;
   const dest = `${ARCHIVE_DIR}/${version}`;
@@ -284,8 +303,16 @@ async function main(): Promise<void> {
     console.log(`bump: ${s.path}`);
   }
 
-  // Internal consumers (cli/opencode/dsh) bundle the engine at build time; their
-  // devDependency uses `workspace:*`, so no per-release spec sync is needed.
+  // Internal packages (cli/opencode/dsh) bundle the engine at build time; their
+  // devDependency keeps `workspace:*` and needs no sync. The ROOT manifest is
+  // what git/hosted installs resolve, so its runtime engine dependency must
+  // track the release as a plain semver range (`^<version>`) served by npm.
+  {
+    const rootPath = "package.json";
+    const text = await Bun.file(rootPath).text();
+    await Bun.write(rootPath, syncRootEngineSpec(text, version));
+    console.log(`sync: ${rootPath} dependencies["@mstar-harness/engine"] -> ^${version}`);
+  }
   await bumpInstall(current, version);
   console.log(`bump: ${INSTALL_REF.path}`);
 

--- a/scripts/validate-release-version.ts
+++ b/scripts/validate-release-version.ts
@@ -69,6 +69,26 @@ if (installVersion !== version) {
   console.log(`OK INSTALL.md ZCode marketplace example: ${installVersion}`);
 }
 
+// The root manifest is what git/hosted installs (`omp plugin install
+// github:…`, `bun add github:…`) resolve, so its runtime engine dependency
+// must be the plain semver range `^<version>` — never `workspace:*`, which is
+// unresolvable outside the declaring workspace. The engine version itself is
+// a VERSION_SURFACES entry (packages/engine/package.json) checked above, so
+// the root range must track the release tag.
+const rootPkg = (await Bun.file("package.json").json()) as {
+  dependencies?: Record<string, string>;
+};
+const engineSpec = rootPkg.dependencies?.["@mstar-harness/engine"];
+const expectedSpec = `^${version}`;
+if (engineSpec !== expectedSpec) {
+  console.error(
+    `MISMATCH root engine dependency (package.json): expected dependencies["@mstar-harness/engine"] = "${expectedSpec}", found ${engineSpec ?? "<missing>"}`,
+  );
+  failed = true;
+} else {
+  console.log(`OK root engine dependency: ${engineSpec}`);
+}
+
 if (failed) {
   console.error(`\nRelease tag ${tag} does not match all surface versions.`);
   process.exit(1);


### PR DESCRIPTION
## Problem

`omp plugin install github:btspoony/mstar-harness` fails on Linux (and any host):

```
error: Workspace dependency "@mstar-harness/engine" not found
Searched in "./*"
error: @mstar-harness/engine@workspace:* failed to resolve
```

## Root cause

`bun add <git-spec>` resolves the dependency's `dependencies` from the **raw** root manifest before pack-time rewriting. The root manifest carried `"@mstar-harness/engine": "workspace:*"` (added with the omp in-process binding, #78). The `workspace:` protocol is unresolvable outside the declaring workspace (`Searched in "./*"` is the consumer side), so every hosted install fails at resolve time. The repo's own design contract (`skills/mstar-host/references/omp.md`) requires this entry to be a published version.

## Fix

- Root `package.json`: engine dependency → `^3.5.0` (published on npm). Dev checkouts keep workspace linking — bun links the workspace member when the range is satisfied (verified: `node_modules/@mstar-harness/engine -> packages/engine`).
- `bun.lock`: surgical 1-line root spec sync (full regen would produce lockfileVersion 2 + unrelated drift vs the pinned `bun@1.2.17`).
- `scripts/prepare-release.ts`: per-release sync of the root spec to `^<new-version>`; stale comment corrected.
- `scripts/validate-release-version.ts`: release gate asserts root spec === `^<version>`.
- `scripts/ci-packed-manifest-guard.ts` (+ test, wired into `ci.yml`): fails CI when the raw or packed root manifest carries `workspace:` in `dependencies`/`peerDependencies`/`optionalDependencies` (regression guard for this exact failure class).
- `.changes/unreleased/omp-git-install-workspace-dep.md`: EN+CN fragment (`packages: root`).

## Verification

- Reproduced original failure with `bun add github:btspoony/mstar-harness` (bun 1.4.0); plain `bun install` in the extracted repo succeeded — failure isolated to the git-dep path.
- Dev evidence (worktree): workspace symlink intact; typecheck / `validation:standalone` / `validation:drift` green; `bun pm pack` manifest = `^3.5.0`, zero `workspace:` tokens in shipped dep sections; fresh temp project `bun add <tarball>` installs engine@3.5.0 + full plugin files; script tests 11/11; `release:validate -- v3.5.0` green; guard negative path exits 1 with violation list.
- End-to-end on this branch: `bun add github:btspoony/mstar-harness#fix/omp-git-install-workspace-dep` succeeds (same code path as `omp plugin install github:`).
- QC single-review (hotfix): **Approve**, 0 Critical / 0 Warning; 2 low suggestions registered as open residuals (guard integration test; stale bun.lock member stamps — cosmetic, plan non-goal).

Merging to `main` fixes installs immediately for `github:` consumers (installs resolve default-branch HEAD; no release tag required).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every git/hosted consumer resolves `@mstar-harness/engine` (npm semver vs workspace); release and CI gates reduce regression risk, but a wrong range could break installs or monorepo linking.
> 
> **Overview**
> Fixes **git/hosted installs** (`omp plugin install github:…`, `bun add github:…`) that failed during dependency resolution because the root manifest used **`workspace:*`** for `@mstar-harness/engine`—unresolvable outside the monorepo.
> 
> The root **`dependencies`** entry is now **`^3.5.0`** (npm); **`bun.lock`** is updated in line. Monorepo dev checkouts can still link the workspace engine when the range is satisfied.
> 
> **Release tooling:** `prepare-release` syncs the root engine spec to `^<version>` each release (`syncRootEngineSpec`); `release:validate` asserts that spec matches the tag.
> 
> **Regression guard:** new **`ci-packed-manifest-guard`** (tests + CI step) rejects `workspace:` in shipped sections of the raw and packed root manifest; **`devDependencies`** stay exempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d429883438a53a45413e8b1edbf9d7aab2f8d41. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->