### PR TITLE
fix(codex): install custom agents as regular files

### DIFF
--- a/.changes/unreleased/codex-agent-regular-files.md
+++ b/.changes/unreleased/codex-agent-regular-files.md
@@ -1,0 +1,8 @@
+---
+packages: root, cli
+---
+
+- Install Codex custom agent TOMLs as regular files so discovered roles can load. Re-running init replaces expected legacy links and backs up differing regular files before refresh; doctor detects links and source drift. Update installation and dispatch guidance to require successful named-role invocation.
+
+<!-- CN -->
+- 将 Codex 自定义角色 TOML 安装为普通文件，使已发现的角色能够加载。再次运行 init 会替换指向预期来源的旧链接，并在刷新不同内容的普通文件前备份；doctor 检测链接与来源内容漂移。同步安装及派发指导，以具名角色实际启动成功作为验证依据。

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,7 +68,7 @@ Restart Cursor or run **Developer: Reload Window** after install.
 
 The harness repo ships its own Codex marketplace catalog at `.agents/plugins/marketplace.json` (marketplace name `mstar-repo`, plugin root = repo root). `init --target codex` registers that repo as a git marketplace under the `mstar-repo` name:
 
-Global (custom agents linked from `~/.mstar/harness`):
+Global (custom agent TOMLs copied from `~/.mstar/harness` as regular files):
 
 ```bash
 npx @mstar-harness/cli init --target codex --scope global
@@ -90,6 +90,8 @@ Without the CLI (direct marketplace registration):
 codex plugin marketplace add btspoony/mstar-harness --ref main
 codex plugin add morning-star-harness@mstar-repo
 ```
+
+Custom agent TOMLs must be regular files: Codex can discover a symlinked role but fail to load it when invoked. Re-run `init` with the installed scope to repair legacy links; see [agent refresh behavior](docs/cli.md#codex-agent-files). After `doctor` passes, ask Codex to use `fullstack-dev` for a short read-only task and confirm that the named subagent actually starts.
 
 #### Codex: project vs global scope
 
@@ -263,12 +265,11 @@ codex plugin marketplace add btspoony/mstar-harness --ref main
 codex plugin add morning-star-harness@mstar-repo
 ```
 
-Link custom agents (Codex discovers agents from `~/.codex/agents/`):
+Install custom agents as regular files (also safely replaces legacy harness symlinks):
 
 ```bash
-git clone https://github.com/btspoony/mstar-harness.git ~/.mstar/harness
-mkdir -p ~/.codex/agents
-ln -s ~/.mstar/harness/codex/agents/*.toml ~/.codex/agents/
+npx @mstar-harness/cli init --target codex --scope global
+npx @mstar-harness/cli doctor --target codex --scope global
 ```
 
 Migrating from the legacy personal marketplace: remove the `morning-star-harness` entry from `~/.agents/plugins/marketplace.json`, then install from the repo marketplace (`codex plugin remove morning-star-harness@personal` if previously installed).

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Without a global install the harness still works and those checks stay advisory.
 
 `npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp\|dsh>`.
 
+Codex agent-link repair and named-role verification: [Codex installation](INSTALL.md#codex).
+
 The repo ships a portable **Agent Plugins v1.0.0** manifest (`plugin.json`) at its root; `skills/` is the Agent Skills component — verify it with `npx @mstar-harness/cli plugin validate`.
 
 Manual install / path layout: [`INSTALL.md`](INSTALL.md). CLI flags: [`docs/cli.md`](docs/cli.md).

--- a/README_CN.md
+++ b/README_CN.md
@@ -74,6 +74,8 @@ npm i -g @mstar-harness/cli
 
 `npx @mstar-harness/cli doctor --target <opencode\|cursor\|codex\|zcode\|omp\|dsh>`。
 
+Codex 角色链接修复与具名子代理验证：[Codex 安装](INSTALL.md#codex)。
+
 仓库根提供便携式 **Agent Plugins v1.0.0** manifest（`plugin.json`），`skills/` 为 Agent Skills 组件——可用 `npx @mstar-harness/cli plugin validate` 校验。
 
 手动安装 / 路径布局：[`INSTALL.md`](INSTALL.md)。CLI 参数：[`docs/cli.md`](docs/cli.md)。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,9 +38,9 @@ Optional advanced: pass `--pm-model` / `--*-models` flags to write explicit `age
 
 ### Codex
 
-The harness repo ships its own marketplace catalog at `.agents/plugins/marketplace.json` (name `mstar-repo`). The CLI registers the repo as a Codex git marketplace and links Codex custom agents from the maintained `~/.mstar/harness` checkout:
+The harness repo ships its own marketplace catalog at `.agents/plugins/marketplace.json` (name `mstar-repo`). The CLI registers the repo as a Codex git marketplace and copies Codex custom agent TOMLs as regular files from the maintained `~/.mstar/harness` checkout:
 
-1) Register the repo marketplace + link agents:
+1) Register the repo marketplace + install agent files:
 
 - `npx @mstar-harness/cli init --target codex --scope global`
 
@@ -48,7 +48,7 @@ The harness repo ships its own marketplace catalog at `.agents/plugins/marketpla
 
 - `codex plugin add morning-star-harness@mstar-repo`
 
-3) Verify the marketplace registration and agent symlinks:
+3) Verify the marketplace registration and regular agent files:
 
 - `npx @mstar-harness/cli doctor --target codex`
 
@@ -133,7 +133,7 @@ Codex install:
 - A pre-existing legacy `personal` marketplace entry is surfaced as a `doctor` note with migration steps (remove the entry, install from `mstar-repo`).
 - Runtime host behavior after install:
   - `/pm` enters the shared PM flow.
-  - Codex custom agents are linked from `~/.mstar/harness/codex/agents/*.toml`.
+  - Codex custom agents are copied from `~/.mstar/harness/codex/agents/*.toml` as regular files; see [refresh and migration](#codex-agent-files).
   - **Project scope only:** `iteration-start`, `iteration-drive`, and `iteration-loop` are installed as project-local skills under `.agents/skills/<name>/SKILL.md` (symlinked to `~/.mstar/harness/commands/<name>.md`); the CLI gitignores those paths.
   - **Global scope:** iteration skills are **not** installed (avoids polluting other projects); `init` prints a warning — re-run with `--scope project` to enable them.
   - Codex-specific clarify, dispatch, sandbox, and tool-discovery rules live in **`mstar-host`** → `references/codex.md`.
@@ -420,7 +420,7 @@ OpenCode `init` enforces these baseline requirements in `opencode.json`:
 - `plugin` contains `@mstar-harness/opencode@latest` (legacy `morning-star@git+…` lines for `btspoony/mstar-harness` are stripped on init, including URLs without `.git`, `ssh://`, or `#tag`)
 - Role models are **not** required — OpenCode defaults apply unless you pass optional `--*-model` flags
 
-Cursor and Codex `init` ensure a maintained local checkout exists at `~/.mstar/harness`. Codex then creates agent symlinks from that checkout. Cursor clones a **separate real git checkout** at the plugin path (see [Install path layout](#install-path-layout)).
+Cursor and Codex `init` ensure a maintained local checkout exists at `~/.mstar/harness`. Codex then copies regular agent TOML files from that checkout. Cursor clones a **separate real git checkout** at the plugin path (see [Install path layout](#install-path-layout)).
 
 Cursor `init`:
 
@@ -432,9 +432,15 @@ Codex `init` registers the repo-bundled Codex marketplace (probed on codex-cli 0
 - `codex plugin marketplace add https://github.com/btspoony/mstar-harness.git --ref main` — idempotent (an already-registered marketplace is skipped)
 - the marketplace catalog is the repo's own `.agents/plugins/marketplace.json` (name `mstar-repo`, plugin root = repo root, `source.path: "./"`)
 
-Codex `init` also links all `codex/agents/*.toml` files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope appends the same harness **process** gitignore set as Cursor project `init` (see above) and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
+Codex `init` also copies all `codex/agents/*.toml` files as regular files into `~/.codex/agents/` for global scope or `.codex/agents/` for project scope. Project scope appends the same harness **process** gitignore set as Cursor project `init` (see above) and symlinks `iteration-start` / `iteration-drive` / `iteration-loop` into `.agents/skills/<name>/SKILL.md` from `~/.mstar/harness/commands/<name>.md` (also gitignored). Global scope skips iteration skills and prints a pollution-avoidance warning.
 
 dsh `init` runs the two `dsh plugin --profile web add` calls (`@mstar-harness/dsh` then `dsh-llm-fallbacks`) in the fixed `web` profile — idempotent (already-installed rows skipped; a fallbacks row installed at a version other than the pin is re-added at the pin instead), fail-loud when the `dsh` binary is missing, and `--no-fallbacks` skips the fallbacks row.
+
+### Codex agent files
+
+Re-run `init --target codex --scope global` (or `project`) to install from the current `~/.mstar/harness/codex/agents/` source. Identical bytes are left untouched. A differing regular file is backed up as `<role>.toml.<uuid>.bak` before atomic replacement; a legacy symlink to the expected harness source is replaced without writing through it. Unrelated symlinks, non-file destinations, and a symlinked agent directory are refused.
+
+`init` does not pull an existing source checkout: refresh that checkout first when upgrading agent definitions, then re-run `init`. Project iteration skill symlinks are unchanged. After `doctor --target codex --scope <global|project>` passes, have Codex invoke a named role (for example, `fullstack-dev` on a short read-only task) and confirm that it starts; role discovery alone is insufficient.
 
 ## What `doctor` Checks
 
@@ -442,7 +448,7 @@ dsh `init` runs the two `dsh plugin --profile web add` calls (`@mstar-harness/ds
 - Missing per-role `agent.<role>.model` is a **yellow recommendation** only (OpenCode defaults are OK).
 - If only legacy git is present, or legacy and npm are both listed, `doctor` prints **yellow recommendations** and still exits 0; run `init` to normalize to `@mstar-harness/opencode@latest`.
 - For Cursor, `doctor` checks the maintained `~/.mstar/harness` checkout, that the Cursor plugin path is a **real git directory** (not a symlink), that `agents/*.md` files use Cursor-first frontmatter, and (project scope) all harness **process** `.gitignore` entries listed under Cursor `init`.
-- For Codex, `doctor` checks that the `mstar-repo` marketplace is registered (via `codex plugin marketplace list`), the maintained `~/.mstar/harness` checkout, and custom-agent symlinks. A legacy personal-marketplace entry for this plugin in `~/.agents/plugins/marketplace.json` is reported as a migration note. Project scope also validates iteration skill symlinks under `.agents/skills/` and harness **process** `.gitignore` entries.
+- For Codex, `doctor` checks that the `mstar-repo` marketplace is registered (via `codex plugin marketplace list`), the maintained `~/.mstar/harness` checkout, and regular custom-agent files whose bytes match the maintained source. Symlinks, missing files, and stale or customized bytes are issues; configuration checks do not prove successful subagent invocation. A legacy personal-marketplace entry for this plugin in `~/.agents/plugins/marketplace.json` is reported as a migration note. Project scope also validates iteration skill symlinks under `.agents/skills/` and harness **process** `.gitignore` entries.
 
 ## Install path layout
 
@@ -450,7 +456,7 @@ Cursor **does not discover symlinked plugin directories**. Use real directories 
 
 | Path | Host | Layout | Notes |
 | --- | --- | --- | --- |
-| `~/.mstar/harness` | Codex (agent `.toml` source), OpenCode dev bundle | git checkout | Codex agent `.toml` files are **symlinked** from here into `~/.codex/agents/`; the Codex marketplace itself is git-sourced (`btspoony/mstar-harness`) |
+| `~/.mstar/harness` | Codex (agent `.toml` source), OpenCode dev bundle | git checkout | Codex agent `.toml` files are **copied as regular files** from here into `~/.codex/agents/`; the Codex marketplace itself is git-sourced (`btspoony/mstar-harness`) |
 | `~/.cursor/plugins/local/morning-star-harness` | Cursor global plugin | **git checkout (real dir)** | **Not** a symlink to `~/.mstar/harness`; `init` clones or `git pull`s here |
 | `.cursor/plugins/morning-star-harness` | Cursor project plugin | **git checkout (real dir)** | gitignored; same clone/pull behavior as global |
 

--- a/packages/cli/src/adapters/codex-agent-files.ts
+++ b/packages/cli/src/adapters/codex-agent-files.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+function statIfPresent(target: string) {
+  try { return fs.lstatSync(target); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function checkParent(target: string) {
+  const parent = path.dirname(target);
+  const stat = statIfPresent(parent);
+  if (stat && !stat.isDirectory()) throw new Error(`Agent directory must be a real directory: ${parent}`);
+}
+
+/** Codex discovers linked TOMLs but cannot apply them with its no-follow loader. */
+export function ensureCodexAgentFile(source: string, target: string, dryRun: boolean): string[] {
+  checkParent(target);
+  const stat = statIfPresent(target);
+  if (stat?.isSymbolicLink()) {
+    const linked = path.resolve(path.dirname(target), fs.readlinkSync(target));
+    const matches = linked === path.resolve(source) ||
+      (fs.existsSync(linked) && fs.existsSync(source) && fs.realpathSync(linked) === fs.realpathSync(source));
+    if (!matches) throw new Error(`Refusing unrelated agent symlink: ${target} -> ${linked}`);
+  } else if (stat && !stat.isFile()) {
+    throw new Error(`Agent path must be a regular file: ${target}`);
+  }
+  // A dry-run may describe a checkout that has not been cloned yet.
+  if (dryRun && !fs.existsSync(source)) return [`Would copy agent ${source} to regular file ${target}`];
+  const bytes = fs.readFileSync(source);
+  let previous: Buffer | undefined;
+  if (stat?.isFile()) {
+    const fd = fs.openSync(target, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    try { previous = fs.readFileSync(fd); } finally { fs.closeSync(fd); }
+    if (previous.equals(bytes)) return [`Agent file already current: ${target}`];
+  }
+  if (dryRun) return [
+    ...(previous ? [`Would back up differing agent file: ${target}`] : []),
+    `Would ${stat?.isSymbolicLink() ? "replace legacy symlink with" : "install"} regular agent file: ${target}`,
+  ];
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const notes: string[] = [];
+  if (previous) {
+    const backup = `${target}.${randomUUID()}.bak`;
+    fs.writeFileSync(backup, previous, { flag: "wx", mode: stat!.mode & 0o777 });
+    notes.push(`Backed up differing agent file to ${backup}`);
+  }
+  // Rename replaces the directory entry itself, never writes through a legacy link.
+  const temporary = `${target}.${randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, bytes, { flag: "wx", mode: 0o644 });
+    fs.renameSync(temporary, target);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+  notes.push(`${stat?.isSymbolicLink() ? "Replaced legacy symlink with" : "Installed"} regular agent file: ${target}`);
+  return notes;
+}
+
+export function validateCodexAgentFile(source: string, target: string, scope: string): string[] {
+  const hint = `Run: mstar-harness init --target codex --scope ${scope}`;
+  try {
+    checkParent(target);
+    const stat = statIfPresent(target);
+    if (!stat) return [`Missing agent file: ${target}. ${hint}`];
+    if (stat.isSymbolicLink()) return [`Agent file must not be a symlink: ${target}. ${hint}`];
+    if (!stat.isFile()) return [`Agent path must be a regular file: ${target}. Move it aside, then ${hint}`];
+    const fd = fs.openSync(target, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    try {
+      if (!fs.readFileSync(fd).equals(fs.readFileSync(source))) return [`Agent file is stale or customized: ${target}. ${hint} (backs up differing bytes before refresh).`];
+    } finally { fs.closeSync(fd); }
+    return [];
+  } catch (error) {
+    return [`Could not validate agent file ${target}: ${error instanceof Error ? error.message : String(error)}. ${hint}`];
+  }
+}

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { ensureCodexAgentFile, validateCodexAgentFile } from "./codex-agent-files";
 import type { AgentAdapter, Scope } from "../types";
 import { resolveProjectRoot } from "../utils";
 import { runCliCommand } from "../exec";
@@ -32,10 +33,10 @@ import {
  *
  * - init: probe for the codex CLI, then `codex plugin marketplace add
  *   <owner/repo> --ref main` (idempotent — an already-added marketplace is a
- *   no-op). Custom-agent symlinks still come from the shared local checkout at
+ *   no-op). Custom-agent regular files still come from the shared local checkout at
  *   `~/.mstar/harness` (codex only discovers agents from `~/.codex/agents/`,
  *   not from plugin packages).
- * - doctor: validate the local checkout + agent symlinks (as before), then
+ * - doctor: validate the local checkout + agent copies, then
  *   check the marketplace is registered and the plugin resolvable via
  *   `codex plugin marketplace list --json` / `codex plugin list --json`.
  *   The repo-bundled `.agents/plugins/marketplace.json` is a release asset of
@@ -68,6 +69,8 @@ const CODEX_AGENT_NAMES = [
   "writing-specialist",
   "prompt-engineer",
 ];
+
+const CODEX_AGENT_GITIGNORE = [".codex/agents/*.toml", ".codex/agents/*.toml.*.bak"];
 
 const CODEX_PROJECT_COMMAND_NAMES = [
   "iteration-start",
@@ -190,30 +193,30 @@ function agentSourcePath(agentName: string) {
   return path.join(HARNESS_REPO_PATH, "codex", "agents", `${agentName}.toml`);
 }
 
-function globalAgentLinkPath(agentName: string) {
+function globalAgentFilePath(agentName: string) {
   return path.join(os.homedir(), ".codex", "agents", `${agentName}.toml`);
 }
 
-function projectAgentLinkPath(agentName: string) {
+function projectAgentFilePath(agentName: string) {
   return path.join(resolveProjectRoot(), ".codex", "agents", `${agentName}.toml`);
 }
 
-function ensureAgentLinks(scope: Scope, dryRun: boolean) {
+function ensureAgentFiles(scope: Scope, dryRun: boolean) {
   const notes: string[] = [];
   for (const agentName of CODEX_AGENT_NAMES) {
     const source = agentSourcePath(agentName);
-    const linkPath = scope === "global" ? globalAgentLinkPath(agentName) : projectAgentLinkPath(agentName);
-    notes.push(ensureSymlink(source, linkPath, dryRun));
+    const filePath = scope === "global" ? globalAgentFilePath(agentName) : projectAgentFilePath(agentName);
+    notes.push(...ensureCodexAgentFile(source, filePath, dryRun));
   }
   return notes;
 }
 
-function validateAgentLinks(scope: Scope) {
+function validateAgentFiles(scope: Scope) {
   const errors: string[] = [];
   for (const agentName of CODEX_AGENT_NAMES) {
     const source = agentSourcePath(agentName);
-    const linkPath = scope === "global" ? globalAgentLinkPath(agentName) : projectAgentLinkPath(agentName);
-    errors.push(...validateSymlink(source, linkPath));
+    const filePath = scope === "global" ? globalAgentFilePath(agentName) : projectAgentFilePath(agentName);
+    errors.push(...validateCodexAgentFile(source, filePath, scope));
   }
   return errors;
 }
@@ -265,7 +268,7 @@ function validateIterationSkillLinks() {
 function runInit(scope: Scope, dryRun: boolean) {
   const notes: string[] = [];
 
-  // The shared local checkout stays: codex agent .toml symlinks (and the Cursor
+  // The shared local checkout stays: codex agent .toml copies (and the Cursor
   // / omp adapters) materialize from it.
   notes.push(...ensureLocalHarnessRepo(dryRun));
 
@@ -295,13 +298,13 @@ function runInit(scope: Scope, dryRun: boolean) {
 
   if (scope === "project") {
     const projectRoot = resolveProjectRoot();
-    notes.push(...appendGitignore(projectRoot, [".codex/agents/*.toml"], dryRun));
+    notes.push(...appendGitignore(projectRoot, CODEX_AGENT_GITIGNORE, dryRun));
     notes.push(...appendHarnessProjectGitignore(projectRoot, dryRun));
     notes.push(...ensureIterationSkillLinks(dryRun));
   } else {
     notes.push(GLOBAL_ITERATION_SKILLS_WARNING);
   }
-  notes.push(...ensureAgentLinks(scope, dryRun));
+  notes.push(...ensureAgentFiles(scope, dryRun));
 
   return {
     location: `${CODEX_BIN} marketplaces (config.toml)`,
@@ -310,7 +313,7 @@ function runInit(scope: Scope, dryRun: boolean) {
 }
 
 function runDoctor(scope: Scope) {
-  const errors = validateLocalHarnessRepo();
+  const errors = [...validateLocalHarnessRepo(), ...validateAgentFiles(scope)];
   const notes: string[] = [];
   const legacyNote = legacyPersonalMarketplaceNote();
   if (legacyNote) notes.push(legacyNote);
@@ -338,12 +341,16 @@ function runDoctor(scope: Scope) {
     const projectRoot = resolveProjectRoot();
     const gitignorePath = path.join(projectRoot, ".gitignore");
     const gitignore = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
+    for (const entry of CODEX_AGENT_GITIGNORE) {
+      if (!gitignore.split(/\r?\n/).includes(entry)) {
+        errors.push(`Missing .gitignore entry: ${entry}. Run: mstar-harness init --target codex --scope project`);
+      }
+    }
     for (const entry of missingHarnessProcessGitignoreEntries(gitignore)) {
       errors.push(`Missing .gitignore entry: ${entry}`);
     }
     errors.push(...validateIterationSkillLinks());
   }
-  errors.push(...validateAgentLinks(scope));
   return { location: `${CODEX_BIN} marketplaces (config.toml)`, errors, notes };
 }
 

--- a/packages/cli/test/codex-agent-files.test.ts
+++ b/packages/cli/test/codex-agent-files.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+const adapterUrl = new URL("../src/adapters/codex.ts", import.meta.url).href;
+const repoAgents = new URL("../../../codex/agents/", import.meta.url).pathname;
+const names = fs.readdirSync(repoAgents).filter((name) => name.endsWith(".toml"));
+
+function fixture() {
+  fs.mkdirSync(path.resolve(".tmp"), { recursive: true });
+  const root = fs.mkdtempSync(path.resolve(".tmp/codex-agent-test-"));
+  const source = path.join(root, ".mstar/harness");
+  fs.mkdirSync(path.join(source, ".codex-plugin"), { recursive: true });
+  fs.writeFileSync(path.join(source, ".codex-plugin/plugin.json"), "{}");
+  fs.cpSync(repoAgents, path.join(source, "codex/agents"), { recursive: true });
+  fs.mkdirSync(path.join(source, "commands"));
+  for (const name of ["iteration-start", "iteration-drive", "iteration-loop", "codebase-audit", "amazing-pr-review", "amazing-e2e-check"]) {
+    fs.writeFileSync(path.join(source, "commands", `${name}.md`), "command");
+  }
+  fs.mkdirSync(path.join(root, "bin"));
+  fs.writeFileSync(path.join(root, "bin/codex"), '#!/bin/sh\nprintf \'%s\\n\' \'{"marketplaces":[{"name":"mstar-repo"}],"installed":[]}\'\n', { mode: 0o755 });
+  fs.mkdirSync(path.join(root, "project"));
+  return { root, source, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+}
+function run(root: string, scope: string, doctor = false, dry = false) {
+  const script = `import os from "node:os"; os.homedir = () => process.env.MSTAR_TEST_ROOT;
+const { codexAdapter } = await import(${JSON.stringify(adapterUrl)});
+try { console.log(JSON.stringify(codexAdapter.${doctor ? "runInstallDoctor" : "runInstallInit"}(${JSON.stringify(scope)}, ${dry}))); }
+catch (e) { console.log(JSON.stringify({failure: e.message})); }`;
+  const result = Bun.spawnSync([process.execPath, "-e", script], {
+    cwd: root, env: { ...process.env, MSTAR_TEST_ROOT: root, MSTAR_CLI_PROJECT_ROOT: path.join(root, "project"), PATH: `${root}/bin:${process.env.PATH}` },
+    stdout: "pipe", stderr: "pipe",
+  });
+  expect(result.exitCode).toBe(0);
+  return JSON.parse(result.stdout.toString());
+}
+function snapshot(root: string): string {
+  return JSON.stringify(fs.readdirSync(root, { recursive: true }).sort().map((entry) => {
+    const target = path.join(root, String(entry)); const stat = fs.lstatSync(target);
+    return [entry, stat.isSymbolicLink() ? fs.readlinkSync(target) : stat.isFile() ? fs.readFileSync(target).toString("base64") : "dir", stat.mtimeMs];
+  }));
+}
+
+describe("Codex regular agent installation", () => {
+  for (const scope of ["global", "project"]) {
+    test(`${scope}: fresh install is no-follow readable, idempotent, refresh preserves previous bytes`, () => {
+      const f = fixture();
+      try {
+        const dest = path.join(f.root, scope === "project" ? "project" : "", ".codex/agents");
+        expect(run(f.root, scope).failure).toBeUndefined();
+        for (const name of names) {
+          const target = path.join(dest, name);
+          expect(fs.lstatSync(target).isSymbolicLink()).toBe(false);
+          const fd = fs.openSync(target, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+          try { expect(fs.readFileSync(fd)).toEqual(fs.readFileSync(path.join(f.source, "codex/agents", name))); }
+          finally { fs.closeSync(fd); }
+        }
+        const before = snapshot(f.root);
+        expect(run(f.root, scope).failure).toBeUndefined();
+        expect(snapshot(f.root)).toBe(before);
+        expect(run(f.root, scope, true).errors).toEqual([]);
+        const target = path.join(dest, names[0]);
+        fs.writeFileSync(target, "user customization");
+        expect(run(f.root, scope, true).errors.join(" ")).toContain(`--scope ${scope}`);
+        const dryBefore = snapshot(f.root);
+        run(f.root, scope, false, true);
+        expect(snapshot(f.root)).toBe(dryBefore);
+        const update = run(f.root, scope);
+        expect(update.notes.join(" ")).toContain("Backed up");
+        expect(fs.readdirSync(dest).some((name) => name.endsWith(".bak") && fs.readFileSync(path.join(dest, name), "utf8") === "user customization")).toBe(true);
+        if (scope === "project") {
+          const project = path.join(f.root, "project");
+          expect(Bun.spawnSync(["git", "init", "--quiet", project]).exitCode).toBe(0);
+          const backup = fs.readdirSync(dest).find((name) => name.endsWith(".bak"))!;
+          const ignored = Bun.spawnSync(["git", "check-ignore", "--no-index", path.join(dest, backup)], { cwd: project });
+          expect(ignored.exitCode).toBe(0);
+          const ignorePath = path.join(project, ".gitignore");
+          fs.writeFileSync(ignorePath, fs.readFileSync(ignorePath, "utf8").replace(".codex/agents/*.toml.*.bak\n", ""));
+          expect(run(f.root, scope, true).errors.join(" ")).toContain(".codex/agents/*.toml.*.bak");
+          const missingIgnoreBefore = snapshot(f.root);
+          expect(run(f.root, scope, false, true).failure).toBeUndefined();
+          expect(snapshot(f.root)).toBe(missingIgnoreBefore);
+          expect(run(f.root, scope).failure).toBeUndefined();
+          const restored = snapshot(f.root);
+          expect(run(f.root, scope).failure).toBeUndefined();
+          expect(snapshot(f.root)).toBe(restored);
+        }
+        fs.appendFileSync(path.join(f.source, "codex/agents", names[0]), "\n# source update\n");
+        expect(run(f.root, scope, true).errors.join(" ")).toContain("stale");
+        expect(run(f.root, scope).failure).toBeUndefined();
+        expect(run(f.root, scope, true).errors).toEqual([]);
+      } finally { f.cleanup(); }
+    });
+    test(`${scope}: migrates expected legacy links, rejects unrelated and nonregular targets`, () => {
+      const f = fixture();
+      try {
+        const dest = path.join(f.root, scope === "project" ? "project" : "", ".codex/agents");
+        fs.mkdirSync(dest, { recursive: true });
+        const target = path.join(dest, names[0]);
+        const source = path.join(f.source, "codex/agents", names[0]);
+        fs.symlinkSync(path.relative(dest, source), target);
+        const linkedBefore = snapshot(f.root);
+        expect(run(f.root, scope, false, true).failure).toBeUndefined();
+        expect(snapshot(f.root)).toBe(linkedBefore);
+        expect(run(f.root, scope, true).errors.join(" ")).toContain("symlink");
+        expect(run(f.root, scope).failure).toBeUndefined();
+        expect(fs.lstatSync(target).isFile()).toBe(true);
+        expect(fs.readFileSync(target)).toEqual(fs.readFileSync(source));
+        fs.unlinkSync(target);
+        const unrelated = path.join(f.root, "unrelated"); fs.writeFileSync(unrelated, "keep");
+        fs.symlinkSync(unrelated, target);
+        expect(run(f.root, scope).failure).toContain("unrelated");
+        expect(fs.readFileSync(unrelated, "utf8")).toBe("keep");
+        fs.unlinkSync(target); fs.mkdirSync(target);
+        expect(run(f.root, scope).failure).toContain("regular file");
+        expect(run(f.root, scope, true).errors.join(" ")).toContain("regular file");
+        fs.rmdirSync(target);
+        expect(run(f.root, scope, true).errors.join(" ")).toContain("Missing");
+      } finally { f.cleanup(); }
+    });
+  }
+});

--- a/skills/mstar-host/references/codex.md
+++ b/skills/mstar-host/references/codex.md
@@ -10,7 +10,7 @@ Parallel PM dispatch: read **`parallel-dispatch.md`** only when Codex exposes an
 
 - Plugin source: `.codex-plugin/plugin.json`.
 - Runtime skills: repo `skills/` mounted by the Codex plugin (`"skills": "./skills/"`).
-- Custom agent source: repo `codex/agents/*.toml`; CLI/manual install links these into `~/.codex/agents/` or project `.codex/agents/`.
+- Custom agent source: repo `codex/agents/*.toml`; CLI install copies these as regular files into `~/.codex/agents/` or project `.codex/agents/`.
 - **`/pm`** or **`pm` skill**: force PM entry → `mstar-roles` → `project-manager.md` (Codex primary; Cursor/OpenCode for general per-plan work). **`commands/`** when running iteration Phase 1–5; project CLI install (`mstar-harness init --target codex --scope project`) materializes `iteration-start`, `iteration-drive`, and `iteration-loop` as `.agents/skills/<name>/SKILL.md` symlinks.
 - Role files under root `agents/` are for hosts that load OpenCode/Cursor-style agent shells; Codex uses `codex/agents/*.toml` and still loads `mstar-roles` references directly.
 - Tool and plugin availability can be lazy-loaded or session-dependent. Use the tools actually present in the current session; do not infer capability from documentation alone.
@@ -35,9 +35,11 @@ Use skill names in prompts and references. Avoid absolute local paths unless the
 
 ## Dispatch and role execution
 
-- **No invoke tool / no linked custom agent = no dispatch**: printing `## Assignment` does not start another Codex worker.
-- If Codex exposes custom-agent / multi-agent tools and matching Morning Star agents are linked, PM may dispatch through those tools and must follow `parallel-dispatch.md`.
+- **No invoke tool / no available custom agent = no dispatch**: printing `## Assignment` does not start another Codex worker.
+- If Codex exposes custom-agent / multi-agent tools and matching Morning Star agents are available, PM may dispatch through those tools and must follow `parallel-dispatch.md`.
 - If no invoke tool is present when dispatch is required, return **`Blocked`** — report missing invoke capability to the user. Do not substitute single-session role execution in the PM thread unless the user explicitly overrides harness dispatch for this turn.
+- Bind the role using the actual invoke schema. For example, when `collaboration.spawn_agent` exposes `agent_type`, set `agent_type: "fullstack-dev"` for `Execute as: fullstack-dev`; do not guess another host's parameter name.
+- Discovery does not prove loading: an advertised role may still fail to start. Record the actual invocation error; a role-load failure is not a missing-tool failure. For installed TOML issues, use `mstar-harness doctor --target codex --scope <global|project>` and repair via `init` for that scope, then retry the named role. Claim dispatch only after a successful invocation.
 - QC: N rules → **`parallel-dispatch.md`** (**`Execution mode: sdd`** → N=3; **`inline`** → N=1) when a callable invoke tool exists. Cannot emit required **N** → **`Blocked`**.
 - Leaf executors still follow `mstar-dispatch-gates`: no recursive Task/subagent calls unless Assignment says `Delegation: allowed (...)`.
 
@@ -56,6 +58,6 @@ Use skill names in prompts and references. Avoid absolute local paths unless the
 
 ## Gotchas
 
-- Codex plugin install gives skills; Morning Star role subagents require custom agent TOML files linked from `codex/agents/`.
+- Codex plugin install gives skills; Morning Star role subagents require regular custom agent TOML files installed from `codex/agents/`.
 - Tool discovery (`tool_search`) can reveal capabilities, but availability is not authorization; Assignment `Delegation` still controls use.
 - Session plans, Goal Mode text, chat summaries, and UI todos are not durable harness SSOT unless mirrored to `{HARNESS_DIR}`.


### PR DESCRIPTION
Codex discovered the symlinked Morning Star roles but failed to start them with `agent type is currently not available`; its role loader reported `Too many levels of symbolic links`. Installing the same TOML bytes as regular files restored named-role dispatch.

Install regular agent files in both global and project scopes. Re-running init atomically migrates expected legacy links, leaves identical files untouched, and backs up differing files before refreshing them. Doctor rejects linked, missing, nonregular, or stale files. Project installs ignore generated backups. Command skill links remain unchanged; installation and Codex dispatch documentation explain the distinction and the source-refresh workflow.

Validation:
- Regression reproduced before the fix; final targeted tests: 6 passing, 144 assertions, including actual Git backup-ignore behavior.
- CLI source typecheck and build passed; independent QC and QA passed with no remaining findings.
- Installed the final local build in both existing CLI prefixes: global init/doctor passed, all 12 role files passed regular-file/no-follow/source-byte checks, repeat init was idempotent, and an actual legacy link was migrated by the installed CLI. Named development, QC, QA, prompt, and ops agents successfully started.

Includes a bilingual root/CLI changelog fragment. No version bump or package publication; local verification used an unpublished patched build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex install filesystem behavior and migration paths for all custom agent TOMLs; mistakes could break named-role dispatch until users re-run init, though backups and strict validation limit data loss.
> 
> **Overview**
> Codex could **discover** symlinked Morning Star role TOMLs but **fail to load** them at invoke time (no-follow loader / symlink errors). This PR switches Codex `init` from symlinking `~/.mstar/harness/codex/agents/*.toml` into `~/.codex/agents/` (or project `.codex/agents/`) to **copying the same bytes as regular files**, for both global and project scope.
> 
> The new `codex-agent-files` helper handles **idempotent install**, **legacy symlink migration** (atomic rename, no write-through links), **UUID backups** before overwriting customized files, and **doctor validation** (must be regular files whose content matches the harness checkout). Project scope also **gitignores** agent TOMLs and `*.bak` backups; iteration skill symlinks are unchanged.
> 
> Docs and **`mstar-host`** Codex dispatch guidance now stress that **doctor passing ≠ working roles**—verify by successfully invoking a named role (e.g. `fullstack-dev`). Integration tests cover global/project install, dry-run, backup/ignore behavior, and refusal of unrelated symlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10868a4b72eb401094fb754a2b031574a962bfb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->