### PR TITLE
feat(cli): codex repo-bundled marketplace install

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "mstar-repo",
+  "interface": {
+    "displayName": "Morning Star"
+  },
+  "plugins": [
+    {
+      "name": "morning-star-harness",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.changes/unreleased/codex-repo-marketplace.md
+++ b/.changes/unreleased/codex-repo-marketplace.md
@@ -1,0 +1,8 @@
+---
+category: CLI
+packages: root, cli
+---
+- Codex installs now use a repo-bundled marketplace: the harness repo ships `.agents/plugins/marketplace.json` (name `mstar-repo`, plugin root = repo root), and `npx @mstar-harness/cli init --target codex` registers it via `codex plugin marketplace add btspoony/mstar-harness --ref main`. Install with `codex plugin add morning-star-harness@mstar-repo`; refresh snapshots with `codex plugin marketplace upgrade`. `doctor --target codex` validates the marketplace registration via the codex CLI and reports legacy `personal` marketplace entries as a migration note; Codex custom-agent `.toml` symlinks continue to come from the shared `~/.mstar/harness` checkout.
+
+<!-- CN -->
+- Codex 安装改为仓库自带 marketplace：仓库新增 `.agents/plugins/marketplace.json`（marketplace 名 `mstar-repo`，插件根 = 仓库根），`npx @mstar-harness/cli init --target codex` 通过 `codex plugin marketplace add btspoony/mstar-harness --ref main` 注册 git marketplace（本地条目路径由 `~/.agents/plugins/marketplace.json` 迁移到仓库 marketplace）。安装命令为 `codex plugin add morning-star-harness@mstar-repo`；`codex plugin marketplace upgrade` 可刷新快照。`doctor --target codex` 通过 codex CLI 校验 marketplace 注册，旧 `personal` 条目以迁移提示展示；Codex 自定义 agent `.toml` 软链接仍来自共享 `~/.mstar/harness` checkout。

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,20 +66,29 @@ Restart Cursor or run **Developer: Reload Window** after install.
 
 ### Codex
 
-Global marketplace + custom agents:
+The harness repo ships its own Codex marketplace catalog at `.agents/plugins/marketplace.json` (marketplace name `mstar-repo`, plugin root = repo root). `init --target codex` registers that repo as a git marketplace under the `mstar-repo` name:
+
+Global (custom agents linked from `~/.mstar/harness`):
 
 ```bash
 npx @mstar-harness/cli init --target codex --scope global
-codex plugin add morning-star-harness --marketplace personal
+codex plugin add morning-star-harness@mstar-repo
 npx @mstar-harness/cli doctor --target codex
 ```
 
-Project marketplace + custom agents:
+Project (iteration commands additionally linked under `.agents/skills/`):
 
 ```bash
 npx @mstar-harness/cli init --target codex --scope project
-codex plugin add morning-star-harness --marketplace personal
+codex plugin add morning-star-harness@mstar-repo
 npx @mstar-harness/cli doctor --target codex --scope project
+```
+
+Without the CLI (direct marketplace registration):
+
+```bash
+codex plugin marketplace add btspoony/mstar-harness --ref main
+codex plugin add morning-star-harness@mstar-repo
 ```
 
 #### Codex: project vs global scope
@@ -236,44 +245,22 @@ npx @mstar-harness/cli init --target cursor --scope global
 
 ### Codex
 
-Personal marketplace (without the CLI):
+Register the repo marketplace directly:
+
+```bash
+codex plugin marketplace add btspoony/mstar-harness --ref main
+codex plugin add morning-star-harness@mstar-repo
+```
+
+Link custom agents (Codex discovers agents from `~/.codex/agents/`):
 
 ```bash
 git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness
-```
-
-Create or update `~/.agents/plugins/marketplace.json`:
-
-```json
-{
-  "name": "personal",
-  "interface": {
-    "displayName": "Personal"
-  },
-  "plugins": [
-    {
-      "name": "morning-star-harness",
-      "source": {
-        "source": "local",
-        "path": "./.mstar/harness"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "Productivity"
-    }
-  ]
-}
-```
-
-Install and link agents:
-
-```bash
-codex plugin add morning-star-harness --marketplace personal
 mkdir -p ~/.codex/agents
 ln -s ~/.mstar/harness/codex/agents/*.toml ~/.codex/agents/
 ```
+
+Migrating from the legacy personal marketplace: remove the `morning-star-harness` entry from `~/.agents/plugins/marketplace.json`, then install from the repo marketplace (`codex plugin remove morning-star-harness@personal` if previously installed).
 
 Codex plugin source in this repository:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Release notes: [CHANGELOG.md](CHANGELOG.md) / [CHANGELOG_CN.md](CHANGELOG_CN.md)
 | Cursor | `npx @mstar-harness/cli init --target cursor` |
 | Kimi | Kimi TUI: `/plugins install https://github.com/btspoony/mstar-harness`<br>→ `/plugins reload` |
 | ZCode | `npx @mstar-harness/cli init --target zcode`<br>then install **morning-star-harness** in ZCode → Settings → Plugin Management |
-| Codex | `npx @mstar-harness/cli init --target codex`<br>then `codex plugin add morning-star-harness --marketplace personal` |
+| Codex | `npx @mstar-harness/cli init --target codex`<br>then `codex plugin add morning-star-harness@mstar-repo` (repo-bundled marketplace) |
 | Generic (Agent Plugins v1) | point any Agent Plugins v1.0.0 conformant client at this repo root<br>(`plugin.json` + `skills/` are the portable package) |
 
 ### Engine gate checks (Recommended)

--- a/README_CN.md
+++ b/README_CN.md
@@ -53,7 +53,7 @@ Harness Workflow Engine · Agent Plugin
 | Cursor | `npx @mstar-harness/cli init --target cursor` |
 | Kimi | Kimi TUI：`/plugins install https://github.com/btspoony/mstar-harness`<br>→ `/plugins reload` |
 | ZCode | `npx @mstar-harness/cli init --target zcode`<br>然后在 ZCode → 设置 → 插件管理安装 **morning-star-harness** |
-| Codex | `npx @mstar-harness/cli init --target codex`<br>然后 `codex plugin add morning-star-harness --marketplace personal` |
+| Codex | `npx @mstar-harness/cli init --target codex`<br>然后 `codex plugin add morning-star-harness@mstar-repo`（仓库自带 marketplace） |
 | Generic（Agent Plugins v1） | 任意 Agent Plugins v1.0.0 兼容客户端直接指向本仓库根<br>（`plugin.json` + `skills/` 即便携包） |
 
 ### 引擎门禁校验（推荐）

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,15 +38,17 @@ Optional advanced: pass `--pm-model` / `--*-models` flags to write explicit `age
 
 ### Codex
 
-1) Add Morning Star to the Codex marketplace metadata and link Codex custom agents. The CLI maintains `~/.mstar/harness`:
+The harness repo ships its own marketplace catalog at `.agents/plugins/marketplace.json` (name `mstar-repo`). The CLI registers the repo as a Codex git marketplace and links Codex custom agents from the maintained `~/.mstar/harness` checkout:
+
+1) Register the repo marketplace + link agents:
 
 - `npx @mstar-harness/cli init --target codex --scope global`
 
 2) Install from that marketplace:
 
-- `codex plugin add morning-star-harness --marketplace personal`
+- `codex plugin add morning-star-harness@mstar-repo`
 
-3) Verify marketplace metadata and agent symlinks:
+3) Verify the marketplace registration and agent symlinks:
 
 - `npx @mstar-harness/cli doctor --target codex`
 
@@ -123,12 +125,12 @@ Cursor install:
 
 Codex install:
 
-- Global personal marketplace + custom agents:
-  - `npx @mstar-harness/cli init --target codex --scope global`
-- Project marketplace + custom agents:
-  - `npx @mstar-harness/cli init --target codex --scope project`
+- Repo-bundled marketplace (`.agents/plugins/marketplace.json`, name `mstar-repo`) — `init` registers it once via `codex plugin marketplace add https://github.com/btspoony/mstar-harness.git --ref main` (idempotent; refresh snapshots with `codex plugin marketplace upgrade`):
+  - Global: `npx @mstar-harness/cli init --target codex --scope global`
+  - Project: `npx @mstar-harness/cli init --target codex --scope project`
 - Then install the plugin:
-  - `codex plugin add morning-star-harness --marketplace personal`
+  - `codex plugin add morning-star-harness@mstar-repo`
+- A pre-existing legacy `personal` marketplace entry is surfaced as a `doctor` note with migration steps (remove the entry, install from `mstar-repo`).
 - Runtime host behavior after install:
   - `/pm` enters the shared PM flow.
   - Codex custom agents are linked from `~/.mstar/harness/codex/agents/*.toml`.
@@ -407,15 +409,12 @@ Cursor `init`:
 - global: `git clone` / `git pull` at `~/.cursor/plugins/local/morning-star-harness`
 - project: `git clone` / `git pull` at `.cursor/plugins/morning-star-harness`, `.gitignore` entry for the plugin directory, and harness **process** gitignore entries for `.mstar/` and legacy `.agents/` (`archived/`, `iterations/`, `plans/`, `sdd/`, `notes.json`, `status.json`). Harness **results** (`knowledge/`, `specs/`, `AGENTS.md`) are not added automatically.
 
-Codex `init` writes or updates marketplace metadata with a local-source entry:
+Codex `init` registers the repo-bundled Codex marketplace (probed on codex-cli 0.144.1; requires the `codex` CLI on PATH):
 
-- `name`: `morning-star-harness`
-- `source.source`: `local`
-- `source.path`: `./.mstar/harness` for global scope, `./.codex/plugins/mstar-harness` for project scope
-- `policy.installation`: `AVAILABLE`
-- `policy.authentication`: `ON_INSTALL`
+- `codex plugin marketplace add https://github.com/btspoony/mstar-harness.git --ref main` — idempotent (an already-registered marketplace is skipped)
+- the marketplace catalog is the repo's own `.agents/plugins/marketplace.json` (name `mstar-repo`, plugin root = repo root, `source.path: "./"`)
 
-Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope also links `.codex/plugins/mstar-harness -> ~/.mstar/harness`, adds `.codex/plugins/mstar-harness` plus `.codex/agents/*.toml` to `.gitignore`, appends the same harness **process** gitignore set as Cursor project `init` (see above), and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
+Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope appends the same harness **process** gitignore set as Cursor project `init` (see above) and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
 
 dsh `init` runs the two `dsh plugin --profile web add` calls (`@mstar-harness/dsh` then `dsh-llm-fallbacks`) in the fixed `web` profile — idempotent (already-installed rows skipped), fail-loud when the `dsh` binary is missing, and `--no-fallbacks` skips the fallbacks row.
 
@@ -425,7 +424,7 @@ dsh `init` runs the two `dsh plugin --profile web add` calls (`@mstar-harness/ds
 - Missing per-role `agent.<role>.model` is a **yellow recommendation** only (OpenCode defaults are OK).
 - If only legacy git is present, or legacy and npm are both listed, `doctor` prints **yellow recommendations** and still exits 0; run `init` to normalize to `@mstar-harness/opencode@latest`.
 - For Cursor, `doctor` checks the maintained `~/.mstar/harness` checkout, that the Cursor plugin path is a **real git directory** (not a symlink), that `agents/*.md` files use Cursor-first frontmatter, and (project scope) all harness **process** `.gitignore` entries listed under Cursor `init`.
-- For Codex, `doctor` checks the local marketplace entry, the maintained `~/.mstar/harness` checkout, and custom-agent symlinks. Project scope also validates iteration skill symlinks under `.agents/skills/` and harness **process** `.gitignore` entries.
+- For Codex, `doctor` checks that the `mstar-repo` marketplace is registered (via `codex plugin marketplace list`), the maintained `~/.mstar/harness` checkout, and custom-agent symlinks. A legacy personal-marketplace entry for this plugin in `~/.agents/plugins/marketplace.json` is reported as a migration note. Project scope also validates iteration skill symlinks under `.agents/skills/` and harness **process** `.gitignore` entries.
 
 ## Install path layout
 
@@ -433,7 +432,7 @@ Cursor **does not discover symlinked plugin directories**. Use real directories 
 
 | Path | Host | Layout | Notes |
 | --- | --- | --- | --- |
-| `~/.mstar/harness` | Codex (marketplace `local` source), OpenCode dev bundle | git checkout | Codex agent `.toml` files are **symlinked** from here into `~/.codex/agents/` |
+| `~/.mstar/harness` | Codex (agent `.toml` source), OpenCode dev bundle | git checkout | Codex agent `.toml` files are **symlinked** from here into `~/.codex/agents/`; the Codex marketplace itself is git-sourced (`btspoony/mstar-harness`) |
 | `~/.cursor/plugins/local/morning-star-harness` | Cursor global plugin | **git checkout (real dir)** | **Not** a symlink to `~/.mstar/harness`; `init` clones or `git pull`s here |
 | `.cursor/plugins/morning-star-harness` | Cursor project plugin | **git checkout (real dir)** | gitignored; same clone/pull behavior as global |
 

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -2,11 +2,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AgentAdapter, Scope } from "../types";
-import { ensureObject, readJson, writeJson } from "../utils";
 import { resolveProjectRoot } from "../utils";
+import { runCliCommand } from "../exec";
 import {
   HARNESS_REPO_PATH,
   PLUGIN_NAME,
+  REPO_URL,
   ensureLocalHarnessRepo,
   ensureSymlink,
   validateLocalHarnessRepo,
@@ -14,14 +15,45 @@ import {
   appendGitignore,
   appendHarnessProjectGitignore,
   missingHarnessProcessGitignoreEntries,
-  homeRelativeSourcePath,
 } from "./shared-install";
 
-const MARKETPLACE_NAME = "personal";
-const MARKETPLACE_DISPLAY_NAME = "Personal";
-const GLOBAL_MARKETPLACE_PATH = path.join(os.homedir(), ".agents", "plugins", "marketplace.json");
-const PLUGIN_CATEGORY = "Productivity";
-const CODEX_PLUGIN_LINK = ".codex/plugins/mstar-harness";
+/**
+ * Codex install flow (repo-marketplace, probed 2026-08-31 on codex-cli 0.144.1):
+ *
+ * The harness repo ships its own marketplace catalog at
+ * `.agents/plugins/marketplace.json` (repo root = marketplace root; the plugin
+ * root is the repo root, so the single entry points at `source.path: "./"`).
+ * Codex does NOT implicitly discover repo marketplaces from the CWD — the
+ * marketplace must be registered once via `codex plugin marketplace add`.
+ * Git-sourced marketplaces are cloned by codex into its own snapshot cache
+ * (`marketplace upgrade` refreshes), so users no longer need a personal
+ * `~/.agents/plugins/marketplace.json` or a CLI-maintained checkout for the
+ * marketplace itself.
+ *
+ * - init: probe for the codex CLI, then `codex plugin marketplace add
+ *   <owner/repo> --ref main` (idempotent — an already-added marketplace is a
+ *   no-op). Custom-agent symlinks still come from the shared local checkout at
+ *   `~/.mstar/harness` (codex only discovers agents from `~/.codex/agents/`,
+ *   not from plugin packages).
+ * - doctor: validate the local checkout + agent symlinks (as before), then
+ *   check the marketplace is registered and the plugin resolvable via
+ *   `codex plugin marketplace list --json` / `codex plugin list --json`.
+ *   The repo-bundled `.agents/plugins/marketplace.json` is a release asset of
+ *   the harness repo itself; the CLI does not validate its entry shape.
+ * - Legacy `~/.agents/plugins/marketplace.json` entries (pre-3.7 "personal"
+ *   marketplace) surface as doctor notes, not errors.
+ */
+
+const CODEX_BIN = "codex";
+const CODEX_LOCAL_TIMEOUT_MS = 10_000;
+const CODEX_MARKETPLACE_TIMEOUT_MS = 300_000;
+/** GitHub shorthand accepted by `codex plugin marketplace add <SOURCE>`. */
+const MARKETPLACE_GIT_SOURCE = "btspoony/mstar-harness";
+/** Marketplace name = upstream repo's bundled `.agents/plugins/marketplace.json` `name`. */
+export const MARKETPLACE_NAME = "mstar-repo";
+const CODEX_INSTALL_HINT =
+  "Install the Codex CLI (https://github.com/openai/codex), e.g. `npm install -g @openai/codex`, then re-run init.";
+
 const CODEX_AGENT_NAMES = [
   "product-manager",
   "architect",
@@ -48,25 +80,75 @@ const CODEX_PROJECT_COMMAND_NAMES = [
 const GLOBAL_ITERATION_SKILLS_WARNING =
   "Codex project-scoped commands (iteration-start / iteration-drive / iteration-loop / codebase-audit / amazing-pr-review) are installed as project-local skills under .agents/skills/ only. Global install skips them to avoid polluting other code agents. Re-run with --scope project to enable.";
 
-type MarketplaceEntry = {
-  name: string;
-  source: {
-    source: "local";
-    path: string;
-  };
-  policy: {
-    installation: "AVAILABLE";
-    authentication: "ON_INSTALL";
-  };
-  category: string;
-};
-
-function globalMarketplacePath() {
-  return GLOBAL_MARKETPLACE_PATH;
+/** Run codex with args; dry-run never spawns a subprocess. env is spread so
+ * the binary resolves from PATH (same contract as the dsh adapter). */
+function runCodex(args: string[], dryRun: boolean, timeoutMs: number): string {
+  return runCliCommand([CODEX_BIN, ...args], { dryRun, timeoutMs, env: process.env });
 }
 
-function projectMarketplacePath() {
-  return path.join(resolveProjectRoot(), ".agents", "plugins", "marketplace.json");
+function codexAvailable(): boolean {
+  try {
+    runCodex(["--version"], false, CODEX_LOCAL_TIMEOUT_MS);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Parse `codex plugin marketplace list --json` → marketplace names. */
+function configuredMarketplaceNames(dryRun: boolean): string[] {
+  if (dryRun) return [];
+  const dump = runCodex(["plugin", "marketplace", "list", "--json"], false, CODEX_LOCAL_TIMEOUT_MS);
+  const parsed = JSON.parse(dump) as {
+    marketplaces?: Array<{ name?: unknown }>;
+  };
+  const list = Array.isArray(parsed.marketplaces) ? parsed.marketplaces : [];
+  return list
+    .map((entry) => (entry && typeof entry.name === "string" ? entry.name : ""))
+    .filter((name) => name !== "");
+}
+
+/** Parse `codex plugin list --json` → installed plugin ids (`name@marketplace`). */
+function installedPluginIds(dryRun: boolean): string[] {
+  if (dryRun) return [];
+  const dump = runCodex(["plugin", "list", "--json"], false, CODEX_LOCAL_TIMEOUT_MS);
+  const parsed = JSON.parse(dump) as {
+    installed?: Array<{ pluginId?: unknown }>;
+  };
+  const list = Array.isArray(parsed.installed) ? parsed.installed : [];
+  return list
+    .map((entry) => (entry && typeof entry.pluginId === "string" ? entry.pluginId : ""))
+    .filter((pluginId) => pluginId !== "");
+}
+
+/**
+ * Read the legacy personal marketplace (`~/.agents/plugins/marketplace.json`),
+ * if it exists, and surface a migration note when it still carries a harness
+ * entry. Never throws — the file is user-owned and optional post-cutover.
+ */
+function legacyPersonalMarketplaceNote(): string | null {
+  const legacyPath = path.join(os.homedir(), ".agents", "plugins", "marketplace.json");
+  let raw: string;
+  try {
+    raw = fs.readFileSync(legacyPath, "utf8");
+  } catch {
+    // Absent or unreadable: the legacy file is user-owned and optional.
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { plugins?: unknown };
+    const plugins = Array.isArray(parsed.plugins) ? parsed.plugins : [];
+    const hasMstar = plugins.some(
+      (entry) =>
+        entry !== null && typeof entry === "object" && !Array.isArray(entry) && "name" in entry && entry.name === PLUGIN_NAME,
+    );
+    if (hasMstar) {
+      return `Legacy personal marketplace entry found at ${legacyPath} \u2014 the ${PLUGIN_NAME} plugin now installs from the repo marketplace (${MARKETPLACE_GIT_SOURCE}). Remove the entry, then install: codex plugin add ${PLUGIN_NAME}@${MARKETPLACE_NAME}`;
+    }
+  } catch {
+    // Unparseable user config: leave it alone.
+  }
+  return null;
 }
 
 function agentSourcePath(agentName: string) {
@@ -79,90 +161,6 @@ function globalAgentLinkPath(agentName: string) {
 
 function projectAgentLinkPath(agentName: string) {
   return path.join(resolveProjectRoot(), ".codex", "agents", `${agentName}.toml`);
-}
-
-function mstarEntry(scope: Scope): MarketplaceEntry {
-  const sourcePath =
-    scope === "global"
-      ? homeRelativeSourcePath(HARNESS_REPO_PATH)
-      : `./${CODEX_PLUGIN_LINK}`;
-  return {
-    name: PLUGIN_NAME,
-    source: {
-      source: "local",
-      path: sourcePath,
-    },
-    policy: {
-      installation: "AVAILABLE",
-      authentication: "ON_INSTALL",
-    },
-    category: PLUGIN_CATEGORY,
-  };
-}
-
-function normalizeMarketplace(raw: Record<string, unknown>) {
-  const next = ensureObject(raw);
-  next.name = MARKETPLACE_NAME;
-  const iface = ensureObject(next.interface);
-  if (typeof iface.displayName !== "string" || !iface.displayName.trim()) {
-    iface.displayName = MARKETPLACE_DISPLAY_NAME;
-  }
-  next.interface = iface;
-  if (!Array.isArray(next.plugins)) {
-    next.plugins = [];
-  }
-  return next;
-}
-
-function upsertEntry(raw: Record<string, unknown>, scope: Scope) {
-  const next = normalizeMarketplace(raw);
-  const plugins = (next.plugins as unknown[]).filter((entry) => {
-    return !(
-      entry &&
-      typeof entry === "object" &&
-      !Array.isArray(entry) &&
-      (entry as { name?: unknown }).name === PLUGIN_NAME
-    );
-  });
-  plugins.push(mstarEntry(scope));
-  next.plugins = plugins;
-  return next;
-}
-
-function findEntry(raw: Record<string, unknown>) {
-  const plugins = Array.isArray(raw.plugins) ? raw.plugins : [];
-  return plugins.find((entry) => {
-    return (
-      entry &&
-      typeof entry === "object" &&
-      !Array.isArray(entry) &&
-      (entry as { name?: unknown }).name === PLUGIN_NAME
-    );
-  }) as Record<string, unknown> | undefined;
-}
-
-function validateEntryShape(entry: Record<string, unknown> | undefined, scope: Scope, marketplacePath: string) {
-  const errors: string[] = [];
-  if (!entry) {
-    errors.push(`Missing ${PLUGIN_NAME} entry in ${marketplacePath}.`);
-    return errors;
-  }
-  const source = ensureObject(entry.source);
-  const expectedSourcePath = mstarEntry(scope).source.path;
-  if (source.source !== "local") errors.push("Codex marketplace entry source.source must be `local`.");
-  if (source.path !== expectedSourcePath) {
-    errors.push(`Codex marketplace entry source.path must be ${expectedSourcePath}.`);
-  }
-  const policy = ensureObject(entry.policy);
-  if (policy.installation !== "AVAILABLE") errors.push("Codex marketplace entry policy.installation must be AVAILABLE.");
-  if (policy.authentication !== "ON_INSTALL") errors.push("Codex marketplace entry policy.authentication must be ON_INSTALL.");
-  if (entry.category !== PLUGIN_CATEGORY) errors.push(`Codex marketplace entry category must be ${PLUGIN_CATEGORY}.`);
-  return errors;
-}
-
-function marketplacePath(scope: Scope) {
-  if (scope === "global") return globalMarketplacePath();
-  return projectMarketplacePath();
 }
 
 function ensureAgentLinks(scope: Scope, dryRun: boolean) {
@@ -230,57 +228,88 @@ function validateIterationSkillLinks() {
 }
 
 function runInit(scope: Scope, dryRun: boolean) {
-  const pathToMarketplace = marketplacePath(scope);
-  const current = readJson(pathToMarketplace);
-  const next = upsertEntry(current, scope);
-  const existingEntry = findEntry(current);
-  const notes = ensureLocalHarnessRepo(dryRun);
+  const notes: string[] = [];
+
+  // The shared local checkout stays: codex agent .toml symlinks (and the Cursor
+  // / omp adapters) materialize from it.
+  notes.push(...ensureLocalHarnessRepo(dryRun));
+
+  const marketplaceArgs = ["plugin", "marketplace", "add", REPO_URL, "--ref", "main"];
+  if (dryRun) {
+    notes.push(`Would run: ${CODEX_BIN} ${marketplaceArgs.join(" ")}`);
+  } else {
+    if (!codexAvailable()) {
+      throw new Error(`${CODEX_BIN} CLI not found on PATH. ${CODEX_INSTALL_HINT}`);
+    }
+    // Idempotent: re-adding an already-configured marketplace is a no-op
+    // (verified locally — output carries alreadyAdded=true, exit 0).
+    try {
+      const already = configuredMarketplaceNames(false).includes(MARKETPLACE_NAME);
+      if (already) {
+        notes.push(`Marketplace ${MARKETPLACE_NAME} already configured.`);
+      } else {
+        runCodex(marketplaceArgs, false, CODEX_MARKETPLACE_TIMEOUT_MS);
+        notes.push(`Added marketplace ${MARKETPLACE_NAME} from ${REPO_URL} (ref main).`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to add marketplace via ${CODEX_BIN}: ${message}`);
+    }
+    notes.push(`Next: codex plugin add ${PLUGIN_NAME}@${MARKETPLACE_NAME}`);
+  }
+
   if (scope === "project") {
     const projectRoot = resolveProjectRoot();
-    notes.push(ensureSymlink(HARNESS_REPO_PATH, path.join(projectRoot, CODEX_PLUGIN_LINK), dryRun));
-    notes.push(...appendGitignore(projectRoot, [CODEX_PLUGIN_LINK, ".codex/agents/*.toml"], dryRun));
+    notes.push(...appendGitignore(projectRoot, [".codex/agents/*.toml"], dryRun));
     notes.push(...appendHarnessProjectGitignore(projectRoot, dryRun));
     notes.push(...ensureIterationSkillLinks(dryRun));
   } else {
     notes.push(GLOBAL_ITERATION_SKILLS_WARNING);
   }
   notes.push(...ensureAgentLinks(scope, dryRun));
-  if (!dryRun) writeJson(pathToMarketplace, next);
-  notes.push(existingEntry ? `Updated ${PLUGIN_NAME} local marketplace entry.` : `Added ${PLUGIN_NAME} local marketplace entry.`);
-  notes.push(`Source path: ${mstarEntry(scope).source.path}`);
-  notes.push(`Install after init: codex plugin add ${PLUGIN_NAME} --marketplace ${MARKETPLACE_NAME}`);
+
   return {
-    location: pathToMarketplace,
+    location: `${CODEX_BIN} marketplaces (config.toml)`,
     notes,
   };
 }
 
 function runDoctor(scope: Scope) {
-  const pathToMarketplace = marketplacePath(scope);
   const errors = validateLocalHarnessRepo();
-  if (!fs.existsSync(pathToMarketplace)) {
-    return { location: pathToMarketplace, errors: [...errors, `Missing Codex marketplace: ${pathToMarketplace}`] };
+  const notes: string[] = [];
+  const legacyNote = legacyPersonalMarketplaceNote();
+  if (legacyNote) notes.push(legacyNote);
+
+  if (!codexAvailable()) {
+    errors.push(`${CODEX_BIN} CLI not found on PATH. ${CODEX_INSTALL_HINT}`);
+    return { location: `${CODEX_BIN} marketplaces (config.toml)`, errors, notes };
   }
-  const marketplace = readJson(pathToMarketplace);
-  if (marketplace.name !== MARKETPLACE_NAME) {
-    errors.push(`Codex personal marketplace name must be ${MARKETPLACE_NAME}.`);
+  try {
+    const marketplaces = configuredMarketplaceNames(false);
+    if (!marketplaces.includes(MARKETPLACE_NAME)) {
+      errors.push(`Marketplace ${MARKETPLACE_NAME} not configured (run init, or: ${CODEX_BIN} plugin marketplace add ${REPO_URL} --ref main).`);
+    }
+    const installed = installedPluginIds(false);
+    const pluginId = `${PLUGIN_NAME}@${MARKETPLACE_NAME}`;
+    if (marketplaces.includes(MARKETPLACE_NAME) && !installed.includes(pluginId)) {
+      notes.push(`Plugin not installed yet: ${CODEX_BIN} plugin add ${pluginId}`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    errors.push(`Could not query ${CODEX_BIN} plugin marketplace list: ${message}`);
   }
-  errors.push(...validateEntryShape(findEntry(marketplace), scope, pathToMarketplace));
+
   if (scope === "project") {
     const projectRoot = resolveProjectRoot();
-    errors.push(...validateSymlink(HARNESS_REPO_PATH, path.join(projectRoot, CODEX_PLUGIN_LINK)));
     const gitignorePath = path.join(projectRoot, ".gitignore");
     const gitignore = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
-    const lines = gitignore.split(/\r?\n/);
-    if (!lines.includes(CODEX_PLUGIN_LINK)) errors.push(`Missing .gitignore entry: ${CODEX_PLUGIN_LINK}`);
-    if (!lines.includes(".codex/agents/*.toml")) errors.push("Missing .gitignore entry: .codex/agents/*.toml");
     for (const entry of missingHarnessProcessGitignoreEntries(gitignore)) {
       errors.push(`Missing .gitignore entry: ${entry}`);
     }
     errors.push(...validateIterationSkillLinks());
   }
   errors.push(...validateAgentLinks(scope));
-  return { location: pathToMarketplace, errors };
+  return { location: `${CODEX_BIN} marketplaces (config.toml)`, errors, notes };
 }
 
 export const codexAdapter: AgentAdapter = {


### PR DESCRIPTION
## Summary

Codex installs now use a **repo-bundled marketplace** instead of a CLI-maintained personal `~/.agents/plugins/marketplace.json`.

- New `.agents/plugins/marketplace.json` (name `mstar-repo`, plugin root = repo root, `source.path: "./"`) — the harness repo is its own Codex marketplace.
- `init --target codex` registers it via `codex plugin marketplace add https://github.com/btspoony/mstar-harness.git --ref main` (idempotent; requires the `codex` CLI on PATH, fail-loud with install hint when absent). No more writing/validating personal marketplace JSON.
- `doctor --target codex` validates the registration via `codex plugin marketplace list --json` / `codex plugin list --json`; a legacy `personal` entry in `~/.agents/plugins/marketplace.json` is reported as a migration note, not an error.
- Codex custom-agent `.toml` symlinks still come from the shared `~/.mstar/harness` checkout (Codex discovers agents from `~/.codex/agents/`, not from plugin packages).
- Install command: `codex plugin add morning-star-harness@mstar-repo`; refresh snapshots with `codex plugin marketplace upgrade`.
- Docs updated (INSTALL.md, README.md/README_CN.md, docs/cli.md) + changelog fragment.

## Verification

- Probed on codex-cli 0.144.1: `codex plugin marketplace add <repo>` accepts local path, `owner/repo`, and full `.git` URL + `--ref`; marketplace name resolves from the repo's `.agents/plugins/marketplace.json`; `codex plugin add morning-star-harness@mstar-repo` installs (version read from `.codex-plugin/plugin.json`).
- Fresh-clone → register → install end-to-end verified (local path + git URL forms).
- `init --target codex` (global/project/dry-run) + `doctor` smoke passed; `bun test` in packages/cli: 495 pass / 0 fail; `release:validate` all surfaces aligned.

## Release ordering note

The git-sourced marketplace clones the **remote** repo, so `init --target codex` only succeeds once this file lands on `main`. Old CLI versions keep working via the legacy personal flow — no breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Codex install contract (external CLI dependency, git marketplace on `main`) and drops project-local plugin checkout symlinks; existing personal-marketplace users need migration.
> 
> **Overview**
> Codex installation moves from a CLI-maintained **personal** `~/.agents/plugins/marketplace.json` (local checkout paths) to a **repo-bundled** catalog at `.agents/plugins/marketplace.json` (`mstar-repo`, plugin root = repo root).
> 
> **`init --target codex`** now requires the `codex` CLI and idempotently runs `codex plugin marketplace add` for the harness git repo (`--ref main`) instead of writing or patching marketplace JSON. Users install with `codex plugin add morning-star-harness@mstar-repo`. **Project scope** no longer symlinks `.codex/plugins/mstar-harness` or gitignores that path; iteration skills and agent `.toml` symlinks from `~/.mstar/harness` are unchanged.
> 
> **`doctor --target codex`** checks marketplace registration and optional plugin install via `codex plugin marketplace list` / `codex plugin list` JSON output, and surfaces legacy personal-marketplace entries as migration notes rather than hard failures.
> 
> INSTALL/README/docs and an unreleased changelog fragment document the new flow, manual `codex plugin marketplace add`, and migration off `personal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533196174a220e5bfb67795b8ec00b14cbb46265. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->