### PR TITLE
fix(release): restore INSTALL.md marketplace version anchor

### DIFF
--- a/.changes/unreleased/restore-install-marketplace-version-anchor.md
+++ b/.changes/unreleased/restore-install-marketplace-version-anchor.md
@@ -1,0 +1,7 @@
+---
+packages: root
+---
+- Restored the quoted `"version"` field in the INSTALL.md ZCode marketplace example that `release:prepare` bumps every release — its removal in #183 broke **Release prep** with `INSTALL.md: could not find quoted "version" field`. The snippet now documents the field as release-maintained so it is not removed again.
+
+<!-- CN -->
+- 恢复了 INSTALL.md ZCode marketplace 示例中带引号的 `"version"` 字段——`release:prepare` 每次发布都会 bump 它,#183 中的删除导致 **Release prep** 报 `INSTALL.md: could not find quoted "version" field`。示例现已注明该字段由发布流程维护,请勿手工移除。

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -304,11 +304,14 @@ To register it by hand (without the CLI) instead, create `~/.zcode/cli/plugins/m
       "name": "morning-star-harness",
       "source": { "source": "github", "repo": "btspoony/mstar-harness", "ref": "main" },
       "description": "Multi-agent code harness framework with unified skills for OpenCode, Cursor, Codex, Kimi Code, and ZCode.",
+      "version": "3.6.0",
       "category": "Productivity"
     }
   ]
 }
 ```
+
+The quoted `"version"` field above is the release-maintained marketplace example: `release:prepare` bumps it every release, so leave it in place when editing this snippet by hand.
 
 Append the marketplace to `~/.zcode/cli/plugins/known_marketplaces.json` (`marketplaces[]`):
 


### PR DESCRIPTION
## Problem

Release prep failed on main ([run 33782715988](https://github.com/btspoony/mstar-harness/actions/runs/33782715988)):

```
prepare-release failed: INSTALL.md: could not find quoted "version" field (expected X.Y.Z)
```

## Root cause

#183 removed the quoted `"version": "3.6.0"` field from the INSTALL.md ZCode marketplace example while de-versioning the CLI-written marketplace snapshot. That field is not snapshot metadata — it is the **INSTALL.md marketplace example** surface: `prepare-release.ts` `bumpInstall()` matches the first quoted `"version": "X.Y.Z"` in INSTALL.md and bumps it every release (and `release:validate` hard-fails a stable release when it is missing). Removing it removed the bump anchor.

## Fix

- Restore `"version": "3.6.0"` in the INSTALL.md ZCode bootstrap snippet (release tooling keeps it fresh — my earlier "it goes stale" rationale was wrong: staleness is exactly what `release:prepare` prevents).
- Add a one-line note above the snippet marking the field as release-maintained so it isn't pruned again.
- Changelog fragment included (consumed by the next `3.6.1` prep).

## Verification (in a clean worktree, same commands as CI)

- `bun run release:prepare -- --patch` → completes; `bump: INSTALL.md` logged; all surfaces + INSTALL aligned at `3.6.1` (generated changes reverted before this PR).
- `bun run release:validate -- v3.6.1` → `OK INSTALL.md ZCode marketplace example: 3.6.1`, `All surfaces aligned at 3.6.1`.
- `bun test scripts/prepare-release.test.ts` → 20 pass / 0 fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to INSTALL.md and an unreleased changelog entry; no runtime or auth logic.
> 
> **Overview**
> **Restores the release bump anchor** that `release:prepare` expects in the manual ZCode marketplace JSON example in `INSTALL.md`.
> 
> PR #183 removed the quoted `"version": "3.6.0"` entry from that snippet, which caused **Release prep** to fail with `INSTALL.md: could not find quoted "version" field`. The field is re-added to the example, and a short note clarifies that **`release:prepare` bumps it each release** so editors do not remove it again.
> 
> A root changelog fragment documents the fix for the next release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 199b885fc356d76dd4d6b22f631c0e1a60e55f7c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->