### PR TITLE
docs(dsh): document headless profile support and background-handle caveats

### DIFF
--- a/.changes/unreleased/dsh-headless-profile-docs.md
+++ b/.changes/unreleased/dsh-headless-profile-docs.md
@@ -1,0 +1,7 @@
+---
+packages: dsh
+---
+- Documented **headless profile support**: the plugin mounts unchanged in the dsh headless profile (`dsh plugin --profile headless add @mstar-harness/dsh`) — all gates, the skill mount, the engine-status catalog, the harness-rules injection, and the 7 `mstar_*` tools ride `dsh-base` seams that headless inherits; verified on dsh 0.1.0-rc.6 (catalog row, harness-dir probe from the session cwd, dispatch-gate hard deny/pass, child dispatch).
+
+<!-- CN -->
+- 文档化 **headless profile 支持**：插件零改动即可挂载进 dsh headless profile（`dsh plugin --profile headless add @mstar-harness/dsh`）——全部闸门、技能挂载、engine-status catalog、harness-rules 注入与 7 个 `mstar_*` 工具都落在 headless 继承的 `dsh-base` seam 上；已在 dsh 0.1.0-rc.6 上验证（catalog 行、按会话 cwd 的 harness 目录探测、派发闸门 hard 拒绝/放行、子会话派发）。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -163,6 +163,24 @@ cd <repo>/packages/dsh && dsh plugin --profile web add .
 ```
 `dsh web` then boots the harness: in-process engine gates (status/dispatch/lease/worktree/seams), the bundled `mstar-*` skills mount, and the bundled slash commands (`/iteration-start`, `/iteration-drive`, `/iteration-loop`, `/codebase-audit`, `/amazing-pr-review`). Host behavior (tools, gates, enforcement, PM dispatch) → **`mstar-host`** → `references/dsh.md`; package docs → [`packages/dsh/README.md`](../packages/dsh/README.md).
 
+#### Headless profile usage
+
+The dsh target also works with the **headless** profile — the one-shot, no-GUI/no-port mode (`dsh --profile headless "<task>"`): one task, the final assistant message on stdout, exit 0 on completion / 1 on failure. The plugin install is the same command pointed at the headless profile:
+
+```sh
+dsh plugin --profile headless add @mstar-harness/dsh
+dsh --profile headless --dump-config   # verify the mstar row joined the layer stack
+```
+
+Every harness capability rides a `dsh-base` seam that headless inherits (gates, skill mount, catalog, system-prompt injection, the 7 `mstar_*` tools), so mstar runs fully in a one-shot run. Always launch from the repo working directory — the runner writes `meta.cwd = process.cwd()` and the harness-dir probe starts there.
+
+**Caveats when using handles (background children) in headless** — the one-shot runner's completion contract is `whenIdle()` on the foreground agent, and background subagent handles do NOT hold the process open:
+
+- `run_in_background: true` dispatches return a task id immediately and the runner treats the agent as idle once the foreground turn ends — the process exits while the children are still running (verified on dsh 0.1.0-rc.6: a background child's settlement notice lands in a turn that never executes). Exit 0 does not imply background children finished.
+- Foreground subagent dispatch works end to end and is the reliable one-shot pattern; parallelism is still available inside a turn by dispatching N children in one message and collecting all of them via `tool-subagent-control` (list/`send`) BEFORE the final message.
+- If you need fire-and-forget children, make the prompt require the agent to wait for every settlement and fold all results into the final message; otherwise run separate headless invocations per job and orchestrate from your script/cron.
+- Leaf subagents must return their completion report in the closing message (not the `report` tool) — the report tool routes into the parent's next-step queue, which strands when the parent's turn has ended (the dsh leaf-delivery discipline, `mstar-host` → `references/dsh.md`).
+
 ### `mstar-harness doctor`
 
 Check an existing config:

--- a/packages/dsh/README.i18n.yaml
+++ b/packages/dsh/README.i18n.yaml
@@ -2,5 +2,5 @@
 # Blob hashes (git hash-object) of each side as of the last confirmation that
 # both languages say the same thing (dsh i18n contract: a pair is three
 # sibling files; editing either side obligates re-confirming and re-recording).
-README.md: 833b3592c55d9b923ee20cedec6d26e309d5f994
-README.zh.md: a71a7e1bec0bea2d45d1103ec714b8cf2712270a
+README.md: 32f5eb62efcbb16a4aaaad28bce99978bc265b48
+README.zh.md: a8e11104404aaa10ed517de8d43ae05105062d2f

--- a/packages/dsh/README.md
+++ b/packages/dsh/README.md
@@ -43,6 +43,23 @@ The **two-command install is the contract** — folding a `dsh-llm-fallbacks` ro
 
 > **Fresh-publish age window**: pnpm's `minimumReleaseAge` gate can make a `dsh plugin add <spec>` range resolution pick an older published version (without the seeds surface) for up to ~24h after a fresh publish — re-run `npx @mstar-harness/cli init --target dsh` after the window (or pin the version) to converge on the latest surface.
 
+### Headless profile (one-shot runs)
+
+The plugin is not web-bound: it also mounts in the dsh **headless** profile (`dsh --profile headless "<task>"` — the one-shot, no-GUI/no-port mode). The install path is identical, one command:
+
+```sh
+dsh plugin --profile headless add @mstar-harness/dsh
+```
+
+The shipped headless template auto-initializes on first use (`@deepseek-ai/dsh-base` + `@deepseek-ai/dsh-headless`), and the reconcile step appends the mstar row to the bundle stack (`dsh-base → dsh-headless → @mstar-harness/dsh`). Every plugin capability rides a `dsh-base` seam that headless inherits — status/dispatch/lease/worktree gates, the skill mount, the engine-status catalog, the harness-rules system-prompt injection, the 7 model-facing tools — so the harness is fully live in a one-shot run. **Launch from the repo working directory** (the runner writes `meta.cwd = process.cwd()` and the per-workspace harness-dir probe starts there). The browser client half is web-profile-only and simply does not load.
+
+**Headless usage caveats** (dsh 0.1.0-rc.6 verified):
+
+- **One-shot turn model** — the runner submits the task as one user message and exits when the agent goes idle (`whenIdle()`); it does NOT await `run_in_background` children. Foreground subagent dispatch works (a child session is created and its result reaches the parent); background QC-tri-style parallelism does NOT complete in-process — either dispatch QC seats foreground (serial wall time) or have the agent collect background results with `tool-subagent-control` BEFORE ending the turn.
+- **No interaction channel** — `ask_user_question` and approval prompts fail closed (there is no answerer). Use `DSH_PERMISSION_MODE=danger-full-access` for unattended runs (sandbox `danger-full-access` + approval `never`); interactive Prepare flows (grill-me) belong on the web profile.
+- **Default model resolution** — headless composes no fallbacks row, so an `agent-default-model` settings pin of `FallbacksChain` fails with `NO_ADAPTER` (the web-profile artifact). Point the default model at a real provider, or install `dsh-llm-fallbacks` into the headless profile too (note: on the published dsh 0.1.0-rc.6 the fallbacks settings integration predates the `SettingsProvider.installSection` API, so the virtual adapter does not register — this resolves with dsh ≥ 0.1.2-alpha).
+- **Config via the profile user layer** — profile-level `cordis.patch.yml` overrides work as documented (e.g. `enforcement: hard` + `dispatchBinding` on the mstar row); the mstar row's own `config: {}` stays neutral.
+
 ### Configuration
 
 | Key | Type | Default | Meaning |

--- a/packages/dsh/README.zh.md
+++ b/packages/dsh/README.zh.md
@@ -43,6 +43,22 @@ dsh plugin --profile web add dsh-llm-fallbacks
 
 > **fresh publish 年龄窗口提示**：pnpm 的 `minimumReleaseAge` 门禁可能让 `dsh plugin add <spec>` 的 range 解析在全新发布后约 24h 内选中旧版本（不含 seeds surface）——窗口过后重跑 `npx @mstar-harness/cli init --target dsh`（或显式 pin 版本）即可收敛到最新 surface。
 
+### Headless profile（一次性运行）
+
+本插件并非 web 专属：它同样可以挂载进 dsh **headless** profile（`dsh --profile headless "<task>"`——一次性、无 GUI/无端口模式）。安装路径完全一致，一条命令：
+
+```sh
+dsh plugin --profile headless add @mstar-harness/dsh
+```
+
+出厂 headless 模板在首次使用时自动初始化（`@deepseek-ai/dsh-base` + `@deepseek-ai/dsh-headless`），reconcile 步骤把 mstar 行追加进 bundle 层栈（`dsh-base → dsh-headless → @mstar-harness/dsh`）。插件的所有能力都落在 headless 继承的 `dsh-base` seam 上——status/dispatch/lease/worktree 闸门、技能挂载、engine-status catalog、harness-rules system-prompt 注入、7 个模型面工具——因此在一次性运行中 harness 完整生效。**必须从仓库工作目录启动**（runner 写入 `meta.cwd = process.cwd()`，按工作区的 harness 目录探测从这里开始）。浏览器客户端半体仅属于 web profile，headless 下自然不加载。
+
+**Headless 使用注意事项**（已在 dsh 0.1.0-rc.6 上验证）：
+
+- **一次性 turn 模型**——runner 把任务作为一条 user message 提交，agent 转入 idle（`whenIdle()`）后即退出；它**不会**等待 `run_in_background` 子任务。前台 subagent 派发可用（创建子会话、结果回到父会话）；后台 QC-tri 式并行在进程内不会完成——要么前台派发 QC 席（串行墙钟时间），要么让 agent 在结束 turn **之前**用 `tool-subagent-control` 收集完后台结果。
+- **无交互通道**——`ask_user_question` 与审批提示 fail-closed（没有应答者）。无人值守运行用 `DSH_PERMISSION_MODE=danger-full-access`（sandbox `danger-full-access` + approval `never`）；交互式 Prepare 流程（grill-me）属于 web profile。
+- **默认模型解析**——headless 不组合 fallbacks 行，因此 settings 里 `agent-default-model` 钉在 `FallbacksChain` 会以 `NO_ADAPTER` 失败（web profile 的产物）。把默认模型指向真实 provider，或同样把 `dsh-llm-fallbacks` 装进 headless profile（注意：已发布的 dsh 0.1.0-rc.6 上，fallbacks 的 settings 集成早于 `SettingsProvider.installSection` API，虚拟适配器不会注册——随 dsh ≥ 0.1.2-alpha 解决）。
+
 ### Configuration
 
 | Key | Type | Default | Meaning |


### PR DESCRIPTION
## What

Document the verified dsh **headless** profile support (no code change — the plugin mounts unchanged):

- `packages/dsh/README.md` + `README.zh.md` — new **“Headless profile (one-shot runs)”** section under Install paths:
  - install: `dsh plugin --profile headless add @mstar-harness/dsh` (same profile-bundle path; reconcile appends the mstar row after `dsh-base` + `dsh-headless`)
  - why it works: every capability (status/dispatch/lease/worktree gates, skill mount, engine-status catalog, harness-rules injection, 7 `mstar_*` tools) rides a `dsh-base` seam that headless inherits; the web-only client half simply does not load
  - launch contract: start from the repo cwd (runner writes `meta.cwd = process.cwd()`, harness-dir probe starts there)
  - four verified caveats: one-shot turn model (`whenIdle()` does not await `run_in_background` children), no interaction channel (approval/ask fail closed; `DSH_PERMISSION_MODE=danger-full-access` for unattended runs), `FallbacksChain` default-model resolution (headless composes no fallbacks row; fallbacks settings API predates dsh ≥ 0.1.2-alpha), profile user-layer config overrides
  - README pairing hashes re-recorded per the dsh i18n contract
- `docs/cli.md` — new **“Headless profile usage”** subsection under the dsh target, carrying the **handles (background children) caveats** the user asked for: background handles don't hold the one-shot process open (verified: settlement notices land in a turn that never executes), foreground dispatch + pre-turn `tool-subagent-control` collection pattern, per-job orchestration for fire-and-forget, and the leaf closing-message (not `report` tool) delivery discipline.
- `.changes/unreleased/dsh-headless-profile-docs.md` — changelog fragment (`packages: dsh`).

## Verification

All claims are backed by a live probe on dsh 0.1.0-rc.6 + @mstar-harness/dsh 3.6.0-alpha.3 (isolated DSH_HOME mirror; session-log evidence decoded from the zstd JSONL):

- headless run with the mstar row mounted: exit 0, correct task output
- `mstar-engine-status` catalog row in the session log, harness dir probed from the session cwd (`/private/tmp/.../repo/.mstar`)
- `mstar:engine-status` + harness-rules system-prompt sections in the composed request
- all 7 `mstar_*` tools present in the composed tool catalog; 22 mstar skills + `pm` visible in a dispatched child
- foreground subagent dispatch end to end (child session `delegationDepth: 1`)
- dispatch gate under `enforcement: hard`: malformed Assignment denied with `assignment.field.missing-*` + `PreToolDecision { kind: 'deny' }`; valid Assignment passes
- background dispatch gap reproduced: two `run_in_background: true` children still running after the parent process exited 0

## Non-goals

No plugin/CLI behavior change; docs only. The CLI `init --target dsh` profile hardcodes `web` — a `--dsh-profile` flag is a possible follow-up and is deliberately NOT included here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and changelog only; no runtime, CLI, or plugin code changes.
> 
> **Overview**
> **Documentation-only** — records that `@mstar-harness/dsh` mounts unchanged on the dsh **headless** profile (`dsh plugin --profile headless add @mstar-harness/dsh`) with full harness behavior via inherited `dsh-base` seams, verified on dsh 0.1.0-rc.6.
> 
> **`packages/dsh/README.md`** and **`README.zh.md`** add a **Headless profile (one-shot runs)** section: install/reconcile stack (`dsh-base → dsh-headless → @mstar-harness/dsh`), launch-from-repo-cwd contract, and caveats (one-shot `whenIdle()` vs `run_in_background`, no interactive channel / `DSH_PERMISSION_MODE`, `FallbacksChain` / optional fallbacks on headless, profile-layer config on EN README). **`README.i18n.yaml`** pairing hashes are re-recorded.
> 
> **`docs/cli.md`** adds **Headless profile usage** under the dsh target with install/`--dump-config` checks and deeper **background-handle** guidance: exit 0 does not mean children finished, foreground dispatch + `tool-subagent-control` before the final message, and leaf closing-message delivery (not `report`).
> 
> **`.changes/unreleased/dsh-headless-profile-docs.md`** changelog fragment for package `dsh`. No plugin or CLI behavior change (`init --target dsh` still targets `web` only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521636179d763e3a80a69eae2157e32d3c2e14ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->