### PR TITLE
feat(release): drop INSTALL.md version anchor and its release tooling

### DIFF
--- a/.changes/unreleased/remove-install-version-anchor.md
+++ b/.changes/unreleased/remove-install-version-anchor.md
@@ -1,0 +1,7 @@
+---
+packages: root
+---
+- Removed the INSTALL.md marketplace version anchor and its release tooling: `release:prepare` no longer bumps a quoted `"version"` field in INSTALL.md and `release:validate` no longer requires one — the ZCode marketplace example (and the marketplace catalogs) are version-less; install-time versions come from `.zcode-plugin/plugin.json`. Follow-up to #183/#184: the anchor's only purpose was being bumped by the release tooling, so it was removed together with the tooling instead of restored.
+
+<!-- CN -->
+- 移除 INSTALL.md marketplace 版本锚点及其发布工具链:`release:prepare` 不再 bump INSTALL.md 中带引号的 `"version"` 字段,`release:validate` 也不再要求它——ZCode marketplace 示例与各 marketplace catalog 均无版本字段,安装时版本取自 `.zcode-plugin/plugin.json`。作为 #183/#184 的后续:该锚点唯一的用途就是被发布工具 bump,因此连同工具一起移除,而非恢复。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ When a change affects shared harness behavior, treat OpenCode, Cursor, Codex, Ki
 
 ## Release Process
 
-Releases are PR-driven and mostly automated. Every release ships one version across all 12 version surfaces (root + 4 npm packages + 7 plugin manifests [6 host + portable Agent Plugins]); also bump the INSTALL.md marketplace example.
+Releases are PR-driven and mostly automated. Every release ships one version across all 12 version surfaces (root + 4 npm packages + 7 plugin manifests [6 host + portable Agent Plugins]).
 
 ### 1. During development — add a changelog fragment
 
@@ -115,7 +115,7 @@ Merging a `release vX.Y.Z` PR runs the **Release** workflow **inline on the `pul
 
 ### Prereleases (alpha)
 
-Prerelease lines use the same PR flow with a suffixed version: `bun run release:prepare -- 3.6.0-alpha.1`, then merge the `release v3.6.0-alpha.1` PR. The Release workflow publishes under the npm dist-tag `alpha` (never `latest`) and flags the GitHub Release as prerelease. `INSTALL.md` / README examples stay on the last stable release — `release:prepare` skips the INSTALL bump and `release:validate` skips the INSTALL check for prerelease versions. Stable `X.Y.Z` releases are unchanged.
+Prerelease lines use the same PR flow with a suffixed version: `bun run release:prepare -- 3.6.0-alpha.1`, then merge the `release v3.6.0-alpha.1` PR. The Release workflow publishes under the npm dist-tag `alpha` (never `latest`) and flags the GitHub Release as prerelease. `release:prepare` and `release:validate` touch version surfaces only — `INSTALL.md` is not a release surface.
 
 ### Conventions
 

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -32,7 +32,6 @@
 import { existsSync, mkdirSync, readdirSync, renameSync } from "node:fs";
 import {
   CHANGELOGS,
-  INSTALL_REF,
   RELEASE_VERSION_RE,
   VERSION_SURFACES,
   compareSemver,
@@ -245,25 +244,6 @@ async function bumpJsonVersion(path: string, oldV: string, newV: string): Promis
 }
 
 /**
- * Bump the INSTALL.md marketplace example to `newV`. The old version is
- * derived from INSTALL.md's own quoted `"version"` field — never from the
- * release `current` — because after a prerelease the surfaces carry a
- * suffixed version while INSTALL.md stays on the last stable; passing that
- * suffixed `current` here would find no match and silently leave INSTALL.md
- * stale (and `release:validate` would then hard-fail the stable release).
- * Fails fast if the file or its version field is missing (validate would
- * fail later anyway).
- */
-async function bumpInstall(newV: string): Promise<void> {
-  const text = await Bun.file(INSTALL_REF.path).text();
-  const m = text.match(/"version"\s*:\s*"(\d+\.\d+\.\d+)"/);
-  if (!m) {
-    throw new Error(`${INSTALL_REF.path}: could not find quoted "version" field (expected X.Y.Z)`);
-  }
-  await Bun.write(INSTALL_REF.path, text.replace(m[0], `"version": "${newV}"`));
-}
-
-/**
  * Rewrite the root manifest's runtime dependency on `@mstar-harness/engine`
  * to `^<version>`. The root package.json is the manifest git/hosted installs
  * resolve (`omp plugin install github:…`, `bun add github:…`), where the
@@ -335,12 +315,6 @@ async function main(): Promise<void> {
     const text = await Bun.file(rootPath).text();
     await Bun.write(rootPath, syncRootEngineSpec(text, version));
     console.log(`sync: ${rootPath} dependencies["@mstar-harness/engine"] -> ^${version}`);
-  }
-  if (isPrereleaseVersion(version)) {
-    console.log(`skip: ${INSTALL_REF.path} (prerelease — stays at last stable)`);
-  } else {
-    await bumpInstall(version);
-    console.log(`bump: ${INSTALL_REF.path}`);
   }
 
   archiveFragments(version, frags);

--- a/scripts/release-surfaces.ts
+++ b/scripts/release-surfaces.ts
@@ -44,9 +44,6 @@ export const CHANGELOGS: readonly ChangelogTarget[] = [
   { path: "packages/omp/CHANGELOG.md", lang: "en", pkg: "omp" },
 ] as const;
 
-/** INSTALL.md ZCode marketplace example carries a quoted version field. */
-export const INSTALL_REF = { path: "INSTALL.md" } as const;
-
 /**
  * Release version regex — `X.Y.Z` with an optional semver prerelease suffix
  * (`-alpha.1`). Anchored; no `+build` metadata support (not needed for

--- a/scripts/validate-release-version.ts
+++ b/scripts/validate-release-version.ts
@@ -17,7 +17,7 @@
  * 0 MISSING / all-MISMATCH is the expected pre-release state, not a gate
  * failure.
  */
-import { INSTALL_REF, RELEASE_VERSION_RE, VERSION_SURFACES, isPrereleaseVersion } from "./release-surfaces.ts";
+import { RELEASE_VERSION_RE, VERSION_SURFACES } from "./release-surfaces.ts";
 
 const tag = process.argv[2] ?? process.env.GITHUB_REF_NAME;
 
@@ -34,7 +34,6 @@ if (!RELEASE_VERSION_RE.test(version)) {
   process.exit(1);
 }
 
-const installVersionRe = /"version"\s*:\s*"(\d+\.\d+\.\d+)"/;
 let failed = false;
 
 for (const { label, path } of VERSION_SURFACES) {
@@ -52,23 +51,6 @@ for (const { label, path } of VERSION_SURFACES) {
     failed = true;
   } else {
     console.log(`OK ${label}: ${json.version}`);
-  }
-}
-
-// Prereleases skip it — INSTALL.md stays on the last stable release.
-if (isPrereleaseVersion(version)) {
-  console.log(`SKIP INSTALL.md (prerelease)`);
-} else {
-  const install = await Bun.file(INSTALL_REF.path).text();
-  const installMatch = install.match(installVersionRe);
-  const installVersion = installMatch?.[1];
-  if (installVersion !== version) {
-    console.error(
-      `MISMATCH INSTALL.md (${INSTALL_REF.path}): expected ${version}, found ${installVersion ?? "<missing>"}`,
-    );
-    failed = true;
-  } else {
-    console.log(`OK INSTALL.md ZCode marketplace example: ${installVersion}`);
   }
 }
 


### PR DESCRIPTION
## What

Removes the INSTALL.md marketplace version anchor **together with the release tooling that depended on it**, instead of restoring the field (supersedes #184, which will be closed).

- `scripts/prepare-release.ts`: drop `bumpInstall()` and the prerelease skip branch — INSTALL.md is no longer touched during release prep.
- `scripts/validate-release-version.ts`: drop the INSTALL check and `installVersionRe`.
- `scripts/release-surfaces.ts`: drop the now-unused `INSTALL_REF`.
- `AGENTS.md`: release-process wording updated (12 version surfaces only; INSTALL.md is not a release surface).
- Changelog fragment included (consumed by the next `3.6.1` prep).

## Why

The quoted `"version"` field in the INSTALL.md ZCode marketplace example existed **only** to be bumped by the release tooling. Since #183, that example is version-less along with both marketplace catalogs (`.claude-plugin/marketplace.json`, root `marketplace.json`, `.agents/plugins/`): install-time versions always resolve from `.zcode-plugin/plugin.json`, never from marketplace entry metadata. Keeping the field meant keeping a line whose only consumer was the bumper itself — removed at the root instead.

## Verification (clean worktree, same commands as CI)

- `bun run release:prepare -- --patch` → completes; no `bump: INSTALL.md` line; INSTALL.md untouched (`0` quoted version fields).
- `bun run release:validate -- v3.6.1` → `All surfaces aligned at 3.6.1` (no INSTALL check emitted).
- `bun test scripts/prepare-release.test.ts` → 20 pass / 0 fail.
- `bun run typecheck` → clean.

## Release flow after merge

Release prep on main will succeed again and assemble the pending fragments (#183 ×3 + this PR) into `release v3.6.1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script and maintainer-doc changes only; no runtime install or auth paths. Slightly narrows what `release:validate` checks, which is intentional.
> 
> **Overview**
> **Removes the INSTALL.md marketplace `"version"` anchor and all release automation that maintained it**, aligning with version-less marketplace catalogs (#183): install versions come from `.zcode-plugin/plugin.json`, not INSTALL or catalog metadata.
> 
> `release:prepare` no longer calls `bumpInstall()` or special-cases prereleases for INSTALL; `release:validate` no longer asserts INSTALL’s quoted version; `INSTALL_REF` is deleted from `release-surfaces.ts`. **AGENTS.md** now documents **12 version surfaces only** and states INSTALL is not part of release prep/validate. A root changelog fragment records the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f83ba04099da4c1b18337752be08c9d68aa6c42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->