### PR TITLE
feat(release): support prerelease versions with npm alpha dist-tag

### DIFF
--- a/.changes/unreleased/release-prerelease-support.md
+++ b/.changes/unreleased/release-prerelease-support.md
@@ -1,0 +1,8 @@
+---
+packages: root
+---
+
+- Prerelease versions (`X.Y.Z-suffix`, e.g. `3.6.0-alpha.1`) now flow through `release:prepare` / `release:validate` / publish: npm publishes under the dist-tag `alpha` (never `latest`), the GitHub Release is flagged prerelease, and the INSTALL.md marketplace example stays on the last stable release.
+
+<!-- CN -->
+- 预发布版本（`X.Y.Z-suffix`，如 `3.6.0-alpha.1`）现可完整走通 `release:prepare` / `release:validate` / 发布流程：npm 以 `alpha` dist-tag 发布（绝不触碰 `latest`），GitHub Release 标记为预发布，INSTALL.md 市场示例保持在上一个稳定版本。

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Target version (e.g. 1.8.7). Leave empty for an auto patch bump."
+        description: "Target version (e.g. 1.8.7, or a prerelease like 1.9.0-alpha.0). Leave empty for an auto patch bump."
         required: false
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ name: Release
 # first — cli/opencode depend on it) -> create+push the `vX.Y.Z` tag -> GitHub
 # Release.
 #
+# Prereleases: a `release vX.Y.Z-alpha.N` PR publishes under the npm dist-tag
+# `alpha` (never `latest`) and creates a GitHub Release flagged prerelease.
+# INSTALL.md stays on the last stable release for prerelease lines.
+#
 # No secrets are required for the default flow (the tag is pushed with the
 # workflow's GITHUB_TOKEN). Releases are PR-driven by design: a manual
 # `git tag && git push --tags` no longer auto-publishes.
@@ -57,6 +61,14 @@ jobs:
         id: ver
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve npm dist-tag
+        id: disttag
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          if [[ "$VERSION" == *-* ]]; then TAG="alpha"; else TAG="latest"; fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${VERSION} under dist-tag ${TAG}"
+
       - name: Validate release versions
         env:
           VERSION: ${{ steps.ver.outputs.version }}
@@ -83,16 +95,16 @@ jobs:
       # are self-contained — no registry ordering constraint. Keep engine first
       # for tidy publication history.
       - name: Publish @mstar-harness/engine
-        run: npm publish --workspace @mstar-harness/engine --access public
+        run: npm publish --workspace @mstar-harness/engine --access public --tag ${{ steps.disttag.outputs.tag }}
 
       - name: Publish @mstar-harness/cli
-        run: npm publish --workspace @mstar-harness/cli --access public
+        run: npm publish --workspace @mstar-harness/cli --access public --tag ${{ steps.disttag.outputs.tag }}
 
       - name: Publish @mstar-harness/opencode
-        run: npm publish --workspace @mstar-harness/opencode --access public
+        run: npm publish --workspace @mstar-harness/opencode --access public --tag ${{ steps.disttag.outputs.tag }}
 
       - name: Publish @mstar-harness/dsh
-        run: npm publish --workspace @mstar-harness/dsh --access public
+        run: npm publish --workspace @mstar-harness/dsh --access public --tag ${{ steps.disttag.outputs.tag }}
 
       - name: Configure git identity
         run: |
@@ -128,4 +140,4 @@ jobs:
           name: v${{ steps.ver.outputs.version }}
           body_path: ${{ steps.changelog.outputs.notes_file }}
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(steps.ver.outputs.version, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,9 @@ jobs:
 
       - name: Resolve npm dist-tag
         id: disttag
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          VERSION="${{ steps.ver.outputs.version }}"
           if [[ "$VERSION" == *-* ]]; then TAG="alpha"; else TAG="latest"; fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Publishing ${VERSION} under dist-tag ${TAG}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,10 @@ Merging a `release vX.Y.Z` PR runs the **Release** workflow **inline on the `pul
 
 > npm trusted publishing / provenance now runs on the `pull_request` event (previously `push:tags`); the workflow filename is unchanged. If the first release via this flow fails publish, revert the trigger to `push:tags` and switch to a PAT-pushed auto-tag model.
 
+### Prereleases (alpha)
+
+Prerelease lines use the same PR flow with a suffixed version: `bun run release:prepare -- 3.6.0-alpha.1`, then merge the `release v3.6.0-alpha.1` PR. The Release workflow publishes under the npm dist-tag `alpha` (never `latest`) and flags the GitHub Release as prerelease. `INSTALL.md` / README examples stay on the last stable release — `release:prepare` skips the INSTALL bump and `release:validate` skips the INSTALL check for prerelease versions. Stable `X.Y.Z` releases are unchanged.
+
 ### Conventions
 
 - Never invent a skipped tag (e.g. do not create `v1.8.4` to fill a historical gap).

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -1,8 +1,8 @@
 /**
  * scripts/prepare-release.ts — fragment `packages:` token validation.
  */
-import { describe, expect, test } from "bun:test";
 import { parseFragment, syncRootEngineSpec, validateFragmentPackages } from "./prepare-release.ts";
+import { RELEASE_VERSION_RE, compareSemver, isPrereleaseVersion } from "./release-surfaces.ts";
 
 describe("validateFragmentPackages (release packages enum)", () => {
   test("cli, root (comma+space, mixed case 'CLI, Root') is valid and normalized lowercase", () => {
@@ -74,9 +74,49 @@ describe("syncRootEngineSpec (root manifest engine dependency)", () => {
     expect(out).not.toContain("^3.4.0");
   });
 
-  test("throws when the root manifest has no engine runtime dependency", () => {
-    expect(() =>
-      syncRootEngineSpec(`{ "dependencies": { "zod": "^4.0.0" } }`, "3.5.0"),
-    ).toThrow('could not find dependencies["@mstar-harness/engine"]');
+  test("rewrites the engine spec to a prerelease range (^3.6.0-alpha.1)", () => {
+    const out = syncRootEngineSpec(manifest("workspace:*"), "3.6.0-alpha.1");
+    expect(out).toContain('"@mstar-harness/engine": "^3.6.0-alpha.1"');
+  });
+});
+
+describe("RELEASE_VERSION_RE / isPrereleaseVersion (shared release version contract)", () => {
+  test("accepts stable and prerelease versions", () => {
+    expect(RELEASE_VERSION_RE.test("3.6.0")).toBe(true);
+    expect(RELEASE_VERSION_RE.test("3.6.0-alpha.1")).toBe(true);
+  });
+
+  test("rejects malformed versions (short core, v-prefix, build metadata)", () => {
+    expect(RELEASE_VERSION_RE.test("3.6")).toBe(false);
+    expect(RELEASE_VERSION_RE.test("v3.6.0")).toBe(false);
+    expect(RELEASE_VERSION_RE.test("3.6.0-alpha.1+build")).toBe(false);
+  });
+
+  test("isPrereleaseVersion flags only versions with a suffix", () => {
+    expect(isPrereleaseVersion("3.6.0")).toBe(false);
+    expect(isPrereleaseVersion("3.6.0-alpha.1")).toBe(true);
+  });
+});
+
+describe("compareSemver (prerelease-aware, semver 2.0.0 §11)", () => {
+  test("prerelease sorts below the same core release", () => {
+    expect(compareSemver("3.6.0-alpha.1", "3.6.0")).toBeLessThan(0);
+  });
+
+  test("prerelease of a newer core outranks an older stable", () => {
+    expect(compareSemver("3.6.0-alpha.1", "3.5.9")).toBeGreaterThan(0);
+  });
+
+  test("numeric prerelease identifiers compare numerically", () => {
+    expect(compareSemver("3.6.0-alpha.1", "3.6.0-alpha.2")).toBeLessThan(0);
+    expect(compareSemver("3.6.0-alpha.10", "3.6.0-alpha.9")).toBeGreaterThan(0);
+  });
+
+  test("alphanumeric identifiers sort ASCII-lexically after numeric", () => {
+    expect(compareSemver("3.6.0-alpha.1", "3.6.0-beta")).toBeLessThan(0);
+  });
+
+  test("equal versions compare equal", () => {
+    expect(compareSemver("3.6.0", "3.6.0")).toBe(0);
   });
 });

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -92,6 +92,16 @@ describe("RELEASE_VERSION_RE / isPrereleaseVersion (shared release version contr
     expect(RELEASE_VERSION_RE.test("3.6.0-alpha.1+build")).toBe(false);
   });
 
+  test("rejects prerelease identifiers violating semver §9 grammar", () => {
+    expect(RELEASE_VERSION_RE.test("3.6.0-alpha..1")).toBe(false);
+    expect(RELEASE_VERSION_RE.test("3.6.0-alpha.01")).toBe(false);
+    expect(RELEASE_VERSION_RE.test("3.6.0-.alpha")).toBe(false);
+  });
+
+  test("accepts a bare numeric prerelease identifier", () => {
+    expect(RELEASE_VERSION_RE.test("3.6.0-0")).toBe(true);
+  });
+
   test("isPrereleaseVersion flags only versions with a suffix", () => {
     expect(isPrereleaseVersion("3.6.0")).toBe(false);
     expect(isPrereleaseVersion("3.6.0-alpha.1")).toBe(true);

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -1,7 +1,7 @@
 /**
  * scripts/prepare-release.ts — fragment `packages:` token validation.
  */
-import { parseFragment, syncRootEngineSpec, validateFragmentPackages } from "./prepare-release.ts";
+import { bumpVersion, parseFragment, syncRootEngineSpec, validateFragmentPackages } from "./prepare-release.ts";
 import { RELEASE_VERSION_RE, compareSemver, isPrereleaseVersion } from "./release-surfaces.ts";
 
 describe("validateFragmentPackages (release packages enum)", () => {
@@ -128,5 +128,20 @@ describe("compareSemver (prerelease-aware, semver 2.0.0 §11)", () => {
 
   test("equal versions compare equal", () => {
     expect(compareSemver("3.6.0", "3.6.0")).toBe(0);
+  });
+});
+
+describe("bumpVersion (auto-bump, prerelease graduation)", () => {
+  test("stable current bumps patch/minor as before", () => {
+    expect(bumpVersion("3.5.1", "patch")).toBe("3.5.2");
+    expect(bumpVersion("3.5.1", "minor")).toBe("3.6.0");
+  });
+
+  test("prerelease current graduates to the same-core stable on patch/default", () => {
+    expect(bumpVersion("3.6.0-alpha.1", "patch")).toBe("3.6.0");
+  });
+
+  test("prerelease current graduates to the next minor stable on minor", () => {
+    expect(bumpVersion("3.6.0-alpha.1", "minor")).toBe("3.7.0");
   });
 });

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -33,8 +33,10 @@ import { existsSync, mkdirSync, readdirSync, renameSync } from "node:fs";
 import {
   CHANGELOGS,
   INSTALL_REF,
+  RELEASE_VERSION_RE,
   VERSION_SURFACES,
   compareSemver,
+  isPrereleaseVersion,
 } from "./release-surfaces.ts";
 
 type Fragment = {
@@ -274,8 +276,8 @@ async function main(): Promise<void> {
   const version = explicit ?? bumpVersion(current, bump);
   const date = new Date().toISOString().slice(0, 10);
 
-  if (!/^\d+\.\d+\.\d+$/.test(version)) {
-    throw new Error(`Invalid version "${version}". Expected X.Y.Z.`);
+  if (!RELEASE_VERSION_RE.test(version)) {
+    throw new Error(`Invalid version "${version}". Expected X.Y.Z or X.Y.Z-<prerelease>.`);
   }
   if (compareSemver(version, current) <= 0) {
     throw new Error(`Version ${version} must be greater than current ${current}.`);
@@ -313,8 +315,12 @@ async function main(): Promise<void> {
     await Bun.write(rootPath, syncRootEngineSpec(text, version));
     console.log(`sync: ${rootPath} dependencies["@mstar-harness/engine"] -> ^${version}`);
   }
-  await bumpInstall(current, version);
-  console.log(`bump: ${INSTALL_REF.path}`);
+  if (isPrereleaseVersion(version)) {
+    console.log(`skip: ${INSTALL_REF.path} (prerelease — stays at last stable)`);
+  } else {
+    await bumpInstall(current, version);
+    console.log(`bump: ${INSTALL_REF.path}`);
+  }
 
   archiveFragments(version, frags);
 

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -75,8 +75,19 @@ function parseArgs(argv: string[]): { version?: string; bump: "patch" | "minor" 
   return { version, bump };
 }
 
-function bumpVersion(v: string, kind: "patch" | "minor"): string {
+/**
+ * Auto-bump the next version from a current version. A current version
+ * carrying a prerelease suffix graduates instead of bumping: `patch`/default
+ * returns the same-core stable (`3.6.0-alpha.1` -> `3.6.0`), `minor` returns
+ * the next minor stable (`3.7.0`). Stable inputs bump as before. Exported for
+ * tests.
+ */
+export function bumpVersion(v: string, kind: "patch" | "minor"): string {
   const [maj, min, pat] = v.split(".").map((n) => parseInt(n, 10));
+  if (isPrereleaseVersion(v)) {
+    if (kind === "minor") return `${maj}.${min + 1}.0`;
+    return `${maj}.${min}.${pat}`;
+  }
   if (kind === "minor") return `${maj}.${min + 1}.0`;
   return `${maj}.${min}.${pat + 1}`;
 }

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -232,14 +232,23 @@ async function bumpJsonVersion(path: string, oldV: string, newV: string): Promis
   await Bun.write(path, text.replace(re, `$1${newV}$2`));
 }
 
-async function bumpInstall(oldV: string, newV: string): Promise<void> {
+/**
+ * Bump the INSTALL.md marketplace example to `newV`. The old version is
+ * derived from INSTALL.md's own quoted `"version"` field — never from the
+ * release `current` — because after a prerelease the surfaces carry a
+ * suffixed version while INSTALL.md stays on the last stable; passing that
+ * suffixed `current` here would find no match and silently leave INSTALL.md
+ * stale (and `release:validate` would then hard-fail the stable release).
+ * Fails fast if the file or its version field is missing (validate would
+ * fail later anyway).
+ */
+async function bumpInstall(newV: string): Promise<void> {
   const text = await Bun.file(INSTALL_REF.path).text();
-  const re = new RegExp(`("version"\\s*:\\s*")${oldV.replace(/\./g, "\\.")}(")`);
-  if (!re.test(text)) {
-    console.warn(`warn: ${INSTALL_REF.path}: no quoted "version" field matching ${oldV} (skipped)`);
-    return;
+  const m = text.match(/"version"\s*:\s*"(\d+\.\d+\.\d+)"/);
+  if (!m) {
+    throw new Error(`${INSTALL_REF.path}: could not find quoted "version" field (expected X.Y.Z)`);
   }
-  await Bun.write(INSTALL_REF.path, text.replace(re, `$1${newV}$2`));
+  await Bun.write(INSTALL_REF.path, text.replace(m[0], `"version": "${newV}"`));
 }
 
 /**
@@ -318,7 +327,7 @@ async function main(): Promise<void> {
   if (isPrereleaseVersion(version)) {
     console.log(`skip: ${INSTALL_REF.path} (prerelease — stays at last stable)`);
   } else {
-    await bumpInstall(current, version);
+    await bumpInstall(version);
     console.log(`bump: ${INSTALL_REF.path}`);
   }
 

--- a/scripts/release-surfaces.ts
+++ b/scripts/release-surfaces.ts
@@ -49,8 +49,15 @@ export const INSTALL_REF = { path: "INSTALL.md" } as const;
  * Release version regex — `X.Y.Z` with an optional semver prerelease suffix
  * (`-alpha.1`). Anchored; no `+build` metadata support (not needed for
  * releases). Shared by prepare (version gate) and validate (tag gate).
+ *
+ * Prerelease identifiers follow semver 2.0.0 §9: dot-separated, each either
+ * a numeric identifier without leading zeros (`0` or `[1-9]\d*`) or an
+ * alphanumeric identifier containing at least one non-digit. Empty
+ * identifiers (`alpha..1`), leading-zero numerics (`alpha.01`), and
+ * identifiers starting with `.` (`-.alpha`) are rejected.
  */
-export const RELEASE_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+export const RELEASE_VERSION_RE =
+  /^\d+\.\d+\.\d+(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?$/;
 
 /** True iff the version carries a prerelease suffix (contains `-`). */
 export function isPrereleaseVersion(v: string): boolean {

--- a/scripts/release-surfaces.ts
+++ b/scripts/release-surfaces.ts
@@ -45,7 +45,34 @@ export const CHANGELOGS: readonly ChangelogTarget[] = [
 /** INSTALL.md ZCode marketplace example carries a quoted version field. */
 export const INSTALL_REF = { path: "INSTALL.md" } as const;
 
+/**
+ * Release version regex — `X.Y.Z` with an optional semver prerelease suffix
+ * (`-alpha.1`). Anchored; no `+build` metadata support (not needed for
+ * releases). Shared by prepare (version gate) and validate (tag gate).
+ */
+export const RELEASE_VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+/** True iff the version carries a prerelease suffix (contains `-`). */
+export function isPrereleaseVersion(v: string): boolean {
+  return v.includes("-");
+}
+
 export function compareSemver(a: string, b: string): number {
+  const [coreA, preA] = splitVersion(a);
+  const [coreB, preB] = splitVersion(b);
+  const coreDiff = compareCore(coreA, coreB);
+  if (coreDiff !== 0) return coreDiff;
+  return comparePrerelease(preA, preB);
+}
+
+/** Split `X.Y.Z[-pre]` into its core and optional prerelease parts. */
+function splitVersion(v: string): [string, string | undefined] {
+  const dash = v.indexOf("-");
+  if (dash === -1) return [v, undefined];
+  return [v.slice(0, dash), v.slice(dash + 1)];
+}
+
+function compareCore(a: string, b: string): number {
   const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
   const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
   for (let i = 0; i < 3; i++) {
@@ -53,6 +80,39 @@ export function compareSemver(a: string, b: string): number {
     if (d !== 0) return d;
   }
   return 0;
+}
+
+/**
+ * Semver 2.0.0 §11 prerelease precedence: identifiers compared left-to-right,
+ * numeric numerically, alphanumeric ASCII-lexically, numeric < alphanumeric,
+ * shorter identifier list < longer with the same prefix. A version without a
+ * prerelease outranks any prerelease of the same core.
+ */
+function comparePrerelease(a: string | undefined, b: string | undefined): number {
+  if (a === undefined && b === undefined) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  const ia = a.split(".");
+  const ib = b.split(".");
+  const n = Math.min(ia.length, ib.length);
+  for (let i = 0; i < n; i++) {
+    const d = compareIdentifier(ia[i], ib[i]);
+    if (d !== 0) return d;
+  }
+  return ia.length - ib.length;
+}
+
+function compareIdentifier(a: string, b: string): number {
+  const aNum = /^\d+$/.test(a);
+  const bNum = /^\d+$/.test(b);
+  if (aNum && bNum) {
+    const na = BigInt(a);
+    const nb = BigInt(b);
+    return na < nb ? -1 : na > nb ? 1 : 0;
+  }
+  if (aNum) return -1; // numeric identifiers sort before alphanumeric
+  if (bNum) return 1;
+  return a < b ? -1 : a > b ? 1 : 0; // ASCII lexicographic
 }
 
 // Release note: v2.0.0 first release attempt failed at install (engine runtime-dep 404);

--- a/scripts/validate-release-version.ts
+++ b/scripts/validate-release-version.ts
@@ -17,7 +17,7 @@
  * 0 MISSING / all-MISMATCH is the expected pre-release state, not a gate
  * failure.
  */
-import { INSTALL_REF, VERSION_SURFACES } from "./release-surfaces.ts";
+import { INSTALL_REF, RELEASE_VERSION_RE, VERSION_SURFACES, isPrereleaseVersion } from "./release-surfaces.ts";
 
 const tag = process.argv[2] ?? process.env.GITHUB_REF_NAME;
 
@@ -29,8 +29,8 @@ if (!tag) {
 
 const version = tag.startsWith("v") ? tag.slice(1) : tag;
 
-if (!/^\d+\.\d+\.\d+/.test(version)) {
-  console.error(`Invalid release tag "${tag}". Expected format: vX.Y.Z`);
+if (!RELEASE_VERSION_RE.test(version)) {
+  console.error(`Invalid release tag "${tag}". Expected format: vX.Y.Z or vX.Y.Z-<prerelease>`);
   process.exit(1);
 }
 
@@ -55,18 +55,21 @@ for (const { label, path } of VERSION_SURFACES) {
   }
 }
 
-// INSTALL.md is the 12th compared entry (11 VERSION_SURFACES + INSTALL.md):
-// its ZCode marketplace example must also reflect the release version.
-const install = await Bun.file(INSTALL_REF.path).text();
-const installMatch = install.match(installVersionRe);
-const installVersion = installMatch?.[1];
-if (installVersion !== version) {
-  console.error(
-    `MISMATCH INSTALL.md (${INSTALL_REF.path}): expected ${version}, found ${installVersion ?? "<missing>"}`,
-  );
-  failed = true;
+// Prereleases skip it — INSTALL.md stays on the last stable release.
+if (isPrereleaseVersion(version)) {
+  console.log(`SKIP INSTALL.md (prerelease)`);
 } else {
-  console.log(`OK INSTALL.md ZCode marketplace example: ${installVersion}`);
+  const install = await Bun.file(INSTALL_REF.path).text();
+  const installMatch = install.match(installVersionRe);
+  const installVersion = installMatch?.[1];
+  if (installVersion !== version) {
+    console.error(
+      `MISMATCH INSTALL.md (${INSTALL_REF.path}): expected ${version}, found ${installVersion ?? "<missing>"}`,
+    );
+    failed = true;
+  } else {
+    console.log(`OK INSTALL.md ZCode marketplace example: ${installVersion}`);
+  }
 }
 
 // The root manifest is what git/hosted installs (`omp plugin install


### PR DESCRIPTION
## Summary

Gives the PR-driven release flow a first-class prerelease line (`X.Y.Z-suffix`, e.g. `3.6.0-alpha.1`) — no manual surface editing, zero risk to the stable `latest` channel.

- `scripts/release-surfaces.ts`: shared `RELEASE_VERSION_RE` (anchored, optional semver prerelease suffix), `isPrereleaseVersion`, and `compareSemver` rewritten to full semver 2.0.0 §11 precedence (prerelease < none; numeric identifiers numerically via BigInt; alphanumeric ASCII-lexically; numeric < alphanumeric; shorter prefix < longer).
- `scripts/prepare-release.ts`: version gate uses the shared regex; prerelease targets skip the `INSTALL.md` bump (stays on last stable); root engine dep still syncs to `^<version>` including suffix.
- `scripts/validate-release-version.ts`: tag gate uses the anchored shared regex (was unanchored); INSTALL surface check skipped for prereleases; root dep check unchanged.
- `.github/workflows/release.yml`: new `Resolve npm dist-tag` step — prereleases publish under `--tag alpha` (never `latest`), stables under explicit `latest` (npm default, so stable behavior is unchanged); GitHub Release flagged `prerelease:` when the version contains `-`.
- `.github/workflows/release-prep.yml`: dispatch input now documents prerelease targets.
- `.changes/unreleased/release-prerelease-support.md`: bilingual fragment (consumed by the next `release:prepare`).
- `AGENTS.md`: Release Process gains a "Prereleases (alpha)" paragraph.

## Usage

```
bun run release:prepare -- 3.6.0-alpha.1
# open + merge PR titled "release v3.6.0-alpha.1"
# → npm publish --tag alpha · GitHub prerelease · INSTALL.md untouched
```

Stable `X.Y.Z` releases behave exactly as before.

## Verification

- `bun test scripts/prepare-release.test.ts` — 15 pass / 0 fail (six semver §11 ordering cases, regex accept/reject incl. `+build` rejection, prerelease root-spec sync).
- `bun run typecheck` — clean.
- End-to-end dry-run: `release:prepare -- 3.6.0-alpha.1` produced all 6 changelog sections + 12 surface bumps + root dep `^3.6.0-alpha.1` with `INSTALL.md` untouched; `release:validate -- v3.6.0-alpha.1` exit 0 (12 OK + `SKIP INSTALL.md`) on the prepared state, exit 1 with 0 MISSING on the unprepared state (pre-bump D7 semantics preserved). Mutations reverted; tree clean.

## Review

Single-seat L3 review: **Approve** (0 Critical / 0 Warning / 3 informational suggestions — parseArgs prefix regex defense-in-depth, §10 leading-zero tolerance out of scope, same-core alpha rejection is intended §11 behavior).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automated npm publish dist-tags and release gating; mis-tagging could affect what consumers resolve from npm, though prereleases are explicitly isolated from `latest`.
> 
> **Overview**
> **Adds first-class prerelease lines** (`X.Y.Z-suffix`, e.g. `3.6.0-alpha.1`) to the existing PR-driven release flow without changing stable `X.Y.Z` behavior.
> 
> Shared release contract in `release-surfaces.ts`: anchored `RELEASE_VERSION_RE`, `isPrereleaseVersion`, and **semver 2.0.0 §11** `compareSemver` (prerelease ordering, numeric identifiers). `prepare-release` and `validate-release-version` use that regex; **prereleases skip the `INSTALL.md` marketplace version bump/check** so install docs stay on the last stable release. Root `package.json` still syncs `@mstar-harness/engine` to `^<version>` including prerelease suffixes.
> 
> The **Release** workflow resolves an npm dist-tag (`alpha` when the version contains `-`, otherwise `latest`) and passes `--tag` on all workspace publishes; GitHub Releases are marked **prerelease** when appropriate. Release prep workflow input text and `AGENTS.md` document the alpha flow. Tests cover regex, semver ordering, and prerelease engine spec sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74582a28fa6cae98956a0d0acda1bdb6c47d1883. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->