### PR TITLE
feat(release): pin marketplace plugin-entry version + wire manifests into version surfaces

### DIFF
--- a/.changes/unreleased/marketplace-version-pin.md
+++ b/.changes/unreleased/marketplace-version-pin.md
@@ -3,8 +3,8 @@ packages: root, cli
 ---
 
 - **Marketplace manifests now pin the plugin version.** `.claude-plugin/marketplace.json` and the root `marketplace.json` carry `version` on the `morning-star-harness` plugin entry, and both manifests joined the release version surfaces — `release:prepare` bumps them at `plugins[0].version` and `release:validate` gates them there, so a ZCode marketplace refresh can detect newer releases.
-- **ZCode bootstrap marketplace entry carries `version`.** The CLI seeds the entry with the CLI release version — the exact value `doctor` validates against, so a current-CLI install always passes doctor; ZCode's marketplace refresh overwrites the seed with the repo-shipped manifest.
+- **ZCode bootstrap marketplace entry carries `version`.** The CLI seeds the entry with the CLI release version; ZCode's marketplace refresh overwrites the seed with the repo-shipped manifest. Doctor deliberately does not gate on version skew — a snapshot newer or older than the installed CLI is the update signal itself, not an unhealthy marketplace.
 
 <!-- CN -->
 - **Marketplace 清单现在固定插件版本。** `.claude-plugin/marketplace.json` 与根 `marketplace.json` 在 `morning-star-harness` 插件条目上携带 `version`，且两份清单加入发布版本面——`release:prepare` 在 `plugins[0].version` 处提升、`release:validate` 在同一路径把关，ZCode marketplace 刷新即可检测到新版本。
-- **ZCode bootstrap marketplace 条目携带 `version`。** CLI 以 CLI 发布版本作为种子——与 `doctor` 校验值完全一致，因此当前版本 CLI 的安装总能通过 doctor；ZCode marketplace 刷新会用仓库随附清单覆盖种子。
+- **ZCode bootstrap marketplace 条目携带 `version`。** CLI 以 CLI 发布版本作为种子；ZCode marketplace 刷新会用仓库随附清单覆盖种子。doctor 有意不按版本偏差把关——快照比已装 CLI 新或旧正是更新信号本身，而非异常状态。

--- a/.changes/unreleased/marketplace-version-pin.md
+++ b/.changes/unreleased/marketplace-version-pin.md
@@ -1,0 +1,10 @@
+---
+packages: root, cli
+---
+
+- **Marketplace manifests now pin the plugin version.** `.claude-plugin/marketplace.json` and the root `marketplace.json` carry `version` on the `morning-star-harness` plugin entry, and both manifests joined the release version surfaces — `release:prepare` bumps them at `plugins[0].version` and `release:validate` gates them there, so a ZCode marketplace refresh can detect newer releases.
+- **ZCode bootstrap marketplace entry carries `version`.** The CLI seeds the entry from the local harness checkout's `.zcode-plugin/plugin.json`, falling back to the CLI package version when the marker is unreadable.
+
+<!-- CN -->
+- **Marketplace 清单现在固定插件版本。** `.claude-plugin/marketplace.json` 与根 `marketplace.json` 在 `morning-star-harness` 插件条目上携带 `version`，且两份清单加入发布版本面——`release:prepare` 在 `plugins[0].version` 处提升、`release:validate` 在同一路径把关，ZCode marketplace 刷新即可检测到新版本。
+- **ZCode bootstrap marketplace 条目携带 `version`。** CLI 从本地 harness 检出的 `.zcode-plugin/plugin.json` 取值，标记不可读时回退 CLI 包版本。

--- a/.changes/unreleased/marketplace-version-pin.md
+++ b/.changes/unreleased/marketplace-version-pin.md
@@ -3,8 +3,8 @@ packages: root, cli
 ---
 
 - **Marketplace manifests now pin the plugin version.** `.claude-plugin/marketplace.json` and the root `marketplace.json` carry `version` on the `morning-star-harness` plugin entry, and both manifests joined the release version surfaces — `release:prepare` bumps them at `plugins[0].version` and `release:validate` gates them there, so a ZCode marketplace refresh can detect newer releases.
-- **ZCode bootstrap marketplace entry carries `version`.** The CLI seeds the entry from the local harness checkout's `.zcode-plugin/plugin.json`, falling back to the CLI package version when the marker is unreadable.
+- **ZCode bootstrap marketplace entry carries `version`.** The CLI seeds the entry with the CLI release version — the exact value `doctor` validates against, so a current-CLI install always passes doctor; ZCode's marketplace refresh overwrites the seed with the repo-shipped manifest.
 
 <!-- CN -->
 - **Marketplace 清单现在固定插件版本。** `.claude-plugin/marketplace.json` 与根 `marketplace.json` 在 `morning-star-harness` 插件条目上携带 `version`，且两份清单加入发布版本面——`release:prepare` 在 `plugins[0].version` 处提升、`release:validate` 在同一路径把关，ZCode marketplace 刷新即可检测到新版本。
-- **ZCode bootstrap marketplace 条目携带 `version`。** CLI 从本地 harness 检出的 `.zcode-plugin/plugin.json` 取值，标记不可读时回退 CLI 包版本。
+- **ZCode bootstrap marketplace 条目携带 `version`。** CLI 以 CLI 发布版本作为种子——与 `doctor` 校验值完全一致，因此当前版本 CLI 的安装总能通过 doctor；ZCode marketplace 刷新会用仓库随附清单覆盖种子。

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,7 @@
   "plugins": [
     {
       "name": "morning-star-harness",
+      "version": "3.7.0",
       "source": { "source": "github", "repo": "btspoony/mstar-harness", "ref": "main" },
       "displayName": "Morning Star Harness",
       "displayName_i18n": { "zh-CN": "启明星工作流" },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ When a change affects shared harness behavior, treat OpenCode, Cursor, Codex, Ki
 
 ## Release Process
 
-Releases are PR-driven and mostly automated. Every release ships one version across all 12 version surfaces (root + 4 npm packages + 7 plugin manifests [6 host + portable Agent Plugins]).
+Releases are PR-driven and mostly automated. Every release ships one version across all version surfaces — the authoritative surface list lives in `scripts/release-surfaces.ts` (15 surfaces at merge time: root + 5 npm packages + 7 plugin manifests [6 host + portable Agent Plugins] + 2 marketplace manifests).
 
 ### 1. During development — add a changelog fragment
 

--- a/marketplace.json
+++ b/marketplace.json
@@ -8,6 +8,7 @@
   "plugins": [
     {
       "name": "morning-star-harness",
+      "version": "3.7.0",
       "source": { "source": "github", "repo": "btspoony/mstar-harness", "ref": "main" },
       "displayName": "Morning Star Harness",
       "displayName_i18n": { "zh-CN": "启明星工作流" },

--- a/packages/cli/src/adapters/zcode.ts
+++ b/packages/cli/src/adapters/zcode.ts
@@ -41,6 +41,7 @@ type GithubSource = { source: "github"; repo: string; ref?: string };
 
 type MarketplacePluginEntry = {
   name: string;
+  version: string;
   source: GithubSource;
   displayName: string;
   icon: string;
@@ -64,9 +65,29 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+/**
+ * Version for the bootstrap marketplace entry: prefer the local harness
+ * checkout's `.zcode-plugin/plugin.json` (matches what ZCode installs);
+ * fall back to the CLI package version when the marker is unreadable.
+ * Exported for tests.
+ */
+export function resolveMarketplaceEntryVersion(markerPath: string, fallback: string): string {
+  try {
+    const raw = JSON.parse(fs.readFileSync(markerPath, "utf8")) as { version?: unknown };
+    if (typeof raw.version === "string" && raw.version !== "") return raw.version;
+  } catch {
+    // marker unreadable (missing checkout / unparseable manifest) — fall through
+  }
+  return fallback;
+}
+
 function marketplacePluginEntry(): MarketplacePluginEntry {
   return {
     name: PLUGIN_NAME,
+    version: resolveMarketplaceEntryVersion(
+      path.join(HARNESS_REPO_PATH, ZCODE_PLUGIN_MARKER),
+      readHarnessVersion(),
+    ),
     source: { ...GITHUB_SOURCE },
     displayName: PLUGIN_DISPLAY_NAME,
     icon: PLUGIN_ICON_URL,
@@ -163,8 +184,8 @@ function validateMarketplaceJson() {
   }
   const expectedVersion = readHarnessVersion();
   // After a successful marketplace refresh, ZCode overwrites this snapshot with the
-  // repo-shipped manifest (`.claude-plugin/marketplace.json`), which pins no version —
-  // install-time versions come from `.zcode-plugin/plugin.json`.
+  // repo-shipped manifest (`.claude-plugin/marketplace.json`), which pins the release
+  // version at the plugin entry; snapshots seeded by older CLIs may still be versionless.
   if (entry.version !== undefined && entry.version !== expectedVersion) {
     errors.push(`ZCode marketplace plugin version must be ${expectedVersion}.`);
   }

--- a/packages/cli/src/adapters/zcode.ts
+++ b/packages/cli/src/adapters/zcode.ts
@@ -172,13 +172,13 @@ function validateMarketplaceJson() {
   if (source.repo !== expected.source.repo) {
     errors.push(`ZCode marketplace plugin source.repo must be ${expected.source.repo}.`);
   }
-  const expectedVersion = readHarnessVersion();
-  // After a successful marketplace refresh, ZCode overwrites this snapshot with the
-  // repo-shipped manifest (`.claude-plugin/marketplace.json`), which pins the release
-  // version at the plugin entry; snapshots seeded by older CLIs may still be versionless.
-  if (entry.version !== undefined && entry.version !== expectedVersion) {
-    errors.push(`ZCode marketplace plugin version must be ${expectedVersion}.`);
-  }
+  // Version skew is deliberately NOT gated here: after a marketplace refresh
+  // the snapshot carries the repo-shipped release version, which may be newer
+  // or older than this CLI's own version. That skew is the update signal the
+  // pinned version exists to expose, not an unhealthy marketplace (gating it
+  // would flag the normal pre-update state and nudge a re-init that could
+  // regress a newer refreshed snapshot). Directional CLI↔plugin update
+  // prompting is tracked separately.
   return errors;
 }
 

--- a/packages/cli/src/adapters/zcode.ts
+++ b/packages/cli/src/adapters/zcode.ts
@@ -66,28 +66,18 @@ function nowIso() {
 }
 
 /**
- * Version for the bootstrap marketplace entry: prefer the local harness
- * checkout's `.zcode-plugin/plugin.json` (matches what ZCode installs);
- * fall back to the CLI package version when the marker is unreadable.
+ * Bootstrap snapshot for ZCode's marketplace.json. The seeded `version` is
+ * the CLI release version — the exact value `validateMarketplaceJson` (doctor)
+ * compares against, so a current-CLI install always passes doctor even when
+ * the shared `~/.mstar/harness` checkout is stale. ZCode's marketplace
+ * refresh overwrites this seed with the repo-shipped manifest
+ * (`.claude-plugin/marketplace.json`), which pins the release version too.
  * Exported for tests.
  */
-export function resolveMarketplaceEntryVersion(markerPath: string, fallback: string): string {
-  try {
-    const raw = JSON.parse(fs.readFileSync(markerPath, "utf8")) as { version?: unknown };
-    if (typeof raw.version === "string" && raw.version !== "") return raw.version;
-  } catch {
-    // marker unreadable (missing checkout / unparseable manifest) — fall through
-  }
-  return fallback;
-}
-
-function marketplacePluginEntry(): MarketplacePluginEntry {
+export function marketplacePluginEntry(): MarketplacePluginEntry {
   return {
     name: PLUGIN_NAME,
-    version: resolveMarketplaceEntryVersion(
-      path.join(HARNESS_REPO_PATH, ZCODE_PLUGIN_MARKER),
-      readHarnessVersion(),
-    ),
+    version: readHarnessVersion(),
     source: { ...GITHUB_SOURCE },
     displayName: PLUGIN_DISPLAY_NAME,
     icon: PLUGIN_ICON_URL,

--- a/packages/cli/test/zcode-marketplace.test.ts
+++ b/packages/cli/test/zcode-marketplace.test.ts
@@ -1,57 +1,28 @@
 /**
- * zcode adapter — bootstrap marketplace entry version resolution.
+ * zcode adapter — bootstrap marketplace entry seeding.
  *
- * The bootstrap `marketplace.json` seed must carry the plugin `version`
- * (from the local harness checkout's `.zcode-plugin/plugin.json`), so ZCode
- * can compare it against the versioned repo manifest after a marketplace
- * refresh. Falls back to the CLI package version when the marker is
- * unreadable.
+ * The bootstrap `marketplace.json` seed carries the CLI release version —
+ * the exact value doctor's `validateMarketplaceJson` compares against — so a
+ * current-CLI install always passes doctor. ZCode's marketplace refresh
+ * overwrites the seed with the repo-shipped manifest, which pins the same
+ * release version.
  */
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { resolveMarketplaceEntryVersion } from "../src/adapters/zcode";
+import { marketplacePluginEntry } from "../src/adapters/zcode";
+import { readHarnessVersion } from "../src/utils";
 
-function withTempMarker(content: string | null, fn: (markerPath: string) => void): void {
-  const dir = mkdtempSync(join(tmpdir(), "mstar-zcode-marker-"));
-  try {
-    const markerPath = join(dir, ".zcode-plugin", "plugin.json");
-    if (content !== null) {
-      mkdirSync(join(dir, ".zcode-plugin"), { recursive: true });
-      writeFileSync(markerPath, content);
-    }
-    fn(markerPath);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-}
-
-describe("resolveMarketplaceEntryVersion (zcode bootstrap entry)", () => {
-  test("reads the version from the local checkout's .zcode-plugin/plugin.json", () => {
-    withTempMarker(JSON.stringify({ name: "morning-star-harness", version: "3.7.0" }), (markerPath) => {
-      expect(resolveMarketplaceEntryVersion(markerPath, "0.0.0-fallback")).toBe("3.7.0");
-    });
+describe("marketplacePluginEntry (zcode bootstrap snapshot)", () => {
+  test("seeds version from the CLI release version (the value doctor validates against)", () => {
+    expect(marketplacePluginEntry().version).toBe(readHarnessVersion());
   });
 
-  test("falls back to the CLI package version when the marker is missing", () => {
-    withTempMarker(null, (markerPath) => {
-      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
-    });
-  });
-
-  test("falls back when the marker is unparseable or versionless", () => {
-    withTempMarker("not json {", (markerPath) => {
-      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
-    });
-    withTempMarker(JSON.stringify({ name: "morning-star-harness" }), (markerPath) => {
-      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
-    });
-    withTempMarker(JSON.stringify({ version: 42 }), (markerPath) => {
-      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
-    });
-    withTempMarker(JSON.stringify({ version: "" }), (markerPath) => {
-      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
-    });
+  test("entry shape stays in sync with the repo-shipped marketplace manifests", () => {
+    const entry = marketplacePluginEntry();
+    expect(entry.name).toBe("morning-star-harness");
+    expect(entry.source).toEqual({ source: "github", repo: "btspoony/mstar-harness", ref: "main" });
+    expect(entry.displayName).toBe("Morning Star Harness");
+    expect(entry.category).toBe("Productivity");
+    expect(entry.description).toContain("Multi-agent code harness");
+    expect(entry.icon).toContain("assets/icon.png");
   });
 });

--- a/packages/cli/test/zcode-marketplace.test.ts
+++ b/packages/cli/test/zcode-marketplace.test.ts
@@ -1,0 +1,57 @@
+/**
+ * zcode adapter — bootstrap marketplace entry version resolution.
+ *
+ * The bootstrap `marketplace.json` seed must carry the plugin `version`
+ * (from the local harness checkout's `.zcode-plugin/plugin.json`), so ZCode
+ * can compare it against the versioned repo manifest after a marketplace
+ * refresh. Falls back to the CLI package version when the marker is
+ * unreadable.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveMarketplaceEntryVersion } from "../src/adapters/zcode";
+
+function withTempMarker(content: string | null, fn: (markerPath: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), "mstar-zcode-marker-"));
+  try {
+    const markerPath = join(dir, ".zcode-plugin", "plugin.json");
+    if (content !== null) {
+      mkdirSync(join(dir, ".zcode-plugin"), { recursive: true });
+      writeFileSync(markerPath, content);
+    }
+    fn(markerPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("resolveMarketplaceEntryVersion (zcode bootstrap entry)", () => {
+  test("reads the version from the local checkout's .zcode-plugin/plugin.json", () => {
+    withTempMarker(JSON.stringify({ name: "morning-star-harness", version: "3.7.0" }), (markerPath) => {
+      expect(resolveMarketplaceEntryVersion(markerPath, "0.0.0-fallback")).toBe("3.7.0");
+    });
+  });
+
+  test("falls back to the CLI package version when the marker is missing", () => {
+    withTempMarker(null, (markerPath) => {
+      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
+    });
+  });
+
+  test("falls back when the marker is unparseable or versionless", () => {
+    withTempMarker("not json {", (markerPath) => {
+      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
+    });
+    withTempMarker(JSON.stringify({ name: "morning-star-harness" }), (markerPath) => {
+      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
+    });
+    withTempMarker(JSON.stringify({ version: 42 }), (markerPath) => {
+      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
+    });
+    withTempMarker(JSON.stringify({ version: "" }), (markerPath) => {
+      expect(resolveMarketplaceEntryVersion(markerPath, "1.2.3")).toBe("1.2.3");
+    });
+  });
+});

--- a/packages/cli/test/zcode-marketplace.test.ts
+++ b/packages/cli/test/zcode-marketplace.test.ts
@@ -1,18 +1,18 @@
 /**
  * zcode adapter — bootstrap marketplace entry seeding.
  *
- * The bootstrap `marketplace.json` seed carries the CLI release version —
- * the exact value doctor's `validateMarketplaceJson` compares against — so a
- * current-CLI install always passes doctor. ZCode's marketplace refresh
- * overwrites the seed with the repo-shipped manifest, which pins the same
- * release version.
+ * The bootstrap `marketplace.json` seed carries the CLI release version so a
+ * current-CLI install seeds a coherent snapshot. ZCode's marketplace refresh
+ * overwrites the seed with the repo-shipped manifest, after which the snapshot
+ * version may be newer or older than this CLI — that skew is the update
+ * signal, which is why doctor deliberately does not gate on it.
  */
 import { describe, expect, test } from "bun:test";
 import { marketplacePluginEntry } from "../src/adapters/zcode";
 import { readHarnessVersion } from "../src/utils";
 
 describe("marketplacePluginEntry (zcode bootstrap snapshot)", () => {
-  test("seeds version from the CLI release version (the value doctor validates against)", () => {
+  test("seeds version from the CLI release version", () => {
     expect(marketplacePluginEntry().version).toBe(readHarnessVersion());
   });
 

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -183,7 +183,11 @@ describe("bumpJsonVersion (locator-aware bump)", () => {
     2,
   );
 
-  /** Run `fn` with cwd set to a fresh temp dir containing `files`. */
+  /**
+   * Invariant: `process.cwd()` is captured before `chdir` and restored, and
+   * the temp dir removed, in `finally` — even when `fn` throws (asserted by
+   * the dedicated restoration test below).
+   */
   async function withTempCwd(files: Record<string, string>, fn: () => Promise<void>): Promise<void> {
     const dir = mkdtempSync(join(tmpdir(), "mstar-release-"));
     const prevCwd = process.cwd();
@@ -223,11 +227,38 @@ describe("bumpJsonVersion (locator-aware bump)", () => {
     });
   });
 
+  test("replaces only the located occurrence when an earlier key carries the same version string", async () => {
+    // Models the QC F-002 scenario: a root-level version key textually before
+    // plugins[0].version with the same old value — the located span, not the
+    // first textual occurrence, must be rewritten.
+    const fixture = `{
+  "version": "3.7.0",
+  "plugins": [{ "name": "morning-star-harness", "version": "3.7.0", "source": { "source": "github" } }]
+}
+`;
+    await withTempCwd({ "marketplace.json": fixture }, async () => {
+      await bumpJsonVersion("marketplace.json", "3.7.0", "3.7.1", "plugins.0.version");
+      const json = JSON.parse(readFileSync("marketplace.json", "utf8"));
+      expect(json.version).toBe("3.7.0"); // earlier textual occurrence untouched
+      expect(readVersionAt(json, "plugins.0.version")).toBe("3.7.1"); // only the located key moved
+    });
+  });
+
   test("prerelease version flows through the nested locator unchanged", async () => {
     await withTempCwd({ "marketplace.json": MARKETPLACE_FIXTURE }, async () => {
       await bumpJsonVersion("marketplace.json", "3.7.0", "3.8.0-alpha.1", "plugins.0.version");
       const json = JSON.parse(readFileSync("marketplace.json", "utf8"));
       expect(readVersionAt(json, "plugins.0.version")).toBe("3.8.0-alpha.1");
     });
+  });
+
+  test("withTempCwd restores process.cwd() even when the callback throws", async () => {
+    const before = process.cwd();
+    await expect(
+      withTempCwd({ "x.json": "{}" }, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(process.cwd()).toBe(before);
   });
 });

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -1,8 +1,18 @@
 /**
  * scripts/prepare-release.ts — fragment `packages:` token validation.
  */
-import { bumpVersion, parseFragment, syncRootEngineSpec, validateFragmentPackages } from "./prepare-release.ts";
-import { RELEASE_VERSION_RE, compareSemver, isPrereleaseVersion } from "./release-surfaces.ts";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { bumpJsonVersion, bumpVersion, parseFragment, syncRootEngineSpec, validateFragmentPackages } from "./prepare-release.ts";
+import {
+  DEFAULT_VERSION_PATH,
+  RELEASE_VERSION_RE,
+  VERSION_SURFACES,
+  compareSemver,
+  isPrereleaseVersion,
+  readVersionAt,
+} from "./release-surfaces.ts";
 
 describe("validateFragmentPackages (release packages enum)", () => {
   test("cli, root (comma+space, mixed case 'CLI, Root') is valid and normalized lowercase", () => {
@@ -143,5 +153,81 @@ describe("bumpVersion (auto-bump, prerelease graduation)", () => {
 
   test("prerelease current graduates to the next minor stable on minor", () => {
     expect(bumpVersion("3.6.0-alpha.1", "minor")).toBe("3.7.0");
+  });
+});
+
+describe("marketplace manifest surfaces (nested version locator)", () => {
+  test("both marketplace manifests are version surfaces located at plugins.0.version", () => {
+    const nested = VERSION_SURFACES.filter((s) => s.versionPath !== undefined);
+    expect(nested.map((s) => s.path).sort()).toEqual([".claude-plugin/marketplace.json", "marketplace.json"]);
+    for (const s of nested) expect(s.versionPath).toBe("plugins.0.version");
+  });
+
+  test("readVersionAt walks the dotted locator; default reads the root version", () => {
+    const doc = { version: "1.0.0", plugins: [{ name: "x", version: "2.0.0" }] };
+    expect(readVersionAt(doc, "plugins.0.version")).toBe("2.0.0");
+    expect(readVersionAt(doc, DEFAULT_VERSION_PATH)).toBe("1.0.0");
+    expect(readVersionAt(doc, "plugins.9.version")).toBeUndefined();
+    expect(readVersionAt(doc, "plugins.0.name")).toBe("x");
+    expect(readVersionAt(doc, "plugins.1.version")).toBeUndefined();
+  });
+});
+
+describe("bumpJsonVersion (locator-aware bump)", () => {
+  const MARKETPLACE_FIXTURE = JSON.stringify(
+    {
+      name: "mstar-local",
+      plugins: [{ name: "morning-star-harness", version: "3.7.0", source: { source: "github" } }],
+    },
+    null,
+    2,
+  );
+
+  /** Run `fn` with cwd set to a fresh temp dir containing `files`. */
+  async function withTempCwd(files: Record<string, string>, fn: () => Promise<void>): Promise<void> {
+    const dir = mkdtempSync(join(tmpdir(), "mstar-release-"));
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      for (const [name, content] of Object.entries(files)) {
+        mkdirSync(dirname(join(dir, name)), { recursive: true });
+        writeFileSync(join(dir, name), content);
+      }
+      await fn();
+    } finally {
+      process.chdir(prevCwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("bumps a marketplace manifest at plugins.0.version; validate re-reads via the locator", async () => {
+    await withTempCwd({ "marketplace.json": MARKETPLACE_FIXTURE }, async () => {
+      await bumpJsonVersion("marketplace.json", "3.7.0", "3.7.1", "plugins.0.version");
+      const json = JSON.parse(readFileSync("marketplace.json", "utf8"));
+      expect(readVersionAt(json, "plugins.0.version")).toBe("3.7.1");
+    });
+  });
+
+  test("default locator still bumps a plain root-version document", async () => {
+    await withTempCwd({ "pkg.json": `{"name":"x","version":"1.2.3"}` }, async () => {
+      await bumpJsonVersion("pkg.json", "1.2.3", "1.2.4");
+      expect(JSON.parse(readFileSync("pkg.json", "utf8")).version).toBe("1.2.4");
+    });
+  });
+
+  test("fails loud when the located version is not the current release", async () => {
+    await withTempCwd({ "marketplace.json": MARKETPLACE_FIXTURE }, async () => {
+      await expect(bumpJsonVersion("marketplace.json", "9.9.9", "3.7.1", "plugins.0.version")).rejects.toThrow(
+        /version at "plugins.0.version" is 3.7.0, expected "9.9.9"/,
+      );
+    });
+  });
+
+  test("prerelease version flows through the nested locator unchanged", async () => {
+    await withTempCwd({ "marketplace.json": MARKETPLACE_FIXTURE }, async () => {
+      await bumpJsonVersion("marketplace.json", "3.7.0", "3.8.0-alpha.1", "plugins.0.version");
+      const json = JSON.parse(readFileSync("marketplace.json", "utf8"));
+      expect(readVersionAt(json, "plugins.0.version")).toBe("3.8.0-alpha.1");
+    });
   });
 });

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -32,10 +32,12 @@
 import { existsSync, mkdirSync, readdirSync, renameSync } from "node:fs";
 import {
   CHANGELOGS,
+  DEFAULT_VERSION_PATH,
   RELEASE_VERSION_RE,
   VERSION_SURFACES,
   compareSemver,
   isPrereleaseVersion,
+  readVersionAt,
 } from "./release-surfaces.ts";
 
 type Fragment = {
@@ -198,14 +200,14 @@ function buildSectionBody(target: (typeof CHANGELOGS)[number], frags: Fragment[]
       lines.push(
         "### 版本对齐",
         "",
-        `- 提升 monorepo 根、\`@mstar-harness/opencode\`、\`@mstar-harness/cli\`、\`@mstar-harness/engine\`、\`@mstar-harness/dsh\`、Cursor/Codex/Kimi/ZCode/omp/Claude 插件清单及便携式 Agent Plugins 清单：**→ ${version}**。`,
+        `- 提升 monorepo 根、\`@mstar-harness/opencode\`、\`@mstar-harness/cli\`、\`@mstar-harness/engine\`、\`@mstar-harness/dsh\`、Cursor/Codex/Kimi/ZCode/omp/Claude 插件清单、便携式 Agent Plugins 清单及两份 marketplace 清单：**→ ${version}**。`,
         "",
       );
     } else {
       lines.push(
         "### Version alignment",
         "",
-        `- Bump monorepo root, \`@mstar-harness/opencode\`, \`@mstar-harness/cli\`, \`@mstar-harness/engine\`, \`@mstar-harness/dsh\`, Cursor/Codex/Kimi/ZCode/omp/Claude plugin manifests, and the portable Agent Plugins manifest: **→ ${version}**.`,
+        `- Bump monorepo root, \`@mstar-harness/opencode\`, \`@mstar-harness/cli\`, \`@mstar-harness/engine\`, \`@mstar-harness/dsh\`, Cursor/Codex/Kimi/ZCode/omp/Claude plugin manifests, the portable Agent Plugins manifest, and both marketplace manifests: **→ ${version}**.`,
         "",
       );
     }
@@ -236,8 +238,24 @@ function insertSection(changelog: string, version: string, date: string, body: s
   return `${changelog.slice(0, afterLine)}\n${header}\n\n${body}\n\n${tail}`;
 }
 
-async function bumpJsonVersion(path: string, oldV: string, newV: string): Promise<void> {
+/**
+ * Bump one surface's version, honoring its locator path. The parsed-value
+ * guard confirms the version lives at the declared `versionPath` before the
+ * text replace, so a restructured document fails loud instead of rewriting
+ * an unrelated `"version"` key; `release:validate` re-reads the same locator,
+ * closing the bump/read loop. Exported for tests.
+ */
+export async function bumpJsonVersion(
+  path: string,
+  oldV: string,
+  newV: string,
+  versionPath: string = DEFAULT_VERSION_PATH,
+): Promise<void> {
   const text = await Bun.file(path).text();
+  const located = readVersionAt(JSON.parse(text), versionPath);
+  if (located !== oldV) {
+    throw new Error(`${path}: version at "${versionPath}" is ${located ?? "<missing>"}, expected "${oldV}"`);
+  }
   const re = new RegExp(`("version"\\s*:\\s*")${oldV.replace(/\./g, "\\.")}(")`);
   if (!re.test(text)) throw new Error(`${path}: could not find version field "${oldV}"`);
   await Bun.write(path, text.replace(re, `$1${newV}$2`));
@@ -302,8 +320,8 @@ async function main(): Promise<void> {
   }
 
   for (const s of VERSION_SURFACES) {
-    await bumpJsonVersion(s.path, current, version);
-    console.log(`bump: ${s.path}`);
+    await bumpJsonVersion(s.path, current, version, s.versionPath);
+    console.log(`bump: ${s.path}${s.versionPath ? ` @ "${s.versionPath}"` : ""}`);
   }
 
   // Internal packages (cli/opencode/dsh) bundle the engine at build time; their

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -37,6 +37,7 @@ import {
   VERSION_SURFACES,
   compareSemver,
   isPrereleaseVersion,
+  locateVersionSpan,
   readVersionAt,
 } from "./release-surfaces.ts";
 
@@ -240,10 +241,12 @@ function insertSection(changelog: string, version: string, date: string, body: s
 
 /**
  * Bump one surface's version, honoring its locator path. The parsed-value
- * guard confirms the version lives at the declared `versionPath` before the
- * text replace, so a restructured document fails loud instead of rewriting
- * an unrelated `"version"` key; `release:validate` re-reads the same locator,
- * closing the bump/read loop. Exported for tests.
+ * check confirms the version lives at the declared `versionPath`; the
+ * replacement is then spliced at the exact located span in the raw text
+ * (`locateVersionSpan` — structural walk), so a coincidental earlier
+ * version-looking string can never be rewritten. Unresolvable locators and
+ * value drift fail loud naming the path; `release:validate` re-reads the
+ * same locator, closing the bump/read loop. Exported for tests.
  */
 export async function bumpJsonVersion(
   path: string,
@@ -256,9 +259,9 @@ export async function bumpJsonVersion(
   if (located !== oldV) {
     throw new Error(`${path}: version at "${versionPath}" is ${located ?? "<missing>"}, expected "${oldV}"`);
   }
-  const re = new RegExp(`("version"\\s*:\\s*")${oldV.replace(/\./g, "\\.")}(")`);
-  if (!re.test(text)) throw new Error(`${path}: could not find version field "${oldV}"`);
-  await Bun.write(path, text.replace(re, `$1${newV}$2`));
+  const span = locateVersionSpan(text, versionPath);
+  if (!span) throw new Error(`${path}: could not locate "${versionPath}" in file text`);
+  await Bun.write(path, text.slice(0, span[0]) + JSON.stringify(newV) + text.slice(span[1]));
 }
 
 /**

--- a/scripts/release-surfaces.ts
+++ b/scripts/release-surfaces.ts
@@ -35,6 +35,125 @@ export function readVersionAt(json: unknown, versionPath: string): string | unde
   return typeof node === "string" && node !== "" ? node : undefined;
 }
 
+// --- raw-text locator (bump side of readVersionAt) -------------------------
+// These helpers walk raw JSON text that callers have already JSON.parse-
+// validated, so structural malformation is impossible by contract; only the
+// locator resolution itself can fail (returning -1 / undefined).
+
+function skipWs(text: string, i: number): number {
+  while (i < text.length && /\s/.test(text[i])) i++;
+  return i;
+}
+
+/** Index just past the JSON string literal opening at `i` (`"` required); -1 when unterminated. */
+function skipString(text: string, i: number): number {
+  i++;
+  while (i < text.length) {
+    const c = text[i];
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (c === '"') return i + 1;
+    i++;
+  }
+  return -1;
+}
+
+/** Index just past the complete JSON value opening at `i`; -1 when malformed. */
+function skipValue(text: string, i: number): number {
+  const c = text[i];
+  if (c === '"') return skipString(text, i);
+  if (c !== "{" && c !== "[") {
+    const m = /^[^,}\]\s]+/.exec(text.slice(i));
+    return m ? i + m[0].length : -1;
+  }
+  let depth = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '"') {
+      const end = skipString(text, i);
+      if (end === -1) return -1;
+      i = end;
+      continue;
+    }
+    if (ch === "{" || ch === "[") depth++;
+    else if (ch === "}" || ch === "]") {
+      depth--;
+      i++;
+      if (depth === 0) return i;
+      continue;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Locate the exact string-literal span (`[start, end)`, quotes included) of
+ * `versionPath` in raw JSON text — the bump-side counterpart of
+ * `readVersionAt`. Structural walk (string- and escape-aware), so a
+ * coincidental `"version": "<oldV>"` inside a string value or under an
+ * earlier key can never match. Returns `undefined` when any segment is
+ * missing, out of range, or the leaf is not a JSON string; callers fail loud.
+ */
+export function locateVersionSpan(text: string, versionPath: string): [number, number] | undefined {
+  let i = skipWs(text, 0);
+  const segs = versionPath.split(".");
+  for (let s = 0; s < segs.length; s++) {
+    const last = s === segs.length - 1;
+    if (/^\d+$/.test(segs[s])) {
+      // array index segment
+      if (text[i] !== "[") return undefined;
+      i = skipWs(text, i + 1);
+      const want = parseInt(segs[s], 10);
+      for (let k = 0; k < want; k++) {
+        if (text[i] === "]") return undefined; // fewer elements than the index
+        const after = skipValue(text, i);
+        if (after === -1) return undefined;
+        i = skipWs(text, after);
+        if (text[i] !== ",") return undefined;
+        i = skipWs(text, i + 1);
+      }
+      if (text[i] === "]") return undefined; // index out of range
+    } else {
+      // object key segment
+      if (text[i] !== "{") return undefined;
+      i = skipWs(text, i + 1);
+      for (;;) {
+        if (text[i] === "}") return undefined; // key absent
+        if (text[i] !== '"') return undefined;
+        const keyEnd = skipString(text, i);
+        if (keyEnd === -1) return undefined;
+        let key: unknown;
+        try {
+          key = JSON.parse(text.slice(i, keyEnd));
+        } catch {
+          return undefined;
+        }
+        i = skipWs(text, keyEnd);
+        if (text[i] !== ":") return undefined;
+        i = skipWs(text, i + 1);
+        if (key === segs[s]) break;
+        const after = skipValue(text, i);
+        if (after === -1) return undefined;
+        i = skipWs(text, after);
+        if (text[i] !== ",") return undefined;
+        i = skipWs(text, i + 1);
+      }
+    }
+    if (last) {
+      if (text[i] !== '"') return undefined; // leaf must be a JSON string
+      const end = skipString(text, i);
+      if (end === -1) return undefined;
+      return [i, end];
+    }
+    // more segments remain: the value must be a container to descend into
+    if (text[i] !== "{" && text[i] !== "[") return undefined;
+  }
+  return undefined;
+}
+
 /** Every manifest/package.json that must carry the harness release version. */
 export const VERSION_SURFACES: readonly VersionSurface[] = [
   { label: "monorepo root", path: "package.json" },

--- a/scripts/release-surfaces.ts
+++ b/scripts/release-surfaces.ts
@@ -6,7 +6,34 @@
  * from ONE list so a release can never validate a surface it failed to bump.
  */
 
-export type VersionSurface = { label: string; path: string };
+export type VersionSurface = {
+  label: string;
+  path: string;
+  /**
+   * Dotted locator to the version field inside the JSON document
+   * (array indices as numeric segments, e.g. `"plugins.0.version"`).
+   * Defaults to `"version"` (root-level) when omitted.
+   */
+  versionPath?: string;
+};
+
+/** Default version locator when a surface omits `versionPath`. */
+export const DEFAULT_VERSION_PATH = "version";
+
+/**
+ * Read the version at a dotted locator path (`"a.b.0.c"`; array indices are
+ * numeric segments). Returns `undefined` when any segment is missing or the
+ * leaf is not a non-empty string. Single definition site shared by the
+ * prepare bump and the validate gate.
+ */
+export function readVersionAt(json: unknown, versionPath: string): string | undefined {
+  let node: unknown = json;
+  for (const seg of versionPath.split(".")) {
+    if (node === null || typeof node !== "object") return undefined;
+    node = (node as Record<string, unknown>)[seg];
+  }
+  return typeof node === "string" && node !== "" ? node : undefined;
+}
 
 /** Every manifest/package.json that must carry the harness release version. */
 export const VERSION_SURFACES: readonly VersionSurface[] = [
@@ -23,6 +50,8 @@ export const VERSION_SURFACES: readonly VersionSurface[] = [
   { label: "omp plugin", path: ".omp-plugin/plugin.json" },
   { label: "Claude plugin", path: ".claude-plugin/plugin.json" },
   { label: "Agent Plugins manifest", path: "plugin.json" },
+  { label: "Claude marketplace manifest", path: ".claude-plugin/marketplace.json", versionPath: "plugins.0.version" },
+  { label: "ZCode marketplace manifest", path: "marketplace.json", versionPath: "plugins.0.version" },
 ] as const;
 
 /**

--- a/scripts/validate-release-version.ts
+++ b/scripts/validate-release-version.ts
@@ -11,13 +11,13 @@
  * failed to bump.
  *
  * Pre-bump timing (D7: no intermediate releases): during an iteration,
- * `release:validate -- v2.0.0` intentionally exits 1 with all 12 entries
+ * `release:validate -- v2.0.0` intentionally exits 1 with all listed surfaces
  * compared (0 MISSING) — every surface still carries the previous version.
  * The bump happens at release-prep AFTER the iteration, so exit 1 with
  * 0 MISSING / all-MISMATCH is the expected pre-release state, not a gate
  * failure.
  */
-import { RELEASE_VERSION_RE, VERSION_SURFACES } from "./release-surfaces.ts";
+import { DEFAULT_VERSION_PATH, RELEASE_VERSION_RE, VERSION_SURFACES, readVersionAt } from "./release-surfaces.ts";
 
 const tag = process.argv[2] ?? process.env.GITHUB_REF_NAME;
 
@@ -36,21 +36,22 @@ if (!RELEASE_VERSION_RE.test(version)) {
 
 let failed = false;
 
-for (const { label, path } of VERSION_SURFACES) {
+for (const { label, path, versionPath } of VERSION_SURFACES) {
+  const vp = versionPath ?? DEFAULT_VERSION_PATH;
   const file = Bun.file(path);
   if (!(await file.exists())) {
     console.error(`MISSING ${path}`);
     failed = true;
     continue;
   }
-  const json = (await file.json()) as { version?: string };
-  if (json.version !== version) {
+  const actual = readVersionAt(await file.json(), vp);
+  if (actual !== version) {
     console.error(
-      `MISMATCH ${label} (${path}): tag ${tag} => ${version}, file has ${json.version ?? "<missing>"}`,
+      `MISMATCH ${label} (${path} @ "${vp}"): tag ${tag} => ${version}, file has ${actual ?? "<missing>"}`,
     );
     failed = true;
   } else {
-    console.log(`OK ${label}: ${json.version}`);
+    console.log(`OK ${label}: ${actual}`);
   }
 }
 


### PR DESCRIPTION
## What

Pins the release version into the repo-shipped marketplace manifests and wires both manifests into the release version-surface tooling, so a ZCode (and Claude-compatible) marketplace refresh can detect newer plugin versions.

- `.claude-plugin/marketplace.json` + root `marketplace.json`: `morning-star-harness` plugin entry gains `"version": "3.7.0"` (files stay content-identical)
- `scripts/release-surfaces.ts`: new `VersionSurface.versionPath` nested locator; both manifests registered as version surfaces at `plugins.0.version` (surface count 13 → 15)
- `scripts/prepare-release.ts` / `scripts/validate-release-version.ts`: bump + gate honor the locator — bump splices at the JSON-located span (new `locateVersionSpan()`, loud-fails on unresolvable paths); validate reads the same locator and names the path on mismatch
- `packages/cli/src/adapters/zcode.ts`: zcode bootstrap marketplace entry seeds `version` from `readHarnessVersion()` — the exact value doctor's `validateMarketplaceJson` compares against
- `AGENTS.md`: stale "12 version surfaces" prose replaced with an SSOT pointer to `scripts/release-surfaces.ts`
- `.changes/unreleased/marketplace-version-pin.md` (`packages: root, cli`)

## Why

The marketplace manifests described the plugin without a `version`, so after a refresh ZCode had no "latest" to compare against the installed plugin — updates were undetectable (manual refresh → remove record → reinstall was the only path). With pinned entries and the release tooling keeping them in sync (bumped by `release:prepare`, gated by `release:validate`), future releases become detectable on refresh.

## Validation

- `bunx tsc` clean; `scripts/prepare-release.test.ts` 28 pass (+4: locator bump/read coverage, earlier-key F-002 fixture, cwd-restoration invariant); packages/cli zcode marketplace tests 2 pass; `bundle-smoke` 4 pass after `cli:build`
- `bun run release:validate -- v3.7.0`: all 15 surfaces OK, including both marketplace manifests at `plugins.0.version`; engine dep range OK
- CLI `doctor --target zcode` healthy with the versioned entry; negative control (seeded `3.6.99`) rejected with an explicit message
- `bun run release:prepare -- --patch` rehearsal bumped both manifests to `3.7.1`, then fully reverted (no rehearsal artifacts committed)
- QC: single-seat inline review; wave 1 `Approve with residuals` (1 Warning / 2 Suggestions) → all three fixed (`fix(qc)` commits) → targeted re-review **Approve, 0 open findings**

## Notes

- Post-release follow-up (tracked in the plan roadmap): after the next release ships, refresh the `mstar-local` marketplace in ZCode and check whether an update entry appears for the new version; the outcome decides the bilingual INSTALL.md update-path docs (one-click update vs refresh → remove → reinstall).
- A companion change (CLI doctor version-comparison note + skill contract) is in flight in a separate branch/workflow; no file overlap with this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release bump/validate pipeline and ZCode install/doctor marketplace checks; mistakes could misalign versions across hosts or block releases, though coverage was added in `prepare-release.test.ts` and `zcode-marketplace.test.ts`.
> 
> **Overview**
> **Marketplace manifests now advertise a release version** on the `morning-star-harness` plugin entry (`version: 3.7.0` in both `.claude-plugin/marketplace.json` and root `marketplace.json`), so ZCode/Claude marketplace refresh can compare against newer releases.
> 
> **Release tooling treats nested JSON versions as first-class surfaces.** `scripts/release-surfaces.ts` adds optional `versionPath` (e.g. `plugins.0.version`), `readVersionAt` for validation, and `locateVersionSpan` for structural bumps; both marketplace files join `VERSION_SURFACES` (15 surfaces total). `release:prepare` and `release:validate` bump/check via the same locator instead of a root-only regex, avoiding accidental rewrites when another key shares the same version string.
> 
> **ZCode install bootstrap seeds `version` from the CLI release** (`marketplacePluginEntry` uses `readHarnessVersion()`), aligned with what `doctor` validates; changelog fragment and `AGENTS.md` point at `release-surfaces.ts` as the SSOT for surface count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5671a7a4f31fc25938d062f57727b118718b433. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->