### PR TITLE
ci(security): harden contribution readiness

### DIFF
--- a/.changes/unreleased/harden-contribution-security.md
+++ b/.changes/unreleased/harden-contribution-security.md
@@ -1,0 +1,9 @@
+---
+category: Harness
+packages: root
+---
+
+- Hardened repository contribution readiness: pinned all GitHub Actions to immutable commit SHAs, restricted ordinary CI to read-only permissions without persisted checkout credentials, added weekly GitHub Actions and Bun workspace dependency updates, and published a bilingual security disclosure policy. Release write permissions and push authentication are unchanged.
+
+<!-- CN -->
+- 加固仓库贡献准备：所有 GitHub Actions 固定到不可变 commit SHA，普通 CI 限为只读权限且不保留 checkout 凭据，新增 GitHub Actions 与 Bun 工作区依赖的每周更新，并发布双语安全漏洞报告政策。发布流程的写权限与推送认证保持不变。

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # One root lockfile covers every packages/* workspace.
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      development-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,20 +42,25 @@ on:
       - ".omp-plugin/**"
       - "assets/**"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 
@@ -171,10 +176,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.4.0
 
@@ -192,12 +199,13 @@ jobs:
       # fetch-depth: 1 checkout has no origin/main ref and the guard would
       # (correctly, per its CI contract) fail loudly instead of running.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.4.0
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -28,17 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,20 +36,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.4.0
 
       # Node 24 ships npm with working Trusted Publishing / provenance (sigstore).
       # Do not `npm install -g npm@latest` on Node 22 — that breaks provenance with MODULE_NOT_FOUND: sigstore.
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           registry-url: https://registry.npmjs.org
@@ -139,7 +139,7 @@ jobs:
           echo "notes_file=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ steps.ver.outputs.version }}
           name: v${{ steps.ver.outputs.version }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes target the latest stable release of Morning Star Harness and its
+`@mstar-harness/*` packages. Upgrade older releases before checking whether a
+reported issue still applies. Prereleases are for evaluation, not supported
+production deployments.
+
+## Reporting a vulnerability
+
+Email **tech@btang.cn** with the subject `mstar-harness security report`.
+Do not open a public issue or pull request containing exploit details, credentials,
+or private repository content.
+
+Include the affected package and version (or commit), host and operating system,
+reproduction steps, expected and observed behavior, and potential impact. Use
+synthetic credentials and a minimal reproduction; never send live secrets.
+Coordinate disclosure with the maintainer while the report is investigated and a
+fix or mitigation is prepared. Ordinary bugs and feature requests belong in
+[GitHub Issues](https://github.com/btspoony/mstar-harness/issues).
+
+## Security boundaries
+
+Morning Star coordinates coding agents and enforces workflow gates; it is not a
+sandbox. Host permissions and approval controls remain the security boundary for
+file access, commands, network access, and credentials. Keep those controls enabled,
+review third-party plugins before installing them, and use least-privilege tokens.
+A passing workflow or scanner result is not a guarantee that a plugin is safe.
+
+## 中文
+
+安全修复面向 Morning Star Harness 及 `@mstar-harness/*` 包的最新稳定版本。
+旧版本请先升级；预发布版本仅供评估，不作为受支持的生产部署。
+
+请将漏洞报告发送至 **tech@btang.cn**，邮件主题为 `mstar-harness security report`。
+请勿在公开 issue 或 PR 中披露利用细节、凭据或私有仓库内容。报告应包含受影响的包与版本
+（或 commit）、宿主与操作系统、复现步骤、预期和实际行为以及潜在影响。使用虚构凭据和
+最小复现，切勿发送真实密钥。调查及修复期间请与维护者协调披露；普通缺陷和功能请求使用
+[GitHub Issues](https://github.com/btspoony/mstar-harness/issues)。
+
+Morning Star 的工作流门禁不是沙箱。文件、命令、网络和凭据访问仍由宿主权限与审批控制
+约束；请保留这些控制，安装前审查第三方插件，并使用最小权限令牌。工作流或扫描通过不
+代表插件没有安全风险。


### PR DESCRIPTION
## Summary

Refs #188 and hashgraph-online/awesome-ai-plugins#231. Addresses concrete repository-hardening gaps reported by [the HOL scan](https://github.com/hashgraph-online/awesome-ai-plugins/actions/runs/33979441265/job/101341917161?pr=231), without weakening scanner thresholds or changing runtime code to evade false positives.

- Pin all 14 GitHub Action references across CI, release prep, and release workflows to full commit SHAs resolved from their existing major refs through the GitHub API.
- Restrict ordinary CI to `contents: read` and disable persisted checkout credentials. Release permissions, checkout authentication, and push steps remain unchanged.
- Add weekly Dependabot updates for GitHub Actions and the root Bun workspace lockfile.
- Add a bilingual security policy with supported versions, private email reporting, and host security boundaries. GitHub private vulnerability reporting is currently disabled; no repository settings were changed.
- Add the bilingual root changelog fragment; assembled changelogs and package versions are unchanged.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/release-prep.yml .github/workflows/release.yml` — exit 0.
- Dependabot configuration passes Draft 7 validation against SchemaStore's `dependabot-2.0.json`, including the `github-actions` and `bun` ecosystems.
- Parsed release workflow comparison confirms permissions and all non-action step configuration, including checkout credential behavior, are unchanged.
- Final local scan uses HOL `plugin-scanner==2.0.1116`, Cisco `2.0.14`, the default profile/auto integrations/balanced policy, and the upstream score/severity thresholds:

```sh
uv tool run --python 3.12 \
  --from plugin-scanner==2.0.1116 \
  --with cisco-ai-skill-scanner==2.0.14 \
  plugin-scanner scan /path/to/checkout \
  --format json --output /path/outside/checkout/scan.json \
  --min-score 80 --fail-on-severity high
```

| Metric | Before | After |
| --- | ---: | ---: |
| Score | 65 | 77 |
| Critical | 0 | 0 |
| High | 20 | 20 |
| Medium | 32 | 4 |
| Low | 4 | 0 |
| Info | 5 | 5 |

`GITHUB_ACTION_UNPINNED`, `SECURITY_MD_MISSING`, and `DEPENDABOT_MISSING` are eliminated. **The scanner still exits 1: 77 is below 80, and high findings remain. This PR does not claim a passing HOL scan.** No GitHub-hosted release execution was performed locally.

## Remaining findings and deliberate non-changes

Read-only source inspection identified the 20 high findings as 14 distinct rule/path matches, with six native matches counted again across Claude/Codex surfaces:

| Rule | Evidence |
| --- | --- |
| `HARDCODED_SECRET` (10 findings / 5 paths) | `packages/dsh/tests/misc-seams.spec.ts:118`, `packages/cli/test/slice4-cli.test.ts:756`, `packages/engine/test/audit.test.ts:105`, and `packages/engine/test/audit-static.test.ts:97` contain intentional synthetic detection/redaction fixtures. `packages/engine/src/audit.ts:470` is a comment illustrating an environment-variable placeholder, not a credential. |
| `SHELL_INJECTION_PATTERN` (2 findings / 1 path) | `packages/dsh/src/index.ts:233` invokes `new RegExp(...).exec(frontmatter)`, not a shell. Its field labels are fixed literals at lines 267–270. |
| `UNICODE_OBFUSCATED_INSTRUCTION` (6 findings) | Ordinary multilingual policy/reference prose in `skills/mstar-roles/references/qc-specialist/deep-review-lenses.md`, `skills/mstar-design-md/SKILL.md`, `skills/mstar-design-md/references/vercel-example.md`, `skills/mstar-audit/SKILL.md`, `skills/mstar-audit/references/security-review.md`, and `skills/mstar-host/references/dsh.md`. |
| `PROMPT_INJECTION_IGNORE_INSTRUCTIONS` and `ASSET_PROMPT_INJECTION` (2 findings) | `skills/mstar-audit/SKILL.md:20` and `skills/mstar-audit/references/pr-review-seat-evidence.md:42` quote attack examples inside explicit instructions to treat repository content as data and **never follow** those attacks. |

The remaining four medium findings are the English/Chinese dsh README's explicit opt-in unattended approval configuration, counted across both ecosystems—not shipped defaults. Optional Codex metadata/ignore recommendations also remain; no fabricated policy URLs, blanket exclusions, baseline suppressions, or scanner CI that hides failure were added.

## Upstream listing status

The linked run's scanner job is red, while its catalog contribution gates passed. The upstream workflow treats source scanning as advisory. Its sweep clones this repository's default branch, so these improvements will only be visible there **after this PR merges and the upstream scan runs again**. Remaining false-positive evidence should be reviewed with HOL rather than deleting regression fixtures or defensive instructions.

User approved publication after reviewing the complete proposed diff. No merge is requested by this action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI permissions tightening, action pinning, Dependabot, and documentation; release write paths are explicitly untouched.
> 
> **Overview**
> Hardens **repository contribution and CI supply-chain posture** without changing application runtime code or release publish behavior.
> 
> **CI** (`ci.yml`) now declares workflow-level `contents: read`, pins `checkout`, `setup-bun`, and `setup-node` to immutable commit SHAs (with version comments), and sets `persist-credentials: false` on all checkouts—including the full-history `drift-lint` job.
> 
> **Release workflows** (`release-prep.yml`, `release.yml`) get the same action SHA pinning only; existing write permissions, checkout auth, tag push, and npm publish steps are unchanged.
> 
> Adds **`.github/dependabot.yml`** for weekly grouped updates to GitHub Actions and the root Bun lockfile (dev deps minor/patch, PR cap 5).
> 
> Adds **`SECURITY.md`** (English + 中文) covering supported versions, private email reporting, and host/plugin security boundaries.
> 
> Adds a bilingual **changelog fragment** under `.changes/unreleased/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc6c908817facc958b80f3572543eee3cc89d83. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->